### PR TITLE
Update non-working urls in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ miscellaneous/
 jquery*.js
 bootstrap*.js*
 bootstrap*.css*
+*.code-workspace

--- a/src/urls/routes.py
+++ b/src/urls/routes.py
@@ -9,7 +9,7 @@ from src.urls.forms import (
     EditURLForm,
     EditURLTitleForm,
 )
-from src.utils.url_validation import InvalidURLError, check_request_head
+from src.utils.url_validation import InvalidURLError, find_common_url
 from src.utils import strings as U4I_STRINGS
 from src.utils.email_validation import email_validation_required
 
@@ -110,7 +110,7 @@ def add_url(utub_id: int):
 
         try:
             user_agent = request.headers.get("User-agent")
-            normalized_url = check_request_head(url_string, user_agent)
+            normalized_url = find_common_url(url_string, user_agent)
         except InvalidURLError:
             # URL was unable to be verified as a valid URL
             return (
@@ -331,7 +331,7 @@ def edit_url_and_title(utub_id: int, url_id: int):
 
         # Here the user wants to try to change or modify the URL
         try:
-            normalized_url = check_request_head(url_to_change_to)
+            normalized_url = find_common_url(url_to_change_to)
         except InvalidURLError:
             # URL was unable to be verified as a valid URL
             return (
@@ -535,7 +535,7 @@ def edit_url(utub_id: int, url_id: int):
 
         # Here the user wants to try to change or modify the URL
         try:
-            normalized_url = check_request_head(url_to_change_to)
+            normalized_url = find_common_url(url_to_change_to)
         except InvalidURLError:
             # URL was unable to be verified as a valid URL
             return (

--- a/src/utils/url_validation.py
+++ b/src/utils/url_validation.py
@@ -77,15 +77,17 @@ def normalize_url(url: str) -> str:
 
     return return_val
 
+
 def generate_random_user_agent() -> str:
     return random.choice(USER_AGENTS)
+
 
 def perform_head_request(url: str) -> requests.Response:
     random_user_agent = generate_random_user_agent()
     try:
         headers = {
             "User-Agent": random_user_agent,
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
         }
         response = requests.head(url, timeout=5, headers=headers)
 
@@ -101,6 +103,7 @@ def perform_head_request(url: str) -> requests.Response:
 
     else:
         return response
+
 
 def perform_get_request(url: str, random_user_agent: str) -> requests.Response:
     try:
@@ -120,7 +123,6 @@ def perform_get_request(url: str, random_user_agent: str) -> requests.Response:
 
     else:
         return response
-
 
 
 def find_common_url(url: str, user_agent: str = None) -> str:
@@ -166,7 +168,9 @@ def find_common_url(url: str, user_agent: str = None) -> str:
             return url
 
         else:
-            if status_code == 302 and any((common_redirect in location for common_redirect in COMMON_REDIRECTS)):
+            if status_code == 302 and any(
+                (common_redirect in location for common_redirect in COMMON_REDIRECTS)
+            ):
                 # Common redirects, where sometimes 'www.facebook.com' could send you to the following:
                 #       'https://www.facebook.com/login/?next=https%3A%2F%2Fwww.facebook.com%2F'
                 # Forces the return of 'https://www.facebook.com', which comes after the ?next= query param
@@ -174,6 +178,7 @@ def find_common_url(url: str, user_agent: str = None) -> str:
 
             # Redirect was found, provide the redirect URL
             return location
+
 
 def filter_out_common_redirect(url: str) -> str:
     for common_redirect in COMMON_REDIRECTS:

--- a/tests/functional/test_update_url_and_title_route.py
+++ b/tests/functional/test_update_url_and_title_route.py
@@ -2,7 +2,7 @@ from flask import url_for
 from flask_login import current_user
 
 from src.models import Utub, Utub_Urls, Url_Tags, URLS
-from src.utils.url_validation import check_request_head
+from src.utils.url_validation import find_common_url
 from src.utils import strings as U4I_STRINGS
 
 URL_FORM = U4I_STRINGS.URL_FORM
@@ -47,7 +47,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 
@@ -55,7 +55,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
         assert utub_creator_of.utub_creator == current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -188,7 +188,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -197,7 +197,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
         assert utub_member_of.utub_creator != current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -331,8 +331,8 @@ def test_update_url_title_with_fresh_valid_url_as_utub_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_FRESH_URL = "yahoo.com"
+    NEW_TITLE = "This is my newest yahoo.com!"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 
@@ -340,7 +340,7 @@ def test_update_url_title_with_fresh_valid_url_as_utub_creator(
         assert utub_creator_of.utub_creator == current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -473,8 +473,8 @@ def test_update_url_title_with_fresh_valid_url_as_url_adder(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_FRESH_URL = "yahoo.com"
+    NEW_TITLE = "This is my newest yahoo.com!"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -483,7 +483,7 @@ def test_update_url_title_with_fresh_valid_url_as_url_adder(
         assert utub_member_of.utub_creator != current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -2016,8 +2016,8 @@ def test_update_url_title_with_fresh_valid_url_as_another_current_utub_member(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_FRESH_URL = "yahoo.com"
+    NEW_TITLE = "This is my newest yahoo.com!"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -2026,7 +2026,7 @@ def test_update_url_title_with_fresh_valid_url_as_another_current_utub_member(
         assert utub_member_of.utub_creator != current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -2151,8 +2151,8 @@ def test_update_url_title_with_fresh_valid_url_as_other_utub_member(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_FRESH_URL = "yahoo.com"
+    NEW_TITLE = "This is my newest yahoo.com!"
     with app.app_context():
         # Get UTub this user is not a member of
         utub_user_not_member_of = Utub.query.get(3)
@@ -2168,7 +2168,7 @@ def test_update_url_title_with_fresh_valid_url_as_other_utub_member(
         ]
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL not in this UTub
@@ -2302,8 +2302,8 @@ def test_update_url_title_with_fresh_valid_url_as_other_utub_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_FRESH_URL = "yahoo.com"
+    NEW_TITLE = "This is my newest yahoo.com!"
     with app.app_context():
         # Get UTub this user is not a member of
         all_utubs = Utub.query.all()
@@ -2331,7 +2331,7 @@ def test_update_url_title_with_fresh_valid_url_as_other_utub_creator(
         assert all_utubs[i].utub_creator == current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL not in this UTub
@@ -2579,7 +2579,7 @@ def test_update_valid_url_with_valid_url_and_missing_valid_title_as_utub_creator
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_URL = "github.com"
+    NEW_URL = "yahoo.com"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 
@@ -2679,7 +2679,7 @@ def test_update_valid_url_with_valid_url_and_valid_title_missing_csrf(
     """
     client, _, _, app = login_first_user_without_register
 
-    NEW_URL = "github.com"
+    NEW_URL = "yahoo.com"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 

--- a/tests/functional/test_update_url_route.py
+++ b/tests/functional/test_update_url_route.py
@@ -2,7 +2,7 @@ from flask import url_for
 from flask_login import current_user
 
 from src.models import Utub, Utub_Urls, Url_Tags, URLS
-from src.utils.url_validation import check_request_head
+from src.utils.url_validation import find_common_url
 from src.utils import strings as U4I_STRINGS
 
 URL_FORM = U4I_STRINGS.URL_FORM
@@ -46,7 +46,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 
@@ -54,7 +54,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
         assert utub_creator_of.utub_creator == current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -185,7 +185,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -194,7 +194,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
         assert utub_member_of.utub_creator != current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -1182,7 +1182,7 @@ def test_update_url_title_with_fresh_valid_url_as_another_current_utub_member(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -1191,7 +1191,7 @@ def test_update_url_title_with_fresh_valid_url_as_another_current_utub_member(
         assert utub_member_of.utub_creator != current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
@@ -1314,7 +1314,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         # Get UTub this user is not a member of
         utub_user_not_member_of = Utub.query.get(3)
@@ -1330,7 +1330,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
         ]
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL not in this UTub
@@ -1462,7 +1462,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_FRESH_URL = "github.com"
+    NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         # Get UTub this user is not a member of
         all_utubs = Utub.query.all()
@@ -1490,7 +1490,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
         assert all_utubs[i].utub_creator == current_user.id
 
         # Verify URL to modify to is not already in database
-        validated_new_fresh_url = check_request_head(NEW_FRESH_URL)
+        validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
         assert URLS.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL not in this UTub
@@ -1721,7 +1721,7 @@ def test_update_valid_url_with_valid_url_missing_csrf(
     """
     client, _, _, app = login_first_user_without_register
 
-    NEW_URL = "github.com"
+    NEW_URL = "yahoo.com"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 

--- a/tests/functional/test_update_url_title_route.py
+++ b/tests/functional/test_update_url_title_route.py
@@ -2,7 +2,7 @@ from flask import url_for
 from flask_login import current_user
 
 from src.models import Utub, Utub_Urls, Url_Tags, URLS, User
-from src.utils.url_validation import check_request_head
+from src.utils.url_validation import find_common_url
 from src.utils import strings as U4I_STRINGS
 
 URL_FORM = U4I_STRINGS.URL_FORM
@@ -58,7 +58,7 @@ def test_update_url_title_utub_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_TITLE = "This is my newest facebook.com!"
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 
@@ -173,7 +173,7 @@ def test_update_url_title_url_adder(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_TITLE = "This is my newest facebook.com!"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -522,7 +522,7 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_TITLE = "This is my newest github.com!"
+    NEW_TITLE = "This is my newest facebook.com!"
     with app.app_context():
         # Get UTub this user is only a member of
         utub_member_of = Utub.query.filter(Utub.utub_creator != current_user.id).first()
@@ -737,7 +737,7 @@ def test_update_url_title_as_member_of_other_utub(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_TITLE = "This is my newest github.com."
+    NEW_TITLE = "This is my newest facebook.com."
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
 
@@ -1015,7 +1015,7 @@ def test_update_url_title_of_nonexistent_url(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_TITLE = "This is my newest github.com."
+    NEW_TITLE = "This is my newest facebook.com."
     with app.app_context():
         utub_creator_of = Utub.query.filter_by(utub_creator=current_user.id).first()
         utub_id = utub_creator_of.id
@@ -1075,7 +1075,7 @@ def test_update_url_title_in_nonexistent_utub(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    NEW_TITLE = "This is my newest github.com."
+    NEW_TITLE = "This is my newest facebook.com."
     NONEXISTENT_UTUB_ID = 999
 
     # Get the URL of another UTub

--- a/tests/models_for_test.py
+++ b/tests/models_for_test.py
@@ -84,7 +84,7 @@ valid_url_without_tag_1 = {
 
 valid_url_without_tag_2 = {
     MODEL_STRS.ID: 2,
-    MODEL_STRS.URL: "https://www.facebook.com/",
+    MODEL_STRS.URL: "https://github.com/",
     MODEL_STRS.TAGS: [],
 }
 
@@ -122,7 +122,7 @@ valid_url_with_tag_1 = {
 
 valid_url_with_tag_2 = {
     MODEL_STRS.URL_ID: 2,
-    MODEL_STRS.URL_STRING: "https://www.facebook.com/",
+    MODEL_STRS.URL_STRING: "https://github.com/",
     MODEL_STRS.URL_TAGS: valid_tag_ids,
     MODEL_STRS.ADDED_BY: 2,
     MODEL_STRS.URL_TITLE: "",

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,5 +1,5 @@
 from src.models import User, Utub, URLS, Tags
-from src.utils.url_validation import check_request_head
+from src.utils.url_validation import find_common_url
 
 new_user = {
     "username": "FakeUserName1234",
@@ -68,11 +68,11 @@ def test_url_model():
     THEN ensure all fields are filled out correctly
     """
     new_url_object = URLS(
-        normalized_url=check_request_head(new_url["url_string"]),
+        normalized_url=find_common_url(new_url["url_string"]),
         current_user_id=new_url["creator"],
     )
 
-    assert new_url_object.url_string == check_request_head(new_url["url_string"])
+    assert new_url_object.url_string == find_common_url(new_url["url_string"])
     assert new_url_object.created_by == new_url["creator"]
     assert len(new_url_object.url_tags) == 0
 

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -79,7 +79,8 @@ def test_valid_urls():
     for valid_url in valid_urls:
         urls_to_check = valid_urls[valid_url]
         for url in urls_to_check:
-            assert valid_url == url_valid.check_request_head(url)
+            commonized_url = url_valid.find_common_url(url)
+            assert valid_url == commonized_url
 
 
 def test_invalid_urls():
@@ -90,7 +91,7 @@ def test_invalid_urls():
     """
     for invalid_url in invalid_urls:
         with raises(url_valid.InvalidURLError):
-            url_valid.check_request_head(invalid_url)
+            url_valid.find_common_url(invalid_url)
 
 
 def test_urls_requiring_valid_user_agent():
@@ -101,4 +102,4 @@ def test_urls_requiring_valid_user_agent():
     THEN ensure that these urls are now validated properly
     """
     for unknown_url in urls_needing_valid_user_agent:
-        assert unknown_url == url_valid.check_request_head(unknown_url)
+        assert unknown_url == url_valid.find_common_url(unknown_url)


### PR DESCRIPTION
Exchange URLs causing issues in tests.

Fix common redirect URL that aren't intended behavior, by replacing them with what is contained with the `next` query parameter.