### PR TITLE
Add tagID to response JSON for add tags

### DIFF
--- a/src/models/tags.py
+++ b/src/models/tags.py
@@ -25,6 +25,6 @@ class Tags(db.Model):
         return {MODEL_STRS.ID: self.id, MODEL_STRS.TAG_STRING: self.tag_string}
 
     @property
-    def serialized_on_delete(self):
+    def serialized_on_add_delete(self):
         """Returns serialized object."""
         return {MODEL_STRS.TAG_ID: self.id, MODEL_STRS.TAG_STRING: self.tag_string}

--- a/src/tags/routes.py
+++ b/src/tags/routes.py
@@ -126,7 +126,7 @@ def add_tag(utub_id: int, url_id: int):
                     STD_JSON.STATUS: STD_JSON.SUCCESS,
                     STD_JSON.MESSAGE: TAGS_SUCCESS.TAG_ADDED_TO_URL,
                     TAGS_SUCCESS.URL_TAGS: url_utub_association.associated_tags,
-                    TAGS_SUCCESS.TAG: tag_model.serialized,
+                    TAGS_SUCCESS.TAG: tag_model.serialized_on_add_delete,
                 }
             ),
             200,
@@ -210,7 +210,7 @@ def remove_tag(utub_id: int, url_id: int, tag_id: int):
                 STD_JSON.MESSAGE: TAGS_SUCCESS.TAG_REMOVED_FROM_URL,
                 TAGS_SUCCESS.URL_TAGS: url_utub_association.associated_tags,
                 TAGS_SUCCESS.TAG_STILL_IN_UTUB: num_left_in_utub > 0,
-                TAGS_SUCCESS.TAG: tag_to_remove.serialized_on_delete,
+                TAGS_SUCCESS.TAG: tag_to_remove.serialized_on_add_delete,
             }
         ),
         200,

--- a/tests/integration/utubtags/test_add_tag_to_url_route.py
+++ b/tests/integration/utubtags/test_add_tag_to_url_route.py
@@ -100,7 +100,7 @@ def test_add_fresh_tag_to_valid_url_as_utub_creator(
 
     # Ensure json response from server is valid
     add_tag_response_json = add_tag_response.json
-    new_tag_id = int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.ID])
+    new_tag_id = int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_ID])
     assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_ADDED_TO_URL
     assert add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_STRING] == tag_to_add
@@ -219,7 +219,7 @@ def test_add_fresh_tag_to_valid_url_as_utub_member(
 
     # Ensure json response from server is valid
     add_tag_response_json = add_tag_response.json
-    new_tag_id = int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.ID])
+    new_tag_id = int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_ID])
     assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_ADDED_TO_URL
     assert add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_STRING] == tag_to_add
@@ -346,7 +346,7 @@ def test_add_existing_tag_to_valid_url_as_utub_creator(
     assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_ADDED_TO_URL
     assert add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_STRING] == tag_to_add
     assert (
-        int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.ID])
+        int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_ID])
         == tag_id_that_exists
     )
     assert sorted(add_tag_response_json[TAGS_SUCCESS.URL_TAGS]) == sorted(
@@ -468,7 +468,7 @@ def test_add_existing_tag_to_valid_url_as_utub_member(
     assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_ADDED_TO_URL
     assert add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_STRING] == tag_to_add
     assert (
-        int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.ID])
+        int(add_tag_response_json[TAGS_SUCCESS.TAG][MODEL_STRS.TAG_ID])
         == tag_id_that_exists
     )
     assert sorted(add_tag_response_json[TAGS_SUCCESS.URL_TAGS]) == sorted(


### PR DESCRIPTION
Modifies JSON response for successful add of tag to URL to use `tagID` instead of `id` within the `tag` body.