### PR TITLE
GET UTubs route

### DIFF
--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -7,7 +7,7 @@
 
 ### Authentication
 
-All HTTP requests to the API must include a session cookie under the header `Cookie`. Containing a cookie that is expired or invalid
+All HTTP requests to the API must include a `session` cookie under the header `Cookie`. Containing a cookie that is expired or invalid
 will redirect the user to the splash page. HTTP requests made over AJAX that use form data require a CSRF token via the `X-Csrftoken` header.
 Otherwise, HTTP requests containing form data should include a field for `csrf_token`, with the token in the value.
 

--- a/src/models/utub_members.py
+++ b/src/models/utub_members.py
@@ -1,4 +1,5 @@
 from src import db
+from src.utils.strings.model_strs import MODELS
 
 
 class Utub_Members(db.Model):
@@ -16,4 +17,4 @@ class Utub_Members(db.Model):
     @property
     def serialized_on_initial_load(self):
         """Returns the serialized object on initial load for this member, including UTub name and id."""
-        return {"id": self.to_utub.id, "name": self.to_utub.name}
+        return {MODELS.ID: self.to_utub.id, MODELS.NAME: self.to_utub.name}

--- a/src/utils/all_routes.py
+++ b/src/utils/all_routes.py
@@ -46,6 +46,7 @@ class USER_ROUTES:
 class UTUB_ROUTES:
     _UTUBS = "utubs."
     HOME = _UTUBS + "home"
+    GET_UTUBS = _UTUBS + "get_utubs"
     ADD_UTUB = _UTUBS + "add_utub"
     DELETE_UTUB = _UTUBS + "delete_utub"
     UPDATE_UTUB_NAME = _UTUBS + "update_utub_name"

--- a/src/utubs/routes.py
+++ b/src/utubs/routes.py
@@ -61,6 +61,17 @@ def get_single_utub(utub_id: str):
     return jsonify(utub_data_serialized)
 
 
+@utubs.route("/utubs", methods=["GET"])
+@email_validation_required
+def get_utubs():
+    """
+    User wants a summary of their UTubs in JSON format.
+    """
+    # TODO: Should serialized summary be utubID and utubName
+    # instead of id and name?
+    return jsonify(current_user.serialized_on_initial_load)
+
+
 @utubs.route("/utubs", methods=["POST"])
 @email_validation_required
 def add_utub():
@@ -70,7 +81,6 @@ def add_utub():
     https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#many-to-many
 
     """
-
     utub_form = UTubForm()
 
     if utub_form.validate_on_submit():

--- a/tests/integration/utubs/test_add_utub_route.py
+++ b/tests/integration/utubs/test_add_utub_route.py
@@ -199,10 +199,7 @@ def test_add_utub_with_get_request(login_first_user_with_register):
         UTUB_FORM.UTUB_DESCRIPTION: valid_empty_utub_1[UTUB_SUCCESS.UTUB_DESCRIPTION],
     }
 
-    new_utub_response = client.get(url_for(ROUTES.UTUBS.ADD_UTUB), data=new_utub_form)
-
-    # Get method is not allowed
-    assert new_utub_response.status_code == 405
+    client.get(url_for(ROUTES.UTUBS.ADD_UTUB), data=new_utub_form)
 
     # Make sure no UTub in database
     with app.app_context():

--- a/tests/integration/utubs/test_get_utubs_summary_route.py
+++ b/tests/integration/utubs/test_get_utubs_summary_route.py
@@ -1,0 +1,85 @@
+from typing import Tuple
+
+from flask import Flask, url_for
+from flask.testing import FlaskClient
+from flask_login import current_user
+import pytest
+
+from src.models.users import Users
+from src.models.utubs import Utubs
+from src.utils.all_routes import ROUTES
+from src.utils.strings.model_strs import MODELS
+
+pytestmark = pytest.mark.utubs
+
+
+def test_get_utubs_if_has_no_utubs(
+    login_first_user_with_register: Tuple[FlaskClient, str, Users, Flask]
+):
+    """
+    GIVEN a logged in user with ID == 1, with no UTubs.
+    WHEN the user requests a summary of all
+        their UTubs
+    THEN verify the response body contains an empty array in the JSON
+    """
+    client, _, _, _ = login_first_user_with_register
+
+    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+
+    assert response.status_code == 200
+    response_json = response.json
+    assert response_json == []
+
+
+def test_get_utubs_if_has_one_utub(
+    every_user_makes_a_unique_utub,
+    login_first_user_without_register: Tuple[FlaskClient, str, Users, Flask],
+):
+    """
+    GIVEN a logged in user with ID == 1, with one UTub.
+    WHEN the user requests a summary of all
+        their UTubs
+    THEN verify the response body contains an array with one UTub in the JSON
+    """
+    client, _, _, app = login_first_user_without_register
+
+    with app.app_context():
+        all_utubs: list[Utubs] = Utubs.query.all()
+        utub_summary = [
+            {MODELS.ID: utub.id, MODELS.NAME: utub.name}
+            for utub in all_utubs
+            if current_user.id in [member.user_id for member in utub.members]
+        ]
+
+    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+
+    assert response.status_code == 200
+    assert utub_summary == response.json
+
+
+def test_get_utubs_if_has_multiple_utubs(
+    every_user_in_every_utub,
+    login_first_user_without_register: Tuple[FlaskClient, str, Users, Flask],
+):
+    """
+    GIVEN a logged in user with ID == 1, and is a member of multiple UTubs .
+    WHEN the user requests a summary of all
+        their UTubs
+    THEN verify the response body contains an array with all utubs in the JSON
+    """
+    client, _, _, app = login_first_user_without_register
+
+    with app.app_context():
+        all_utubs: list[Utubs] = Utubs.query.all()
+        utub_summary = [
+            {MODELS.ID: utub.id, MODELS.NAME: utub.name}
+            for utub in all_utubs
+            if current_user.id in [member.user_id for member in utub.members]
+        ]
+
+    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+
+    assert response.status_code == 200
+    assert sorted(utub_summary, key=lambda x: x[MODELS.ID]) == sorted(
+        response.json, key=lambda x: x[MODELS.ID]
+    )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -26,73 +26,77 @@ new_tag = {
 }
 
 
-def test_user_model():
+def test_user_model(app):
     """
     GIVEN a new user model
     WHEN a new User model is created
     THEN ensure all fields are filled out correctly
     """
-    new_user_object = Users(
-        username=new_user["username"],
-        email=new_user["email"],
-        plaintext_password=new_user["password"],
-    )
+    with app.app_context():
+        new_user_object = Users(
+            username=new_user["username"],
+            email=new_user["email"],
+            plaintext_password=new_user["password"],
+        )
 
-    assert new_user_object.username == new_user["username"]
-    assert new_user_object.password != new_user["password"]
-    assert new_user_object.email == new_user["email"].lower()
-    assert new_user_object.is_password_correct(new_user["password"]) is True
-    assert len(new_user_object.utubs_created) == 0
-    assert len(new_user_object.utub_urls) == 0
-    assert len(new_user_object.utubs_is_member_of) == 0
-    assert new_user_object.email_confirm is None
+        assert new_user_object.username == new_user["username"]
+        assert new_user_object.password != new_user["password"]
+        assert new_user_object.email == new_user["email"].lower()
+        assert new_user_object.is_password_correct(new_user["password"]) is True
+        assert len(new_user_object.utubs_created) == 0
+        assert len(new_user_object.utub_urls) == 0
+        assert len(new_user_object.utubs_is_member_of) == 0
+        assert new_user_object.email_confirm is None
 
 
-def test_utub_model():
+def test_utub_model(app):
     """
     GIVEN a new UTub model
     WHEN a new UTub model is created
     THEN ensure all fields are filled out correctly
     """
-    new_utub_object = Utubs(
-        name=new_utub["name"],
-        utub_creator=new_utub["creator"],
-        utub_description=new_utub["description"],
-    )
+    with app.app_context():
+        new_utub_object = Utubs(
+            name=new_utub["name"],
+            utub_creator=new_utub["creator"],
+            utub_description=new_utub["description"],
+        )
 
-    assert new_utub_object.name == new_utub["name"]
-    assert new_utub_object.utub_creator == new_utub["creator"]
-    assert new_utub_object.utub_description == new_utub["description"]
-    assert len(new_utub_object.members) == 0
-    assert len(new_utub_object.utub_urls) == 0
-    assert len(new_utub_object.utub_url_tags) == 0
+        assert new_utub_object.name == new_utub["name"]
+        assert new_utub_object.utub_creator == new_utub["creator"]
+        assert new_utub_object.utub_description == new_utub["description"]
+        assert len(new_utub_object.members) == 0
+        assert len(new_utub_object.utub_urls) == 0
+        assert len(new_utub_object.utub_url_tags) == 0
 
 
-def test_url_model():
+def test_url_model(app):
     """
     GIVEN a new URL model
     WHEN a new URL model is created
     THEN ensure all fields are filled out correctly
     """
-    new_url_object = Urls(
-        normalized_url=find_common_url(new_url["url_string"]),
-        current_user_id=new_url["creator"],
-    )
+    with app.app_context():
+        new_url_object = Urls(
+            normalized_url=find_common_url(new_url["url_string"]),
+            current_user_id=new_url["creator"],
+        )
 
-    assert new_url_object.url_string == find_common_url(new_url["url_string"])
-    assert new_url_object.created_by == new_url["creator"]
-    assert len(new_url_object.url_tags) == 0
+        assert new_url_object.url_string == find_common_url(new_url["url_string"])
+        assert new_url_object.created_by == new_url["creator"]
+        assert len(new_url_object.url_tags) == 0
 
 
-def test_tag_model():
+def test_tag_model(app):
     """
     GIVEN a new Tag model
     WHEN a new Tag model is created
     THEN ensure all fields are filled out correctly
     """
-    new_tag_object = Tags(
-        tag_string=new_tag["tag_string"], created_by=new_tag["creator"]
-    )
+    with app.app_context():
+        new_tag_object = Tags(
+            tag_string=new_tag["tag_string"], created_by=new_tag["creator"]
+        )
 
-    assert new_tag_object.tag_string == new_tag["tag_string"]
-    assert new_tag_object.created_by == new_tag["creator"]
+        assert new_tag_object.tag_string == new_tag["tag_string"]
+        assert new_tag_object.created_by == new_tag["creator"]


### PR DESCRIPTION
Provides an endpoint `/utubs` with GET HTTP method to allow retrieving a summary of a user's UTubs.

Previously, this summary has been directly rendered into the HTML template as a JavaScript object. This endpoint instead allows for asynchronous retrieval of the summary of a user's UTubs.

The summary of a UTub includes its ID and name.

Closes #171 