### PR TITLE
Separate modals and components

### DIFF
--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -120,7 +120,7 @@ function buildURLDeck(dictURLs, dictTags) {
     let URLcol = createURLBlock(
       dictURLs[i].url_ID,
       dictURLs[i].url_string,
-      dictURLs[i].url_description,
+      dictURLs[i].url_title,
       dictURLs[i].url_tags,
       dictTags,
     );
@@ -637,7 +637,7 @@ function addURLSetup() {
   let newURL = $("#newURLString").val();
   data = {
     url_string: newURL,
-    url_description: newURLTitle,
+    url_title: newURLTitle,
   };
 
   return [postURL, data];
@@ -651,7 +651,7 @@ function addURLSuccess(response) {
   let URLcol = createURLBlock(
     response.URL.url_ID,
     response.URL.url_string,
-    response.URL.url_description,
+    response.URL.url_title,
     [],
     [],
   );
@@ -767,7 +767,7 @@ function editURLSetup() {
   let editedURLTitle = editedURLTitlefield.value;
   data = {
     url_string: editedURL,
-    url_description: editedURLTitle,
+    url_title: editedURLTitle,
   };
 
   return [postURL, data];
@@ -777,7 +777,7 @@ function editURLSetup() {
 function editURLSuccess(response) {
   // Extract response data
   let editedURLID = response.URL.url_ID;
-  let editedURLTitle = response.URL.url_description;
+  let editedURLTitle = response.URL.url_title;
   let editedURLString = response.URL.url_string;
 
   // If edit URL action, rebind the ability to select/deselect URL by clicking it

--- a/src/templates/components/navbar.html
+++ b/src/templates/components/navbar.html
@@ -1,0 +1,31 @@
+<nav id="mainNavbar" class="navbar navbar-expand-md navbar-dark bg-dark py-0 fixed-top">
+    <a class="navbar-brand navbar-start" href="#">
+        URLS4IRL
+        <div id="iconContainer">
+            <img id="u4iFavicon" src="/static/favicon/android-chrome-192x192.png" />
+        </div>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
+        aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="navbar-collapse collapse w-100 order-3 navbar-end" id="navbarNavDropdown">
+        <ul class="navbar-nav ml-auto">
+            {% if current_user.is_authenticated and current_user.email_confirm.is_validated %}
+            <li id="{{current_user.id}}" class="nav-item user">
+                <a class="nav-link" href="javascript:;"> Logged in as {{current_user.username}}</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{{url_for('users.logout')}}">Logout</a>
+            </li>
+            {% else %}
+            <li class="nav-item">
+                <a class="nav-link to-login" href="javascript:;">Login</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link to-register" href="javascript:;">Register</a>
+            </li>
+            {% endif %}
+        </ul>
+    </div>
+</nav>

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -3,7 +3,7 @@
 
 <!-- Backend load of UTub JSON data -->
 <script type="text/javascript">
-    var UTubs = JSON.parse('{{utubs_for_this_user|tojson|safe}}');
+    const UTubs = JSON.parse('{{utubs_for_this_user|tojson|safe}}');
 </script>
 <!-- 12/17 DP this is visible to the user? Ok? -->
 

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -76,79 +76,19 @@
     {% include '_routes.html' %}
 
     <!-- Navigation Bar -->
-    <nav id="mainNavbar" class="navbar navbar-expand-md navbar-dark bg-dark py-0 fixed-top">
-        <a class="navbar-brand navbar-start" href="#">
-            URLS4IRL
-            <div id="iconContainer">
-                <img id="u4iFavicon" src="/static/favicon/android-chrome-192x192.png" />
-            </div>
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
-            aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="navbar-collapse collapse w-100 order-3 navbar-end" id="navbarNavDropdown">
-            <ul class="navbar-nav ml-auto">
-                {% if current_user.is_authenticated and current_user.email_confirm.is_validated %}
-                <li id="{{current_user.id}}" class="nav-item user">
-                    <a class="nav-link" href="javascript:;"> Logged in as {{current_user.username}}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="{{url_for('users.logout')}}">Logout</a>
-                </li>
-                {% else %}
-                <li class="nav-item">
-                    <a class="nav-link to-login" href="javascript:;">Login</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link to-register" href="javascript:;">Register</a>
-                </li>
-                {% endif %}
-            </ul>
-        </div>
-    </nav>
+    {% include 'components/navbar.html' %}
     <!-- Navigation Bar -->
 
     {% block modal_extender %}
     <!-- Modal -->
     {% if current_user.is_authenticated and current_user.email_confirm.is_validated %}
 
-    <div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="FormModal"
-        aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <script type="text/javascript">
-                    if (document.querySelector('head').childElementCount === 1) {
-                        window.location.href = '/home';
-                    };
-                </script>
-
-                <form id="ModalForm" name="stepForm" class="form" method="post" action="" novalidate>
-                    <div class="modal-header">
-                        <h4 id="confirmModalTitle" class="modal-title"></h4>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close">
-                        </button>
-                    </div>
-                    <div id="confirmModalBody" class="modal-body">
-                    </div>
-                    <div class="modal-footer">
-                        <button id="modalDismiss" type="button" class="btn btn-default" data-dismiss="modal"></button>
-                        <button id="modalRedirect" type="button" class="btn btn-default" data-dismiss="modal"></button>
-                        <button id="modalSubmit" type="submit" class="btn btn-danger" data-dismiss="modal"></button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
+    {% include 'modals/homeModalBase.html' %}
 
     {% else %}
-    <div class="modal fade" id="SplashModal" tabindex="-1" role="dialog" aria-labelledby="FormModal"
-        style="display: none;" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-            </div>
-        </div>
-    </div>
+
+    {% include 'modals/splashModalBase.html' %}
+
     {% endif %}
     <!-- Modal -->
     {% endblock %}

--- a/src/templates/modals/homeModalBase.html
+++ b/src/templates/modals/homeModalBase.html
@@ -1,0 +1,27 @@
+<div class="modal fade" id="confirmModal" tabindex="-1" role="dialog" aria-labelledby="FormModal"
+    aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <script type="text/javascript">
+                if (document.querySelector('head').childElementCount === 1) {
+                    window.location.href = '/home';
+                };
+            </script>
+
+            <form id="ModalForm" name="stepForm" class="form" method="post" action="" novalidate>
+                <div class="modal-header">
+                    <h4 id="confirmModalTitle" class="modal-title"></h4>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="close">
+                    </button>
+                </div>
+                <div id="confirmModalBody" class="modal-body">
+                </div>
+                <div class="modal-footer">
+                    <button id="modalDismiss" type="button" class="btn btn-default" data-dismiss="modal"></button>
+                    <button id="modalRedirect" type="button" class="btn btn-default" data-dismiss="modal"></button>
+                    <button id="modalSubmit" type="submit" class="btn btn-danger" data-dismiss="modal"></button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/templates/modals/splashModalBase.html
+++ b/src/templates/modals/splashModalBase.html
@@ -1,0 +1,7 @@
+<div class="modal fade" id="SplashModal" tabindex="-1" role="dialog" aria-labelledby="FormModal"
+    style="display: none;" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Creates distinct HTML folders for `components` and `modals` - where `components` will contain distinct HTML components of the page, and `modals` will contain the base modal HTML files for both the splash page and the user's home page.

Also fixes `url_description` to `url_title` in `urls.js` so the correct parameter is pulled and sent in the HTTP requests.

Closes #117 