### PR TITLE
Fix login modal errors not displaying

### DIFF
--- a/src/static/scripts/splash.js
+++ b/src/static/scripts/splash.js
@@ -236,7 +236,7 @@ function loginModalOpener(url) {
 
       request.fail(function (xhr, textStatus, error) {
         if (
-          xhr.status == 400 &&
+          xhr.status == 401 &&
           xhr.responseJSON.hasOwnProperty("Error_code")
         ) {
           switch (xhr.responseJSON.Error_code) {


### PR DESCRIPTION
Backend had updated HTTP error codes for most login form failures to `401` from `400`. This hadn't been captured in the JavaScript handling the login modal. This PR updates the JavaScript for the login modal to capture `401` errors over `400` errors.

Closes #159 