### PR TITLE
Util route for 404 page

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
     DevDeploy:
+        name: Deploy to development server
         runs-on: ubuntu-latest
 
         steps:

--- a/src/splash/routes.py
+++ b/src/splash/routes.py
@@ -38,6 +38,11 @@ STD_JSON = STD_JSON_RESPONSE
 splash = Blueprint("splash", __name__)
 
 
+@splash.route("/invalid")
+def error_page():
+    abort(404)
+
+
 @splash.route("/", methods=["GET"])
 def splash_page():
     """Splash page for an unlogged in user."""

--- a/src/static/scripts/splash.js
+++ b/src/static/scripts/splash.js
@@ -104,7 +104,7 @@ function handleUserHasAccountNotEmailValidated(message) {
 }
 
 function emailValidationModalOpener() {
-  const modalOpener = $.get(routes.confirm_email_after_register());
+  const modalOpener = $.get(routes.confirmEmailAfterRegister());
 
   modalOpener.done((data, _, xhr) => {
     xhr.status === 200 ? $("#SplashModal .modal-content").html(data) : null;

--- a/src/static/scripts/splash/emailValidation.js
+++ b/src/static/scripts/splash/emailValidation.js
@@ -16,7 +16,7 @@ function handleValidateEmail(event = null) {
   event !== null ? event.preventDefault() : null;
 
   const validateEmailRequest = $.ajax({
-    url: routes.send_validation_email(),
+    url: routes.sendValidationEmail(),
     type: "POST",
     data: $("#ModalForm").serialize(),
   });

--- a/src/static/scripts/splash/forgotPassword.js
+++ b/src/static/scripts/splash/forgotPassword.js
@@ -7,7 +7,7 @@ function handleForgotPassword(event) {
   $("#submit").attr("disabled", "disabled");
 
   const forgotPasswordRequest = $.ajax({
-    url: routes.forgot_password(),
+    url: routes.forgotPassword(),
     type: "POST",
     data: $("#ModalForm").serialize(),
   });

--- a/src/static/scripts/splash/login.js
+++ b/src/static/scripts/splash/login.js
@@ -23,7 +23,7 @@ function openRegisterModalFromLogin() {
 }
 
 function openForgotPasswordModal() {
-  const modalOpener = $.get(routes.forgot_password());
+  const modalOpener = $.get(routes.forgotPassword());
 
   modalOpener.done((data, _, xhr) => {
     xhr.status === 200 ? $("#SplashModal .modal-content").html(data) : null;

--- a/src/templates/_routes.html
+++ b/src/templates/_routes.html
@@ -57,9 +57,12 @@
                 // Splash routes
                 this.login = () => "{{url_for('splash.login')}}";
                 this.register = () => "{{url_for('splash.register_user')}}";
-                this.confirm_email_after_register = () => "{{url_for('splash.confirm_email_after_register')}}";
-                this.send_validation_email = () => "{{url_for('splash.send_validation_email')}}";
-                this.forgot_password = () => "{{url_for('splash.forgot_password')}}";
+                this.confirmEmailAfterRegister = () => "{{url_for('splash.confirm_email_after_register')}}";
+                this.sendValidationEmail = () => "{{url_for('splash.send_validation_email')}}";
+                this.forgotPassword = () => "{{url_for('splash.forgot_password')}}";
+                
+                // Util routes
+                this.errorPage = () => "{{url_for('splash.error_page')}}";
                 
                 // Logout
                 this.logout = () => "{{url_for('users.logout')}}";


### PR DESCRIPTION
A utility route to get the 404 page, naming change for dev deployment action, and camelCase for the `routes` singleton for all splash page routes.

Utility route is also added to routes singleton.