### PR TITLE
Fix register modal and email error notification

### DIFF
--- a/src/templates/email_validation/email_needs_validation_modal.html
+++ b/src/templates/email_validation/email_needs_validation_modal.html
@@ -16,12 +16,10 @@
     <div class="modal-body">
         {{ validate_email_form.hidden_tag() }}
         <p id="ValidateEmailText" class="validate-email-text">Your email address has not been validated. To complete
-            your registration, please click the button below to receive a validation email.</p>
+            your registration, <strong>please click</strong> the button below to receive a validation email.</p>
         <div id="SplashModalAlertBanner" class="alert alert-banner-splash-modal-hide" role="alert"></div>
         <div class="modal-footer">
             <button type="button" class="btn btn-warning close-modal login-register-form-group center-block col-4" data-dismiss="modal">Close</button>
-            <!-- <a class="btn btn-warning col-4 login-register-form-group login-buttons center-block close-modal"
-                href="javascript:;">Close</a> -->
             {{ validate_email_form.submit(class="btn btn-success login-register-form-group login-buttons center-block
             col-8")}}
         </div>

--- a/src/templates/register_user.html
+++ b/src/templates/register_user.html
@@ -84,7 +84,6 @@
         </fieldset>
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         {{ register_form.submit(class="btn btn-success login-register-form-group col-12")}}
     </div>
 </form>

--- a/src/users/routes.py
+++ b/src/users/routes.py
@@ -485,12 +485,12 @@ def _handle_email_sending_result(email_result: Response):
         return (
             jsonify(
                 {
-                STD_JSON.STATUS: STD_JSON.FAILURE,
-                STD_JSON.MESSAGE: EMAILS.EMAIL_FAILED,
-                STD_JSON.ERROR_CODE: 3,
-                STD_JSON.ERRORS: errors,
+                    STD_JSON.STATUS: STD_JSON.FAILURE,
+                    STD_JSON.MESSAGE: EMAILS.EMAIL_FAILED,
+                    STD_JSON.ERROR_CODE: 3,
+                    STD_JSON.ERRORS: errors,
                 }
-            ), 
+            ),
             400,
         )
 

--- a/src/users/routes.py
+++ b/src/users/routes.py
@@ -464,8 +464,8 @@ def send_validation_email():
 
 
 def _handle_email_sending_result(email_result: Response):
-    status_code = email_result.status_code
-    json_response = email_result.json()
+    status_code: int = email_result.status_code
+    json_response: dict = email_result.json()
 
     if status_code == 200:
         return (
@@ -476,16 +476,21 @@ def _handle_email_sending_result(email_result: Response):
         )
 
     elif status_code < 500:
-        message = json_response[EMAILS.MESSAGES]
-        errors = message[EMAILS.MAILJET_ERRORS]
+        message = json_response.get(EMAILS.MESSAGES, EMAILS.ERROR_WITH_MAILJET)
+        if message == EMAILS.ERROR_WITH_MAILJET:
+            errors = message
+        else:
+            errors = message.get(EMAILS.MAILJET_ERRORS, EMAILS.ERROR_WITH_MAILJET)
 
-        return jsonify(
-            {
+        return (
+            jsonify(
+                {
                 STD_JSON.STATUS: STD_JSON.FAILURE,
                 STD_JSON.MESSAGE: EMAILS.EMAIL_FAILED,
                 STD_JSON.ERROR_CODE: 3,
                 STD_JSON.ERRORS: errors,
-            },
+                }
+            ), 
             400,
         )
 
@@ -495,8 +500,11 @@ def _handle_email_sending_result(email_result: Response):
 
 def _handle_mailjet_failure(email_result: Response, error_code: int = 1):
     json_response = email_result.json()
-    message = json_response[EMAILS.MESSAGES]
-    errors = message[EMAILS.MAILJET_ERRORS]
+    message = json_response.get(EMAILS.MESSAGES, EMAILS.ERROR_WITH_MAILJET)
+    if message == EMAILS.ERROR_WITH_MAILJET:
+        errors = message
+    else:
+        errors = message.get(EMAILS.MAILJET_ERRORS, EMAILS.ERROR_WITH_MAILJET)
     return (
         jsonify(
             {


### PR DESCRIPTION
Fixes issue #122, as well as removing a floating button in the register modal.

Backend did not properly handle a 401 error code - Mailjet does not respond with a JSON, so Flask crashed when attempting to access the assumed errors in the response from Mailjet for a 401.

Fixed key access error cannot happen - instead, a default value is used.