### PR TITLE
Upgrade greenlet to 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ Flask-Migrate==3.1.0
 Flask-Session==0.5.0
 Flask-SQLAlchemy==3.0.0
 Flask-WTF==1.1.1
-greenlet==1.1.2
+greenlet==2.0.2
 gunicorn==21.2.0
 identify==2.5.29
 idna==3.3


### PR DESCRIPTION
Other packages requiring usage of greenlet. This requires Python v3.11 going forward.