### PR TITLE
Add user agent to url validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ tomli==2.0.1
 tomlkit==0.11.8
 typing_extensions==4.7.1
 url-normalize==1.4.3
-urllib3==1.26.8
+urllib3~=1.26.17
 Werkzeug==2.3.6
 wrapt==1.15.0
 WTForms==3.0.1

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -65,7 +65,7 @@ invalid_urls = (
 
 urls_needing_valid_user_agent = {
     "https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862",
-    "https://www.lenovo.com/us/en/p/laptops/thinkpad/thinkpadt/thinkpad-t16-gen-2-(16-inch-amd)/len101t0076#ports_slots"
+    "https://www.lenovo.com/us/en/p/laptops/thinkpad/thinkpadt/thinkpad-t16-gen-2-(16-inch-amd)/len101t0076#ports_slots",
 }
 
 

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -63,8 +63,9 @@ invalid_urls = (
     "http:\\www.example.com\\andhere.html",
 )
 
-unknown_urls = {
-    "https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862"
+urls_needing_valid_user_agent = {
+    "https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862",
+    "https://www.lenovo.com/us/en/p/laptops/thinkpad/thinkpadt/thinkpad-t16-gen-2-(16-inch-amd)/len101t0076#ports_slots"
 }
 
 
@@ -91,12 +92,12 @@ def test_invalid_urls():
             url_valid.check_request_head(invalid_url)
 
 
-def test_unknown_urls():
+def test_urls_requiring_valid_user_agent():
     """
-    GIVEN URLs that seeem to fail unknowingly...
-    WHEN the url validation function checks these invalid URLs
-    THEN ensure the request times out
+    GIVEN URLs that seemed to fail unknowingly, but were due to the request
+        failing due to a User-agent indicating a script
+    WHEN the url validation function checks these URLs
+    THEN ensure that these urls are now validated properly
     """
-    for unknown_url in unknown_urls:
-        with raises(url_valid.InvalidURLError):
-            url_valid.check_request_head(unknown_url)
+    for unknown_url in urls_needing_valid_user_agent:
+        assert unknown_url == url_valid.check_request_head(unknown_url)

--- a/urls4irl/static/scripts/bootstrap.bundle.min.js
+++ b/urls4irl/static/scripts/bootstrap.bundle.min.js
@@ -7,8 +7,8 @@
   "object" == typeof exports && "undefined" != typeof module
     ? e(exports, require("jquery"))
     : "function" == typeof define && define.amd
-    ? define(["exports", "jquery"], e)
-    : e(((t = t || self).bootstrap = {}), t.jQuery);
+      ? define(["exports", "jquery"], e)
+      : e(((t = t || self).bootstrap = {}), t.jQuery);
 })(this, function (t, p) {
   "use strict";
   function i(t, e) {
@@ -139,8 +139,8 @@
         return t instanceof ShadowRoot
           ? t
           : t.parentNode
-          ? m.findShadowRoot(t.parentNode)
-          : null;
+            ? m.findShadowRoot(t.parentNode)
+            : null;
       var e = t.getRootNode();
       return e instanceof ShadowRoot ? e : null;
     },
@@ -1053,8 +1053,8 @@
         ? jt(n)
         : n
       : t
-      ? t.ownerDocument.documentElement
-      : document.documentElement;
+        ? t.ownerDocument.documentElement
+        : document.documentElement;
   }
   function Rt(t) {
     return null !== t.parentNode ? Rt(t.parentNode) : t;
@@ -1540,8 +1540,8 @@
             return "" === t[t.length - 1] && -1 !== ["+", "-"].indexOf(e)
               ? ((t[t.length - 1] = e), (i = !0), t)
               : i
-              ? ((t[t.length - 1] += e), (i = !1), t)
-              : t.concat(e);
+                ? ((t[t.length - 1] += e), (i = !1), t)
+                : t.concat(e);
           }, [])
           .map(function (t) {
             return (function (t, e, n, i) {
@@ -1631,10 +1631,10 @@
               "left" === a
                 ? ((r.top += l[0]), (r.left -= l[1]))
                 : "right" === a
-                ? ((r.top += l[0]), (r.left += l[1]))
-                : "top" === a
-                ? ((r.left += l[0]), (r.top -= l[1]))
-                : "bottom" === a && ((r.left += l[0]), (r.top += l[1])),
+                  ? ((r.top += l[0]), (r.left += l[1]))
+                  : "top" === a
+                    ? ((r.left += l[0]), (r.top -= l[1]))
+                    : "bottom" === a && ((r.left += l[0]), (r.top += l[1])),
               (t.popper = r),
               t
             );
@@ -2333,10 +2333,10 @@
             t.hasClass(ke)
               ? ((e = Ue), p(this._menu).hasClass(Pe) && (e = Be))
               : t.hasClass(Le)
-              ? (e = Qe)
-              : t.hasClass(xe)
-              ? (e = Ve)
-              : p(this._menu).hasClass(Pe) && (e = Ke),
+                ? (e = Qe)
+                : t.hasClass(xe)
+                  ? (e = Ve)
+                  : p(this._menu).hasClass(Pe) && (e = Ke),
             e
           );
         }),
@@ -3219,8 +3219,8 @@
                 t.html(e))
               : t.text(e)
             : this.config.html
-            ? p(e).parent().is(t) || t.empty().append(e)
-            : t.text(p(e).text());
+              ? p(e).parent().is(t) || t.empty().append(e)
+              : t.text(p(e).text());
         }),
         (t.getTitle = function () {
           var t = this.element.getAttribute("data-original-title");
@@ -3256,8 +3256,8 @@
           return !1 === this.config.container
             ? document.body
             : m.isElement(this.config.container)
-            ? p(this.config.container)
-            : p(document).find(this.config.container);
+              ? p(this.config.container)
+              : p(document).find(this.config.container);
         }),
         (t._getAttachment = function (t) {
           return Nn[t.toUpperCase()];

--- a/urls4irl/static/scripts/bootstrap.min.js
+++ b/urls4irl/static/scripts/bootstrap.min.js
@@ -7,8 +7,8 @@
   "object" == typeof exports && "undefined" != typeof module
     ? e(exports, require("jquery"), require("popper.js"))
     : "function" == typeof define && define.amd
-    ? define(["exports", "jquery", "popper.js"], e)
-    : e(((t = t || self).bootstrap = {}), t.jQuery, t.Popper);
+      ? define(["exports", "jquery", "popper.js"], e)
+      : e(((t = t || self).bootstrap = {}), t.jQuery, t.Popper);
 })(this, function (t, g, u) {
   "use strict";
   function i(t, e) {
@@ -140,8 +140,8 @@
         return t instanceof ShadowRoot
           ? t
           : t.parentNode
-          ? _.findShadowRoot(t.parentNode)
-          : null;
+            ? _.findShadowRoot(t.parentNode)
+            : null;
       var e = t.getRootNode();
       return e instanceof ShadowRoot ? e : null;
     },
@@ -1142,10 +1142,10 @@
             t.hasClass(jt)
               ? ((e = Qt), g(this._menu).hasClass(xt) && (e = Bt))
               : t.hasClass(Ht)
-              ? (e = zt)
-              : t.hasClass(Rt)
-              ? (e = Xt)
-              : g(this._menu).hasClass(xt) && (e = Yt),
+                ? (e = zt)
+                : t.hasClass(Rt)
+                  ? (e = Xt)
+                  : g(this._menu).hasClass(xt) && (e = Yt),
             e
           );
         }),
@@ -2028,8 +2028,8 @@
                 t.html(e))
               : t.text(e)
             : this.config.html
-            ? g(e).parent().is(t) || t.empty().append(e)
-            : t.text(g(e).text());
+              ? g(e).parent().is(t) || t.empty().append(e)
+              : t.text(g(e).text());
         }),
         (t.getTitle = function () {
           var t = this.element.getAttribute("data-original-title");
@@ -2065,8 +2065,8 @@
           return !1 === this.config.container
             ? document.body
             : _.isElement(this.config.container)
-            ? g(this.config.container)
-            : g(document).find(this.config.container);
+              ? g(this.config.container)
+              : g(document).find(this.config.container);
         }),
         (t._getAttachment = function (t) {
           return Pe[t.toUpperCase()];

--- a/urls4irl/static/scripts/jquery-3.6.0.js
+++ b/urls4irl/static/scripts/jquery-3.6.0.js
@@ -702,15 +702,15 @@
             ? // Strip the backslash prefix from a non-hex escape sequence
               nonHex
             : // Replace a hexadecimal escape sequence with the encoded Unicode code point
-            // Support: IE <=11+
-            // For values outside the Basic Multilingual Plane (BMP), manually construct a
-            // surrogate pair
-            high < 0
-            ? String.fromCharCode(high + 0x10000)
-            : String.fromCharCode(
-                (high >> 10) | 0xd800,
-                (high & 0x3ff) | 0xdc00,
-              );
+              // Support: IE <=11+
+              // For values outside the Basic Multilingual Plane (BMP), manually construct a
+              // surrogate pair
+              high < 0
+              ? String.fromCharCode(high + 0x10000)
+              : String.fromCharCode(
+                  (high >> 10) | 0xd800,
+                  (high & 0x3ff) | 0xdc00,
+                );
         },
         // CSS string/identifier serialization
         // https://drafts.csswg.org/cssom/#common-serializing-idioms
@@ -1641,15 +1641,15 @@
                 return a == document
                   ? -1
                   : b == document
-                  ? 1
-                  : /* eslint-enable eqeqeq */
-                  aup
-                  ? -1
-                  : bup
-                  ? 1
-                  : sortInput
-                  ? indexOf(sortInput, a) - indexOf(sortInput, b)
-                  : 0;
+                    ? 1
+                    : /* eslint-enable eqeqeq */
+                      aup
+                      ? -1
+                      : bup
+                        ? 1
+                        : sortInput
+                          ? indexOf(sortInput, a) - indexOf(sortInput, b)
+                          : 0;
 
                 // If the nodes are siblings, we can do a quick check
               } else if (aup === bup) {
@@ -1675,16 +1675,16 @@
                 ? // Do a sibling check if the nodes have a common ancestor
                   siblingCheck(ap[i], bp[i])
                 : // Otherwise nodes in our document sort first
-                // Support: IE 11+, Edge 17 - 18+
-                // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
-                // two documents; shallow comparisons work.
-                /* eslint-disable eqeqeq */
-                ap[i] == preferredDoc
-                ? -1
-                : bp[i] == preferredDoc
-                ? 1
-                : /* eslint-enable eqeqeq */
-                  0;
+                  // Support: IE 11+, Edge 17 - 18+
+                  // IE/Edge sometimes throw a "Permission denied" error when strict-comparing
+                  // two documents; shallow comparisons work.
+                  /* eslint-disable eqeqeq */
+                  ap[i] == preferredDoc
+                  ? -1
+                  : bp[i] == preferredDoc
+                    ? 1
+                    : /* eslint-enable eqeqeq */
+                      0;
             };
 
         return document;
@@ -1757,10 +1757,10 @@
         return val !== undefined
           ? val
           : support.attributes || !documentIsHTML
-          ? elem.getAttribute(name)
-          : (val = elem.getAttributeNode(name)) && val.specified
-          ? val.value
-          : null;
+            ? elem.getAttribute(name)
+            : (val = elem.getAttributeNode(name)) && val.specified
+              ? val.value
+              : null;
       };
 
       Sizzle.escape = function (sel) {
@@ -1996,21 +1996,23 @@
               return operator === "="
                 ? result === check
                 : operator === "!="
-                ? result !== check
-                : operator === "^="
-                ? check && result.indexOf(check) === 0
-                : operator === "*="
-                ? check && result.indexOf(check) > -1
-                : operator === "$="
-                ? check && result.slice(-check.length) === check
-                : operator === "~="
-                ? (" " + result.replace(rwhitespace, " ") + " ").indexOf(
-                    check,
-                  ) > -1
-                : operator === "|="
-                ? result === check ||
-                  result.slice(0, check.length + 1) === check + "-"
-                : false;
+                  ? result !== check
+                  : operator === "^="
+                    ? check && result.indexOf(check) === 0
+                    : operator === "*="
+                      ? check && result.indexOf(check) > -1
+                      : operator === "$="
+                        ? check && result.slice(-check.length) === check
+                        : operator === "~="
+                          ? (
+                              " " +
+                              result.replace(rwhitespace, " ") +
+                              " "
+                            ).indexOf(check) > -1
+                          : operator === "|="
+                            ? result === check ||
+                              result.slice(0, check.length + 1) === check + "-"
+                            : false;
               /* eslint-enable max-len */
             };
           },
@@ -2404,8 +2406,8 @@
               argument < 0
                 ? argument + length
                 : argument > length
-                ? length
-                : argument;
+                  ? length
+                  : argument;
             for (; --i >= 0; ) {
               matchIndexes.push(i);
             }
@@ -2512,9 +2514,9 @@
         return parseOnly
           ? soFar.length
           : soFar
-          ? Sizzle.error(selector)
-          : // Cache the tokens
-            tokenCache(selector, groups).slice(0);
+            ? Sizzle.error(selector)
+            : // Cache the tokens
+              tokenCache(selector, groups).slice(0);
       };
 
       function toSelector(tokens) {
@@ -3147,8 +3149,8 @@
             return elem[name] === true
               ? name.toLowerCase()
               : (val = elem.getAttributeNode(name)) && val.specified
-              ? val.value
-              : null;
+                ? val.value
+                : null;
           }
         });
       }

--- a/urls4irl/urls/routes.py
+++ b/urls4irl/urls/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from flask_login import current_user
 from urls4irl import db
 from urls4irl.models import Utub, Utub_Urls, URLS, Url_Tags
@@ -106,7 +106,8 @@ def add_url(utub_id: int):
         url_string = utub_new_url_form.url_string.data
 
         try:
-            normalized_url = check_request_head(url_string)
+            user_agent = request.headers.get("User-agent")
+            normalized_url = check_request_head(url_string, user_agent)
         except InvalidURLError:
             # URL was unable to be verified as a valid URL
             return (

--- a/urls4irl/utils/url_validation.py
+++ b/urls4irl/utils/url_validation.py
@@ -28,13 +28,13 @@ import random
 import requests
 
 USER_AGENTS = (
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
 )
 
 
@@ -98,7 +98,11 @@ def check_request_head(url: str, user_agent: str = None) -> str:
     url = normalize_url(url)
 
     try:
-        headers = {'User-Agent': random.choice(USER_AGENTS) if user_agent is None else user_agent}
+        headers = {
+            "User-Agent": random.choice(USER_AGENTS)
+            if user_agent is None
+            else user_agent
+        }
         response = requests.get(url, timeout=10, headers=headers)
 
     except requests.exceptions.ReadTimeout:

--- a/urls4irl/utils/url_validation.py
+++ b/urls4irl/utils/url_validation.py
@@ -24,7 +24,18 @@ returns the URL the redirect pointed to. Otherwise, uses the original URL.
 """
 
 from url_normalize import url_normalize
+import random
 import requests
+
+USER_AGENTS = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+)
 
 
 class InvalidURLError(Exception):
@@ -62,7 +73,7 @@ def normalize_url(url: str) -> str:
     return return_val
 
 
-def check_request_head(url: str) -> str:
+def check_request_head(url: str, user_agent: str = None) -> str:
     """
     Status codes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 
@@ -87,7 +98,8 @@ def check_request_head(url: str) -> str:
     url = normalize_url(url)
 
     try:
-        response = requests.get(url, timeout=10)
+        headers = {'User-Agent': random.choice(USER_AGENTS) if user_agent is None else user_agent}
+        response = requests.get(url, timeout=10, headers=headers)
 
     except requests.exceptions.ReadTimeout:
         raise InvalidURLError
@@ -118,9 +130,3 @@ def check_request_head(url: str) -> str:
         else:
             # Redirect was found, provide the redirect URL
             return location
-
-
-if __name__ == "__main__":
-    check_request_head(
-        "https://www.homedepot.com/c/ah/how-to-build-a-bookshelf/9ba683603be9fa5395fab904e329862"
-    )


### PR DESCRIPTION
Ensures that when a user adds a URL, their `User-Agent `that is used in the HTTP request is pushed through to the URL validation function, `check_request_head`. Certain websites were blocking the default `User-agent` defined in the Python `requests` library, which clearly indicated a scripted attempt at a GET request. This solves that issue and causes website to believe request is coming from a valid browser.

Additionally, includes security fix for the urllib3 library - updates made to `requirements.txt`