### PR TITLE
UrlID to UtubUrlID

### DIFF
--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -667,14 +667,14 @@ The HTML body on a 200 response contains the following JSON.
 >     ],
 >     "urls": [
 >         {
->             "urlID": 1,
+>             "utubUrlID": 1,
 >             "urlString": "https://urls4irl.app",
 >             "urlTagIDs": [1, 2, 3],
 >             "canDelete": true,           // Can only delete if UTub creator, or adder of URL  
 >             "urlTitle": "Title for URL",
 >         },
 >         {
->             "urlID": 2,
+>             "utubUrlID": 2,
 >             "urlString": "https://www.github.com",
 >             "urlTagIDs": [2, 3],
 >             "canDelete": false,             
@@ -1292,7 +1292,7 @@ Required form data:
 >     "addedByUserID": 1, 
 >     "URL": {
 >         "urlString": "https://urls4irl.app/",
->         "urlID": 1,
+>         "utubUrlID": 1,
 >         "urlTitle": "This is my home page!",
 >     }
 > }
@@ -1370,14 +1370,14 @@ Indicates form errors with adding this URL to this UTub.
 
 </details>
 <details>
- <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/urls/{urlID}</b></code> <code>(remove a URL from a UTub)</code></summary>
+ <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}</b></code> <code>(remove a URL from a UTub)</code></summary>
 
 ##### Parameters
 
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
 > | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
-> | `urlID` |  required  | int ($int64) | The unique ID of the URL to remove from the UTub |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the Utub-URL to remove from the UTub |
 
 ##### Responses
 
@@ -1398,7 +1398,7 @@ Indicates form errors with adding this URL to this UTub.
 >     "utubID": 1,
 >     "URL": {
 >         "urlString": "https://urls4irl.app/",
->         "urlID": 1,
+>         "utubUrlID": 1,
 >         "urlTitle": "This is my home page!",
 >     },
 >     "tags": [
@@ -1433,14 +1433,14 @@ Indicates form errors with adding this URL to this UTub.
 
 </details>
 <details>
- <summary><code>PATCH</code> <code><b>/utubs/{UTubID}/urls/{urlID}</b></code> <code>(edit the URL string in a UTub)</code></summary>
+ <summary><code>PATCH</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}</b></code> <code>(edit the URL string in a UTub)</code></summary>
 
 ##### Parameters
 
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
 > | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
-> | `urlID` |  required  | int ($int64) | The unique ID of the URL to modify |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL to modify |
 
 ##### Request Payload
 
@@ -1471,7 +1471,7 @@ Required form data:
 >     "status": "Success" or "No change",
 >     "message": "URL modified." or "URL not modified",
 >     "URL": {
->         "urlID": 1,
+>         "utubUrlID": 1,
 >         "urlString": "https://www.google.com",
 >         "urlTagIDs": [1, 2, 3],                   // Array of tag IDs associated with this URL in UTub
 >     }
@@ -1551,14 +1551,14 @@ Indicates missing or invalid form data sent in the request.
 </details>
 
 <details>
- <summary><code>PATCH</code> <code><b>/utubs/{UTubID}/urls/{urlID}/title</b></code> <code>(edit the title of a URL in a UTub)</code></summary>
+ <summary><code>PATCH</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}/title</b></code> <code>(edit the title of a URL in a UTub)</code></summary>
 
 ##### Parameters
 
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
 > | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
-> | `urlID` |  required  | int ($int64) | The unique ID of the URL with the title to modify |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL with the title to modify |
 
 ##### Request Payload
 
@@ -1589,7 +1589,7 @@ Required form data:
 >     "status": "Success" or "No change",
 >     "message": "URL title was modified." or "URL title not modified",
 >     "URL": {
->         "urlID": 1,
+>         "utubUrlID": 1,
 >         "urlTitle": "This is google.",
 >         "urlTagIDs": [1, 2, 3],                   // Array of tag IDs associated with this URL in UTub
 >     }
@@ -1664,14 +1664,14 @@ Indicates invalid form data sent in the request.
 #### UTub Tags
 
 <details>
- <summary><code>POST</code> <code><b>/utubs/{UTubID}/urls/{urlID}/tags</b></code> <code>(add a tag to a URL in a UTub)</code></summary>
+ <summary><code>POST</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}/tags</b></code> <code>(add a tag to a URL in a UTub)</code></summary>
 
 ##### Parameters
 
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
 > | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
-> | `urlID` |  required  | int ($int64) | The unique ID of the URL to add the tag to |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL to add the tag to |
 
 ##### Request Payload
 
@@ -1777,14 +1777,14 @@ Indicates form errors with adding this tag onto this URL in this UTub.
 
 </details>
 <details>
- <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/urls/{urlID}/tags/{tagID}</b></code> <code>(remove a tag from a URL in a UTub)</code></summary>
+ <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}/tags/{tagID}</b></code> <code>(remove a tag from a URL in a UTub)</code></summary>
 
 ##### Parameters
 
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
 > | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
-> | `urlID` |  required  | int ($int64) | The unique ID of the URL with the tag to remove |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL with the tag to remove |
 > | `tagID` |  required  | int ($int64) | The unique ID of the tag to remove |
 
 ##### Responses
@@ -1838,7 +1838,7 @@ Indicates form errors with adding this tag onto this URL in this UTub.
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
 > | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL with given tag |
-> | `urlID` |  required  | int ($int64) | The unique ID of the URL associated with the tag to modify |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL associated with the tag to modify |
 > | `tagID` |  required  | int ($int64) | The unique ID of the tag to modify |
 
 ##### Request Payload

--- a/src/models/tags.py
+++ b/src/models/tags.py
@@ -13,7 +13,7 @@ class Tags(db.Model):
     __tablename__ = "Tags"
     id: int = Column(Integer, primary_key=True)
     tag_string: str = Column(
-        String(30), nullable=False, name="tagString"
+        String(30), nullable=False, name="tagString", unique=True
     )  # Note that multiple URLs can have the same tag
     created_by: int = Column(
         Integer, ForeignKey("Users.id"), nullable=False, name="createdBy"

--- a/src/models/urls.py
+++ b/src/models/urls.py
@@ -20,7 +20,7 @@ class Urls(db.Model):
     created_at = Column(
         DateTime(timezone=True), nullable=False, default=utc_now, name="createdAt"
     )
-    url_tags = db.relationship("Url_Tags", back_populates="tagged_url")
+    url_tags = db.relationship("Utub_Url_Tags", back_populates="tagged_url")
 
     def __init__(self, normalized_url: str, current_user_id: int):
         self.url_string = normalized_url
@@ -29,9 +29,9 @@ class Urls(db.Model):
     @property
     def serialized_url(self):
         """Includes an array of tag IDs for all ID's on this url"""
-        from src.models.url_tags import Url_Tags
+        from src.models.utub_url_tags import Utub_Url_Tags
 
-        url_tags: list[Url_Tags] = self.url_tags
+        url_tags: list[Utub_Url_Tags] = self.url_tags
         return {
             MODEL_STRS.ID: self.id,
             MODEL_STRS.URL: self.url_string,

--- a/src/models/urls.py
+++ b/src/models/urls.py
@@ -2,7 +2,6 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 
 from src import db
 from src.utils.datetime_utils import utc_now
-from src.utils.strings.model_strs import MODELS as MODEL_STRS
 
 
 class Urls(db.Model):
@@ -20,20 +19,7 @@ class Urls(db.Model):
     created_at = Column(
         DateTime(timezone=True), nullable=False, default=utc_now, name="createdAt"
     )
-    url_tags = db.relationship("Utub_Url_Tags", back_populates="tagged_url")
 
     def __init__(self, normalized_url: str, current_user_id: int):
         self.url_string = normalized_url
         self.created_by = int(current_user_id)
-
-    @property
-    def serialized_url(self):
-        """Includes an array of tag IDs for all ID's on this url"""
-        from src.models.utub_url_tags import Utub_Url_Tags
-
-        url_tags: list[Utub_Url_Tags] = self.url_tags
-        return {
-            MODEL_STRS.ID: self.id,
-            MODEL_STRS.URL: self.url_string,
-            MODEL_STRS.TAGS: [tag.tag_item.serialized for tag in url_tags],
-        }

--- a/src/models/utub_url_tags.py
+++ b/src/models/utub_url_tags.py
@@ -10,7 +10,7 @@ from src.models.utubs import Utubs
 from src.utils.datetime_utils import utc_now
 
 
-class Url_Tags(db.Model):
+class Utub_Url_Tags(db.Model):
     """
     Represents the Many-to-Many relationship between tags, UTubs, and URLs.
     This table indicates which URLs in a specified UTub contain a specified tag.
@@ -18,7 +18,7 @@ class Url_Tags(db.Model):
     https://stackoverflow.com/questions/52920701/many-to-many-with-three-tables-relating-with-each-other-sqlalchemy
     """
 
-    __tablename__ = "UrlTags"
+    __tablename__ = "UtubUrlTags"
 
     id: int = Column(Integer, primary_key=True)
     utub_id: int = Column(

--- a/src/models/utub_url_tags.py
+++ b/src/models/utub_url_tags.py
@@ -5,8 +5,8 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer
 
 from src import db
 from src.models.tags import Tags
-from src.models.urls import Urls
 from src.models.utubs import Utubs
+from src.models.utub_urls import Utub_Urls
 from src.utils.datetime_utils import utc_now
 
 
@@ -24,14 +24,16 @@ class Utub_Url_Tags(db.Model):
     utub_id: int = Column(
         Integer, ForeignKey("Utubs.id"), nullable=False, name="utubID"
     )
-    url_id: int = Column(Integer, ForeignKey("Urls.id"), nullable=True, name="urlID")
+    utub_url_id: int = Column(
+        Integer, ForeignKey("UtubUrls.id"), nullable=True, name="utubUrlID"
+    )
     tag_id: int = Column(Integer, ForeignKey("Tags.id"), nullable=False, name="tagID")
     added_at: datetime = Column(
         DateTime(timezone=True), nullable=False, default=utc_now, name="addedAt"
     )
 
     tag_item: Tags = db.relationship("Tags")
-    tagged_url: Urls = db.relationship("Urls", back_populates="url_tags")
+    tagged_url: Utub_Urls = db.relationship("Utub_Urls", back_populates="url_tags")
     utub_containing_this_tag: Utubs = db.relationship(
         "Utubs", back_populates="utub_url_tags"
     )

--- a/src/models/utub_urls.py
+++ b/src/models/utub_urls.py
@@ -43,7 +43,7 @@ class Utub_Urls(db.Model):
         url_item: Urls = self.standalone_url
 
         return {
-            MODEL_STRS.URL_ID: self.id,
+            MODEL_STRS.UTUB_URL_ID: self.id,
             MODEL_STRS.URL_STRING: url_item.url_string,
             MODEL_STRS.URL_TAGS: self.associated_tags,
             MODEL_STRS.URL_TITLE: self.url_title,
@@ -54,7 +54,7 @@ class Utub_Urls(db.Model):
     @property
     def serialized_on_string_edit(self) -> dict[str, int | str | list[int]]:
         return {
-            MODEL_STRS.URL_ID: self.id,
+            MODEL_STRS.UTUB_URL_ID: self.id,
             MODEL_STRS.URL_STRING: self.standalone_url.url_string,
             MODEL_STRS.URL_TAGS: self.associated_tags,
         }
@@ -62,7 +62,7 @@ class Utub_Urls(db.Model):
     @property
     def serialized_on_title_edit(self) -> dict[str, int | str | list[int]]:
         return {
-            MODEL_STRS.URL_ID: self.id,
+            MODEL_STRS.UTUB_URL_ID: self.id,
             MODEL_STRS.URL_TITLE: self.url_title,
             MODEL_STRS.URL_TAGS: self.associated_tags,
         }
@@ -76,15 +76,3 @@ class Utub_Urls(db.Model):
                 url_tags.append(tag_in_utub.tag_id)
 
         return sorted(url_tags)
-
-    @property
-    def serialized_url(self):
-        """Includes an array of tag IDs for all ID's on this url"""
-        from src.models.utub_url_tags import Utub_Url_Tags
-
-        url_tags: list[Utub_Url_Tags] = self.url_tags
-        return {
-            MODEL_STRS.ID: self.id,
-            MODEL_STRS.URL: self.standalone_url.url_string,
-            MODEL_STRS.TAGS: [tag.tag_item.serialized for tag in url_tags],
-        }

--- a/src/models/utubs.py
+++ b/src/models/utubs.py
@@ -35,7 +35,9 @@ class Utubs(db.Model):
         name="utubDescription",
     )
     utub_url_tags = db.relationship(
-        "Url_Tags", back_populates="utub_containing_this_tag", cascade="all, delete"
+        "Utub_Url_Tags",
+        back_populates="utub_containing_this_tag",
+        cascade="all, delete",
     )
     utub_urls: list[Utub_Urls] = db.relationship(
         "Utub_Urls", back_populates="utub", cascade="all, delete"
@@ -54,9 +56,9 @@ class Utubs(db.Model):
 
         # self.utub_url_tags may contain repeats of tags since same tags can be on multiple URLs
         # Need to pull only the unique ones
-        from src.models.url_tags import Url_Tags
+        from src.models.utub_url_tags import Utub_Url_Tags
 
-        utub_url_tags: list[Url_Tags] = self.utub_url_tags
+        utub_url_tags: list[Utub_Url_Tags] = self.utub_url_tags
 
         utub_tags = []
         for utub_url_tag in utub_url_tags:

--- a/src/models/utubs.py
+++ b/src/models/utubs.py
@@ -82,6 +82,7 @@ class Utubs(db.Model):
                 for url_in_utub in self.utub_urls
             ],
             MODEL_STRS.TAGS: utub_tags,
+            MODEL_STRS.IS_CREATOR: self.utub_creator == current_user_id,
         }
 
     def set_last_updated(self):

--- a/src/tags/routes.py
+++ b/src/tags/routes.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 
 from src import db
 from src.models.tags import Tags
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.tags.forms import UTubNewUrlTagForm
@@ -55,7 +55,7 @@ def add_tag(utub_id: int, url_id: int):
         tag_to_add = url_tag_form.tag_string.data
 
         # If too many tags, disallow adding tag
-        tags_already_on_this_url: list[Url_Tags] = [
+        tags_already_on_this_url: list[Utub_Url_Tags] = [
             tags for tags in utub.utub_url_tags if tags.url_id == url_id
         ]
 
@@ -94,7 +94,7 @@ def add_tag(utub_id: int, url_id: int):
                 )
 
             # Associate with the UTub and URL
-            utub_url_tag = Url_Tags(
+            utub_url_tag = Utub_Url_Tags(
                 utub_id=utub_id, url_id=url_id, tag_id=tag_already_created.id
             )
             tag_model = tag_already_created
@@ -104,7 +104,9 @@ def add_tag(utub_id: int, url_id: int):
             new_tag = Tags(tag_string=tag_to_add, created_by=current_user.id)
             db.session.add(new_tag)
             db.session.commit()
-            utub_url_tag = Url_Tags(utub_id=utub_id, url_id=url_id, tag_id=new_tag.id)
+            utub_url_tag = Utub_Url_Tags(
+                utub_id=utub_id, url_id=url_id, tag_id=new_tag.id
+            )
             tag_model = new_tag
 
         db.session.add(utub_url_tag)
@@ -182,7 +184,7 @@ def remove_tag(utub_id: int, url_id: int, tag_id: int):
         )
 
     # User is member of this UTub
-    tag_for_url_in_utub: Url_Tags = Url_Tags.query.filter_by(
+    tag_for_url_in_utub: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
         utub_id=utub_id, url_id=url_id, tag_id=tag_id
     ).first_or_404()
     url_id_to_remove_tag = tag_for_url_in_utub.url_id
@@ -192,7 +194,7 @@ def remove_tag(utub_id: int, url_id: int, tag_id: int):
     utub.set_last_updated()
     db.session.commit()
 
-    num_left_in_utub: int = Url_Tags.query.filter_by(
+    num_left_in_utub: int = Utub_Url_Tags.query.filter_by(
         utub_id=utub_id, tag_id=tag_id
     ).count()
 
@@ -240,7 +242,7 @@ def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
             403,
         )
 
-    tag_on_url_in_utub: Url_Tags = Url_Tags.query.filter_by(
+    tag_on_url_in_utub: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
         utub_id=utub_id, url_id=url_id, tag_id=tag_id
     ).first_or_404()
 
@@ -274,7 +276,7 @@ def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
 
         else:
             # Check if tag already on URL
-            tag_on_url = Url_Tags.query.filter_by(
+            tag_on_url = Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id, url_id=url_id, tag_id=tag_that_already_exists.id
             ).first()
             if tag_on_url is not None:
@@ -299,7 +301,7 @@ def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
         utub.set_last_updated()
         db.session.commit()
 
-        previous_tag_count_in_utub: int = Url_Tags.query.filter_by(
+        previous_tag_count_in_utub: int = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id, tag_id=tag_id
         ).count()
 

--- a/src/tags/routes.py
+++ b/src/tags/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import abort, Blueprint, jsonify
 from flask_login import current_user
 
 from src import db
@@ -18,9 +18,9 @@ tags = Blueprint("tags", __name__)
 STD_JSON = STD_JSON_RESPONSE
 
 
-@tags.route("/utubs/<int:utub_id>/urls/<int:url_id>/tags", methods=["POST"])
+@tags.route("/utubs/<int:utub_id>/urls/<int:utub_url_id>/tags", methods=["POST"])
 @email_validation_required
-def add_tag(utub_id: int, url_id: int):
+def add_tag(utub_id: int, utub_url_id: int):
     """
     User wants to add a tag to a URL. 5 tags per URL.
     # TODO: Do not allow empty tags
@@ -29,9 +29,10 @@ def add_tag(utub_id: int, url_id: int):
         utub_id (int): The utub that this user is being added to
         url_id (int): The URL this user wants to add a tag to
     """
-    utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-        Utub_Urls.utub_id == utub_id, Utub_Urls.url_id == url_id
-    ).first_or_404()
+    utub_url_association: Utub_Urls = Utub_Urls.query.get_or_404(utub_url_id)
+    if utub_url_association.utub_id != utub_id:
+        abort(404)
+
     utub: Utubs = utub_url_association.utub
 
     user_in_utub = current_user.id in [member.user_id for member in utub.members]
@@ -55,9 +56,14 @@ def add_tag(utub_id: int, url_id: int):
         tag_to_add = url_tag_form.tag_string.data
 
         # If too many tags, disallow adding tag
-        tags_already_on_this_url: list[Utub_Url_Tags] = [
-            tags for tags in utub.utub_url_tags if tags.url_id == url_id
-        ]
+        # tags_on_url: list[Utub_Url_Tags] = utub.utub_url_tags
+        # tags_already_on_this_url: list[Utub_Url_Tags] = [
+        #     tags for tags in utub.utub_url_tags if tags.utub_url_id == utub_url_id
+        # ]
+
+        tags_already_on_this_url: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub.id, Utub_Url_Tags.utub_url_id == utub_url_id
+        ).all()
 
         if len(tags_already_on_this_url) >= 5:
             # Cannot have more than 5 tags on a URL
@@ -95,7 +101,7 @@ def add_tag(utub_id: int, url_id: int):
 
             # Associate with the UTub and URL
             utub_url_tag = Utub_Url_Tags(
-                utub_id=utub_id, url_id=url_id, tag_id=tag_already_created.id
+                utub_id=utub_id, utub_url_id=utub_url_id, tag_id=tag_already_created.id
             )
             tag_model = tag_already_created
 
@@ -105,7 +111,7 @@ def add_tag(utub_id: int, url_id: int):
             db.session.add(new_tag)
             db.session.commit()
             utub_url_tag = Utub_Url_Tags(
-                utub_id=utub_id, url_id=url_id, tag_id=new_tag.id
+                utub_id=utub_id, utub_url_id=utub_url_id, tag_id=new_tag.id
             )
             tag_model = new_tag
 
@@ -114,16 +120,12 @@ def add_tag(utub_id: int, url_id: int):
         db.session.commit()
 
         # Successfully added tag to URL on UTub
-        url_utub_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id, Utub_Urls.url_id == url_id
-        ).first_or_404()
-
         return (
             jsonify(
                 {
                     STD_JSON.STATUS: STD_JSON.SUCCESS,
                     STD_JSON.MESSAGE: TAGS_SUCCESS.TAG_ADDED_TO_URL,
-                    TAGS_SUCCESS.URL_TAGS: url_utub_association.associated_tags,
+                    TAGS_SUCCESS.URL_TAGS: utub_url_association.associated_tags,
                     TAGS_SUCCESS.TAG: tag_model.serialized_on_add_delete,
                 }
             ),
@@ -158,10 +160,10 @@ def add_tag(utub_id: int, url_id: int):
 
 
 @tags.route(
-    "/utubs/<int:utub_id>/urls/<int:url_id>/tags/<int:tag_id>", methods=["DELETE"]
+    "/utubs/<int:utub_id>/urls/<int:utub_url_id>/tags/<int:tag_id>", methods=["DELETE"]
 )
 @email_validation_required
-def remove_tag(utub_id: int, url_id: int, tag_id: int):
+def remove_tag(utub_id: int, utub_url_id: int, tag_id: int):
     """
     User wants to delete a tag from a URL contained in a UTub. Only available to owner of that utub.
 
@@ -185,9 +187,9 @@ def remove_tag(utub_id: int, url_id: int, tag_id: int):
 
     # User is member of this UTub
     tag_for_url_in_utub: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
-        utub_id=utub_id, url_id=url_id, tag_id=tag_id
+        utub_id=utub_id, utub_url_id=utub_url_id, tag_id=tag_id
     ).first_or_404()
-    url_id_to_remove_tag = tag_for_url_in_utub.url_id
+    url_id_to_remove_tag = tag_for_url_in_utub.utub_url_id
     tag_to_remove: Tags = tag_for_url_in_utub.tag_item
 
     db.session.delete(tag_for_url_in_utub)
@@ -198,9 +200,7 @@ def remove_tag(utub_id: int, url_id: int, tag_id: int):
         utub_id=utub_id, tag_id=tag_id
     ).count()
 
-    url_utub_association: Utub_Urls = Utub_Urls.query.filter(
-        Utub_Urls.utub_id == utub.id, Utub_Urls.url_id == url_id_to_remove_tag
-    ).first_or_404()
+    url_utub_association: Utub_Urls = Utub_Urls.query.get_or_404(url_id_to_remove_tag)
 
     return (
         jsonify(
@@ -216,9 +216,11 @@ def remove_tag(utub_id: int, url_id: int, tag_id: int):
     )
 
 
-@tags.route("/utubs/<int:utub_id>/urls/<int:url_id>/tags/<int:tag_id>", methods=["PUT"])
+@tags.route(
+    "/utubs/<int:utub_id>/urls/<int:utub_url_id>/tags/<int:tag_id>", methods=["PUT"]
+)
 @email_validation_required
-def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
+def modify_tag_on_url(utub_id: int, utub_url_id: int, tag_id: int):
     """
     User wants to modify an existing tag on a URL
 
@@ -243,7 +245,7 @@ def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
         )
 
     tag_on_url_in_utub: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
-        utub_id=utub_id, url_id=url_id, tag_id=tag_id
+        utub_id=utub_id, utub_url_id=utub_url_id, tag_id=tag_id
     ).first_or_404()
 
     url_tag_form = UTubNewUrlTagForm()
@@ -277,7 +279,9 @@ def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
         else:
             # Check if tag already on URL
             tag_on_url = Utub_Url_Tags.query.filter_by(
-                utub_id=utub_id, url_id=url_id, tag_id=tag_that_already_exists.id
+                utub_id=utub_id,
+                utub_url_id=utub_url_id,
+                tag_id=tag_that_already_exists.id,
             ).first()
             if tag_on_url is not None:
                 return (
@@ -294,10 +298,7 @@ def modify_tag_on_url(utub_id: int, url_id: int, tag_id: int):
         tag_on_url_in_utub.tag_id = tag_that_already_exists.id
         tag_on_url_in_utub.tag_item = tag_that_already_exists
 
-        url_utub_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub.id, Utub_Urls.url_id == url_id
-        ).first_or_404()
-
+        url_utub_association: Utub_Urls = Utub_Urls.query.get_or_404(utub_url_id)
         utub.set_last_updated()
         db.session.commit()
 

--- a/src/templates/_routes.html
+++ b/src/templates/_routes.html
@@ -16,34 +16,34 @@
                 // URL routes
                 this.addURL = (utub_id) =>
                     "{{url_for('urls.add_url', utub_id=-1)}}".replace("-1", utub_id);
-                this.deleteURL = (utub_id, url_id) =>
-                    "{{url_for('urls.remove_url', utub_id=-1, url_id=-2)}}"
+                this.deleteURL = (utub_id, utub_url_id) =>
+                    "{{url_for('urls.remove_url', utub_id=-1, utub_url_id=-2)}}"
                         .replace("-1", utub_id)
-                        .replace("-2", url_id);
-                this.editURL = (utub_id, url_id) =>
-                    "{{url_for('urls.edit_url', utub_id=-1, url_id=-2)}}"
+                        .replace("-2", utub_url_id);
+                this.editURL = (utub_id, utub_url_id) =>
+                    "{{url_for('urls.edit_url', utub_id=-1, utub_url_id=-2)}}"
                         .replace("-1", utub_id)
-                        .replace("-2", url_id);
-                this.editURLTitle = (utub_id, url_id) =>
-                    "{{url_for('urls.edit_url_title', utub_id=-1, url_id=-2)}}"
+                        .replace("-2", utub_url_id);
+                this.editURLTitle = (utub_id, utub_url_id) =>
+                    "{{url_for('urls.edit_url_title', utub_id=-1, utub_url_id=-2)}}"
                         .replace("-1", utub_id)
-                        .replace("-2", url_id);
+                        .replace("-2", utub_url_id);
 
                 // Tag routes
-                this.addTag = (utub_id, url_id) =>
-                    "{{url_for('tags.add_tag', utub_id=-1, url_id=-2)}}"
+                this.addTag = (utub_id, utub_url_id) =>
+                    "{{url_for('tags.add_tag', utub_id=-1, utub_url_id=-2)}}"
                         .replace("-1", utub_id)
-                        .replace("-2", url_id);
-                this.removeTag = (utub_id, url_id, tag_id) =>
-                    "{{url_for('tags.remove_tag', utub_id=-1, url_id=-2, tag_id=-3)}}"
+                        .replace("-2", utub_url_id);
+                this.removeTag = (utub_id, utub_url_id, tag_id) =>
+                    "{{url_for('tags.remove_tag', utub_id=-1, utub_url_id=-2, tag_id=-3)}}"
                         .replace("-1", utub_id)
-                        .replace("-2", url_id)
+                        .replace("-2", utub_url_id)
                         .replace("-3", tag_id);
                 // 04/04/24 DP "modify" --> "edit"
-                this.editTag = (utub_id, url_id, tag_id) =>
-                    "{{url_for('tags.modify_tag_on_url', utub_id=-1, url_id=-2, tag_id=-3)}}"
+                this.editTag = (utub_id, utub_url_id, tag_id) =>
+                    "{{url_for('tags.modify_tag_on_url', utub_id=-1, utub_url_id=-2, tag_id=-3)}}"
                         .replace("-1", utub_id)
-                        .replace("-2", url_id)
+                        .replace("-2", utub_url_id)
                         .replace("-3", tag_id)
 
                 // Member routes

--- a/src/urls/routes.py
+++ b/src/urls/routes.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 
 from src import db
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.urls.forms import (
@@ -53,12 +53,12 @@ def remove_url(utub_id: int, url_id: int):
         utub.set_last_updated()
 
         # Remove all tags associated with this URL in this UTub as well
-        Url_Tags.query.filter_by(utub_id=utub_id, url_id=url_id).delete()
+        Utub_Url_Tags.query.filter_by(utub_id=utub_id, url_id=url_id).delete()
 
         db.session.commit()
 
-        remaining_utub_tags: list[Url_Tags] = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id
+        remaining_utub_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id
         ).all()
         remaining_utub_tag_ids = set([tag.tag_id for tag in remaining_utub_tags])
         tags = [
@@ -363,7 +363,7 @@ def edit_url(utub_id: int, url_id: int):
         url_in_utub.standalone_url = url_in_database
 
         # Find tags associated with URL
-        url_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        url_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id, url_id=url_id
         ).all()
 

--- a/src/urls/routes.py
+++ b/src/urls/routes.py
@@ -85,7 +85,7 @@ def remove_url(utub_id: int, utub_url_id: int):
                     URL_SUCCESS.UTUB_ID: utub.id,
                     URL_SUCCESS.URL: {
                         URL_SUCCESS.URL_STRING: url_string_to_remove,
-                        URL_SUCCESS.URL_ID: utub_url_id,
+                        URL_SUCCESS.UTUB_URL_ID: utub_url_id,
                         URL_SUCCESS.URL_TITLE: url_in_utub.url_title,
                     },
                     MODELS.TAGS: tags,
@@ -217,7 +217,7 @@ def add_url(utub_id: int):
                     URL_SUCCESS.ADDED_BY: current_user.id,
                     URL_SUCCESS.URL: {
                         URL_SUCCESS.URL_STRING: normalized_url,
-                        URL_SUCCESS.URL_ID: url_utub_user_add.id,
+                        URL_SUCCESS.UTUB_URL_ID: url_utub_user_add.id,
                         URL_SUCCESS.URL_TITLE: utub_new_url_form.url_title.data,
                     },
                 }

--- a/src/utils/strings/model_strs.py
+++ b/src/utils/strings/model_strs.py
@@ -1,11 +1,14 @@
 # Strings for standardizing the model serialization
-ID = "id"
-NAME = "name"
+ADDED_BY = "addedByUserID"
+CAN_DELETE = "canDelete"
 CREATED_BY = "createdByUserID"
 CREATED_AT = "createdAt"
 DESCRIPTION = "description"
 EMAIL = "email"
+ID = "id"
+IS_CREATOR = "isCreator"
 MEMBERS = "members"
+NAME = "name"
 PASSWORD = "password"
 TAG_STRING = "tagString"
 TAGGED_URL = "tagged_url"
@@ -18,11 +21,9 @@ URL_TAGS = "urlTagIDs"
 URL_STRING = "urlString"
 URL_ID = "urlID"
 URL_TITLE = "urlTitle"
-ADDED_BY = "addedByUserID"
 USERNAME = "username"
-IS_CREATOR = "isCreator"
-CAN_DELETE = "canDelete"
 UTUB_DESCRIPTION = "utubDescription"
+UTUB_URL_ID = "utubUrlID"
 
 
 class MODELS:
@@ -48,3 +49,4 @@ class MODELS:
     UTUB_DESCRIPTION = UTUB_DESCRIPTION
     IS_CREATOR = IS_CREATOR
     CAN_DELETE = CAN_DELETE
+    UTUB_URL_ID = UTUB_URL_ID

--- a/src/utils/strings/url_strs.py
+++ b/src/utils/strings/url_strs.py
@@ -5,6 +5,7 @@ from src.utils.strings.model_strs import (
     URL_STRING,
     URL_TITLE,
     URL_TAGS,
+    UTUB_URL_ID,
 )
 from src.utils.strings.utub_strs import UTUB_GENERAL
 
@@ -38,6 +39,7 @@ class URL_SUCCESS(URL_GENERAL, UTUB_GENERAL):
     URL_TITLE_MODIFIED = URL_TITLE_MODIFIED
     URL_OR_TITLE_MODIFIED = URL_OR_TITLE_MODIFIED
     URL_MODIFIED = URL_MODIFIED
+    UTUB_URL_ID = UTUB_URL_ID
 
 
 # Strings for URL failure

--- a/src/utubs/routes.py
+++ b/src/utubs/routes.py
@@ -7,7 +7,6 @@ from src.models.utub_members import Member_Role, Utub_Members
 from src.utubs.forms import UTubForm, UTubDescriptionForm, UTubNewNameForm
 from src.utubs.utils import build_form_errors
 from src.utils.strings.json_strs import STD_JSON_RESPONSE
-from src.utils.strings.model_strs import MODELS
 from src.utils.strings.utub_strs import UTUB_SUCCESS, UTUB_FAILURE
 from src.utils.email_validation import email_validation_required
 
@@ -56,8 +55,6 @@ def get_single_utub(utub_id: str):
         abort(404)
 
     utub_data_serialized = utub.serialized(current_user.id)
-    utub_data_serialized[MODELS.IS_CREATOR] = utub.utub_creator == current_user.id
-
     return jsonify(utub_data_serialized)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from src.models.tags import Tags
 from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
-from src.models.utub_members import Utub_Members
+from src.models.utub_members import Member_Role, Utub_Members
 from src.models.utub_urls import Utub_Urls
 from src.models.urls import Urls
 from src.utils.strings import model_strs
@@ -357,6 +357,7 @@ def add_single_user_to_utub_without_logging_in(app: Flask, register_multiple_use
         )
         creator_to_utub = Utub_Members()
         creator_to_utub.to_user = creator
+        creator_to_utub.member_role = Member_Role.CREATOR
         new_utub.members.append(creator_to_utub)
 
         # Grab and add second user
@@ -388,6 +389,7 @@ def add_multiple_users_to_utub_without_logging_in(app: Flask, register_multiple_
         )
         creator_to_utub = Utub_Members()
         creator_to_utub.to_user = creator
+        creator_to_utub.member_role = Member_Role.CREATOR
         new_utub.members.append(creator_to_utub)
 
         # Other users that aren't creators have ID's of 2 and 3 from fixture
@@ -425,6 +427,7 @@ def every_user_makes_a_unique_utub(app: Flask, register_multiple_users):
             )
 
             creator_to_utub = Utub_Members()
+            creator_to_utub.member_role = Member_Role.CREATOR
             creator_to_utub.to_user = other_user
             new_utub.members.append(creator_to_utub)
             db.session.commit()
@@ -772,13 +775,11 @@ def add_all_urls_and_users_to_each_utub_with_all_tags(
         for utub in all_utubs:
             for single_url_in_utub in utub.utub_urls:
                 for tag in all_tags:
-                    tags_on_url_in_utub = len(
-                        Utub_Url_Tags.query.filter(
-                            Utub_Url_Tags.utub_id == utub.id,
-                            Utub_Url_Tags.utub_url_id == single_url_in_utub.id,
-                            Utub_Url_Tags.tag_id == tag.id,
-                        ).all()
-                    )
+                    tags_on_url_in_utub = Utub_Url_Tags.query.filter(
+                        Utub_Url_Tags.utub_id == utub.id,
+                        Utub_Url_Tags.utub_url_id == single_url_in_utub.id,
+                        Utub_Url_Tags.tag_id == tag.id,
+                    ).count()
 
                     if tags_on_url_in_utub == 0:
                         new_url_tag = Utub_Url_Tags()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from src import create_app, db
 from src.config import TestingConfig
 from src.models.email_validations import Email_Validations
 from src.models.tags import Tags
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -602,7 +602,7 @@ def add_two_users_and_all_urls_to_each_utub_with_one_tag(
                 url_id = url_in_utub.url_id
                 url_in_this_utub = url_in_utub.standalone_url
 
-                new_tag_url_utub_association = Url_Tags()
+                new_tag_url_utub_association = Utub_Url_Tags()
                 new_tag_url_utub_association.utub_containing_this_tag = utub
                 new_tag_url_utub_association.tagged_url = url_in_this_utub
                 new_tag_url_utub_association.tag_item = one_tag
@@ -644,7 +644,7 @@ def add_two_users_and_all_urls_to_each_utub_with_tags(
                 url_in_this_utub = url_in_utub.standalone_url
 
                 for tag in all_tags:
-                    new_tag_url_utub_association = Url_Tags()
+                    new_tag_url_utub_association = Utub_Url_Tags()
                     new_tag_url_utub_association.utub_containing_this_tag = utub
                     new_tag_url_utub_association.tagged_url = url_in_this_utub
                     new_tag_url_utub_association.tag_item = tag
@@ -742,7 +742,7 @@ def add_all_urls_and_users_to_each_utub_with_one_tag(
         for utub in all_utubs:
             for url in utub.utub_urls:
                 tag_with_url_id = Tags.query.get(url.url_id)
-                new_url_tag = Url_Tags()
+                new_url_tag = Utub_Url_Tags()
                 new_url_tag.url_id = url.url_id
                 new_url_tag.tagged_url = url.standalone_url
                 new_url_tag.utub_containing_this_tag = utub
@@ -777,15 +777,15 @@ def add_all_urls_and_users_to_each_utub_with_all_tags(
             for single_url_in_utub in utub.utub_urls:
                 for tag in all_tags:
                     tags_on_url_in_utub = len(
-                        Url_Tags.query.filter(
-                            Url_Tags.utub_id == utub.id,
-                            Url_Tags.url_id == single_url_in_utub.url_id,
-                            Url_Tags.tag_id == tag.id,
+                        Utub_Url_Tags.query.filter(
+                            Utub_Url_Tags.utub_id == utub.id,
+                            Utub_Url_Tags.url_id == single_url_in_utub.url_id,
+                            Utub_Url_Tags.tag_id == tag.id,
                         ).all()
                     )
 
                     if tags_on_url_in_utub == 0:
-                        new_url_tag = Url_Tags()
+                        new_url_tag = Utub_Url_Tags()
                         new_url_tag.url_id = single_url_in_utub.url_id
                         new_url_tag.tagged_url = single_url_in_utub.standalone_url
                         new_url_tag.utub_containing_this_tag = utub

--- a/tests/integration/splash/test_forgot_password.py
+++ b/tests/integration/splash/test_forgot_password.py
@@ -175,7 +175,7 @@ def test_forgot_password_with_email_not_in_database(app, load_login_page):
     nonregistered_user = valid_user_1
 
     with app.app_context():
-        num_of_forgot_password_objs = len(Forgot_Passwords.query.all())
+        num_of_forgot_password_objs = Forgot_Passwords.query.count()
 
     response = client.post(
         url_for(ROUTES.SPLASH.FORGOT_PASSWORD_PAGE),
@@ -192,7 +192,7 @@ def test_forgot_password_with_email_not_in_database(app, load_login_page):
     assert response_json[STD_JSON.MESSAGE] == FORGOT_PASSWORD.EMAIL_SENT_MESSAGE
 
     with app.app_context():
-        assert num_of_forgot_password_objs == len(Forgot_Passwords.query.all())
+        assert num_of_forgot_password_objs == Forgot_Passwords.query.count()
 
 
 def test_forgot_password_with_validated_email(
@@ -215,7 +215,7 @@ def test_forgot_password_with_validated_email(
     client, csrf_token = load_login_page
 
     with app.app_context():
-        num_forgot_passwords = len(Forgot_Passwords.query.all())
+        num_forgot_passwords = Forgot_Passwords.query.count()
         users: list[Users] = Users.query.filter(
             Users.email == new_user[FORGOT_PASSWORD.EMAIL].lower()
         ).all()
@@ -263,7 +263,7 @@ def test_forgot_password_with_validated_email_uppercase(
     client, csrf_token = load_login_page
 
     with app.app_context():
-        num_forgot_passwords = len(Forgot_Passwords.query.all())
+        num_forgot_passwords = Forgot_Passwords.query.count()
         all_users_with_email: list[Users] = Users.query.filter(
             Users.email == new_user[FORGOT_PASSWORD.EMAIL].lower()
         ).all()
@@ -313,7 +313,7 @@ def test_forgot_password_with_non_validated_email(
     client, csrf_token = load_login_page
 
     with app.app_context():
-        num_forgot_passwords = len(Forgot_Passwords.query.all())
+        num_forgot_passwords = Forgot_Passwords.query.count()
 
     response = client.post(
         url_for(ROUTES.SPLASH.FORGOT_PASSWORD_PAGE),
@@ -330,7 +330,7 @@ def test_forgot_password_with_non_validated_email(
     assert response_json[STD_JSON.MESSAGE] == FORGOT_PASSWORD.EMAIL_SENT_MESSAGE
 
     with app.app_context():
-        assert len(Forgot_Passwords.query.all()) == num_forgot_passwords
+        assert Forgot_Passwords.query.count() == num_forgot_passwords
 
 
 def test_forgot_password_rate_limits_correctly(
@@ -352,7 +352,7 @@ def test_forgot_password_rate_limits_correctly(
     client, csrf_token = load_login_page
 
     with app.app_context():
-        num_forgot_passwords = len(Forgot_Passwords.query.all())
+        num_forgot_passwords = Forgot_Passwords.query.count()
         all_users_with_email: list[Users] = Users.query.filter(
             Users.email == new_user[FORGOT_PASSWORD.EMAIL].lower()
         ).all()
@@ -419,7 +419,7 @@ def test_forgot_password_generates_token_correctly(
     client, csrf_token = load_login_page
 
     with app.app_context():
-        num_forgot_passwords = len(Forgot_Passwords.query.all())
+        num_forgot_passwords = Forgot_Passwords.query.count()
         all_users_with_email: list[Users] = Users.query.filter(
             Users.email == new_user[FORGOT_PASSWORD.EMAIL].lower()
         ).all()

--- a/tests/integration/splash/test_reset_password.py
+++ b/tests/integration/splash/test_reset_password.py
@@ -92,12 +92,10 @@ def test_expired_token_deletes_object_and_redirects(
 
     with app.app_context():
         assert (
-            len(
-                Forgot_Passwords.query.filter(
-                    Forgot_Passwords.reset_token == expired_token
-                ).all()
-            )
-            == 0
+            Forgot_Passwords.query.filter(
+                Forgot_Passwords.reset_token == expired_token
+            ).first()
+            is None
         )
 
 
@@ -113,12 +111,10 @@ def test_invalid_reset_password_token(user_attempts_reset_password):
     # Verify invalid token is invalid
     with app.app_context():
         assert (
-            len(
-                Forgot_Passwords.query.filter(
-                    Forgot_Passwords.reset_token == invalid_token
-                ).all()
-            )
-            == 0
+            Forgot_Passwords.query.filter(
+                Forgot_Passwords.reset_token == invalid_token
+            ).first()
+            is None
         )
 
     reset_response = client.get(
@@ -158,12 +154,10 @@ def test_not_email_validated_user_with_password_reset_token_fails(
 
     with app.app_context():
         assert (
-            len(
-                Forgot_Passwords.query.filter(
-                    Forgot_Passwords.reset_token == reset_token
-                ).all()
-            )
-            == 0
+            Forgot_Passwords.query.filter(
+                Forgot_Passwords.reset_token == reset_token
+            ).first()
+            is None
         )
 
 
@@ -189,11 +183,9 @@ def test_matching_user_reset_token_not_in_database_fails(user_attempts_reset_pas
 
     with app.app_context():
         assert (
-            len(
-                Forgot_Passwords.query.filter(
-                    Forgot_Passwords.reset_token == correct_token
-                ).all()
-            )
+            Forgot_Passwords.query.filter(
+                Forgot_Passwords.reset_token == correct_token
+            ).count()
             == 1
         )
 
@@ -324,12 +316,10 @@ def test_valid_new_password_changes_password_and_deletes_forgot_password_object(
             new_user[RESET_PASSWORD.PASSWORD]
         )
         assert (
-            len(
-                Forgot_Passwords.query.filter(
-                    Forgot_Passwords.reset_token == reset_token
-                ).all()
-            )
-            == 0
+            Forgot_Passwords.query.filter(
+                Forgot_Passwords.reset_token == reset_token
+            ).first()
+            is None
         )
 
     # Ensure no one is logged in

--- a/tests/integration/utubmembers/test_add_member_to_utub_route.py
+++ b/tests/integration/utubmembers/test_add_member_to_utub_route.py
@@ -156,32 +156,20 @@ def test_add_then_remove_then_add_user_who_has_urls_to_utub(
 
     with app.app_context():
         # Get this user's UTub they created
-        utub_user_created = Utubs.query.filter(
+        utub_user_created: Utubs = Utubs.query.filter(
             Utubs.utub_creator == current_user.id
         ).first()
-
-        # Ensure other users in this UTub
-        assert len(utub_user_created.members) > 1
 
         initial_num_of_users_in_utub = len(utub_user_created.members)
 
         # Grab a sample user
-        other_user_in_utub_with_urls: Utub_Members = Utub_Members.query.filter(
-            Utub_Members.user_id != current_user.id
-        ).first()
+        other_user_in_utub_with_urls: Utub_Members = [
+            member
+            for member in utub_user_created.members
+            if member.user_id != current_user.id
+        ][-1]
         other_user_id_in_utub_with_urls = other_user_in_utub_with_urls.user_id
         other_user_username = other_user_in_utub_with_urls.to_user.username
-
-        # Ensure this other user has URLs in the UTub
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_user_created.id,
-                    Utub_Urls.user_id == other_user_id_in_utub_with_urls,
-                ).all()
-            )
-            > 0
-        )
 
         # Get number of URLs and tags in this UTub initially
         initial_num_of_urls_in_utub = len(

--- a/tests/integration/utubmembers/test_add_member_to_utub_route.py
+++ b/tests/integration/utubmembers/test_add_member_to_utub_route.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 import pytest
 
 from src import db
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -188,11 +188,13 @@ def test_add_then_remove_then_add_user_who_has_urls_to_utub(
             Utub_Urls.query.filter(Utub_Urls.utub_id == utub_user_created.id).all()
         )
         initial_num_of_url_tags_in_utub = len(
-            Url_Tags.query.filter(Url_Tags.utub_id == utub_user_created.id).all()
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_user_created.id
+            ).all()
         )
 
         all_urls_in_utubs = len(Utub_Urls.query.all())
-        all_url_tags_in_utub = len(Url_Tags.query.all())
+        all_url_tags_in_utub = len(Utub_Url_Tags.query.all())
 
     # Remove this user first
     remove_user_response = client.delete(
@@ -250,13 +252,17 @@ def test_add_then_remove_then_add_user_who_has_urls_to_utub(
     with app.app_context():
         # Ensure proper counts of all associations after removing then adding user who owned URLs in the UTub
         assert len(Utub_Urls.query.all()) == all_urls_in_utubs
-        assert len(Url_Tags.query.all()) == all_url_tags_in_utub
+        assert len(Utub_Url_Tags.query.all()) == all_url_tags_in_utub
         assert (
             len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_user_created.id).all())
             == initial_num_of_urls_in_utub
         )
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_user_created.id).all())
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_user_created.id
+                ).all()
+            )
             == initial_num_of_url_tags_in_utub
         )
         assert (

--- a/tests/integration/utubmembers/test_remove_member_from_utub_route.py
+++ b/tests/integration/utubmembers/test_remove_member_from_utub_route.py
@@ -216,12 +216,6 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        # Ensure creator is currently logged in
-        assert current_utub.utub_creator == current_user.id
-
-        # Ensure multiple users in this Utubs
-        assert len(current_utub.members) > 1
-
         # Grab another user from the members
         second_user_in_utub_association: Utub_Members = Utub_Members.query.filter(
             Utub_Members.utub_id == current_utub.id,
@@ -229,41 +223,12 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
         ).first()
         second_user_in_utub: Users = second_user_in_utub_association.to_user
 
-        # Ensure this user has URLs associated with them in UTub
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub.id,
-                    Utub_Urls.user_id == second_user_in_utub.id,
-                ).all()
-            )
-            > 0
-        )
-        example_url_of_user = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == current_utub.id,
-            Utub_Urls.user_id == second_user_in_utub.id,
-        ).first()
-
-        # Ensure this user has URLs that have tags associated with them
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == current_utub.id,
-                    Utub_Url_Tags.url_id == example_url_of_user.url_id,
-                ).all()
-            )
-            > 0
-        )
-
         # Get initial counts of URLs, Tags, and relative associations in the database
         current_num_of_urls_in_utub = len(current_utub.utub_urls)
         current_num_of_url_tags_in_utub = len(current_utub.utub_url_tags)
 
         all_urls_utub_associations = len(Utub_Urls.query.all())
         all_urls_tag_associations = len(Utub_Url_Tags.query.all())
-
-        # Ensure second user in this UTub
-        assert second_user_in_utub in [user.to_user for user in current_utub.members]
 
         # Count all user-utub associations in db
         initial_num_user_utubs = len(Utub_Members.query.all())

--- a/tests/integration/utubmembers/test_remove_member_from_utub_route.py
+++ b/tests/integration/utubmembers/test_remove_member_from_utub_route.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 import pytest
 
 from src import db
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -247,9 +247,9 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
         # Ensure this user has URLs that have tags associated with them
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == current_utub.id,
-                    Url_Tags.url_id == example_url_of_user.url_id,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == current_utub.id,
+                    Utub_Url_Tags.url_id == example_url_of_user.url_id,
                 ).all()
             )
             > 0
@@ -260,7 +260,7 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
         current_num_of_url_tags_in_utub = len(current_utub.utub_url_tags)
 
         all_urls_utub_associations = len(Utub_Urls.query.all())
-        all_urls_tag_associations = len(Url_Tags.query.all())
+        all_urls_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Ensure second user in this UTub
         assert second_user_in_utub in [user.to_user for user in current_utub.members]
@@ -315,12 +315,16 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
 
         # Ensure URL-Tag associations aren't removed
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == current_utub.id).all())
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == current_utub.id
+                ).all()
+            )
             == current_num_of_url_tags_in_utub
         )
 
         # Ensure all associations still correct
-        assert len(Url_Tags.query.all()) == all_urls_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == all_urls_tag_associations
         assert len(Utub_Urls.query.all()) == all_urls_utub_associations
 
 

--- a/tests/integration/utubmembers/test_remove_member_from_utub_route.py
+++ b/tests/integration/utubmembers/test_remove_member_from_utub_route.py
@@ -6,7 +6,7 @@ from src import db
 from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
-from src.models.utub_members import Utub_Members
+from src.models.utub_members import Member_Role, Utub_Members
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
 from src.utils.strings.form_strs import GENERAL_FORM
@@ -44,12 +44,6 @@ def test_remove_valid_user_from_utub_as_creator(
         # Get the only UTub, which contains two members
         current_utub: Utubs = Utubs.query.first()
 
-        # Ensure creator is currently logged in
-        assert current_utub.utub_creator == current_user.id
-
-        # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
-
         # Grab the second user from the members
         second_user_in_utub_association: Utub_Members = Utub_Members.query.filter(
             Utub_Members.utub_id == current_utub.id,
@@ -57,11 +51,13 @@ def test_remove_valid_user_from_utub_as_creator(
         ).first()
         second_user_in_utub: Users = second_user_in_utub_association.to_user
 
-        # Ensure second user in this UTub
-        assert second_user_in_utub in [user.to_user for user in current_utub.members]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
+
+        # Count all user-utub associations in utub
+        initial_num_users_in_utub = Utub_Members.query.filter(
+            Utub_Members.utub_id == current_utub.id
+        ).count()
 
     # Remove second user
     remove_user_response = client.delete(
@@ -93,7 +89,7 @@ def test_remove_valid_user_from_utub_as_creator(
     # Ensure database is correctly updated
     with app.app_context():
         current_utub = Utubs.query.first()
-        assert len(current_utub.members) == 1
+        assert len(current_utub.members) == initial_num_users_in_utub - 1
 
         # Ensure second user not in this UTub
         assert second_user_in_utub not in [
@@ -101,7 +97,7 @@ def test_remove_valid_user_from_utub_as_creator(
         ]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs - 1
+        assert Utub_Members.query.count() == initial_num_user_utubs - 1
 
 
 def test_remove_self_from_utub_as_member(
@@ -132,19 +128,13 @@ def test_remove_self_from_utub_as_member(
         # Get the only UTub with two members
         current_utub: Utubs = Utubs.query.first()
 
-        # Ensure creator is not currently logged in user
-        assert current_utub.utub_creator != current_user.id
-
-        # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
-
-        # Ensure second user in this UTub
-        assert current_user in [user.to_user for user in current_utub.members]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
+        initial_num_users_in_utub = Utub_Members.query.filter(
+            Utub_Members.utub_id == current_utub.id
+        ).count()
 
-        current_user_id = int(current_user.id)
+        current_user_id = current_user.id
         current_user_username = current_user.username
 
     # Remove self from UTub
@@ -177,13 +167,13 @@ def test_remove_self_from_utub_as_member(
     # Ensure database is correctly updated
     with app.app_context():
         current_utub = Utubs.query.first()
-        assert len(current_utub.members) == 1
+        assert len(current_utub.members) == initial_num_users_in_utub - 1
 
         # Ensure logged in user not in this UTub
         assert current_user not in [user.to_user for user in current_utub.members]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs - 1
+        assert Utub_Members.query.count() == initial_num_user_utubs - 1
 
 
 def test_remove_valid_user_with_urls_from_utub_as_creator(
@@ -227,11 +217,11 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
         current_num_of_urls_in_utub = len(current_utub.utub_urls)
         current_num_of_url_tags_in_utub = len(current_utub.utub_url_tags)
 
-        all_urls_utub_associations = len(Utub_Urls.query.all())
-        all_urls_tag_associations = len(Utub_Url_Tags.query.all())
+        all_urls_utub_associations = Utub_Urls.query.count()
+        all_urls_tag_associations = Utub_Url_Tags.query.count()
 
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove second user
     remove_user_response = client.delete(
@@ -270,27 +260,23 @@ def test_remove_valid_user_with_urls_from_utub_as_creator(
         ]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs - 1
+        assert Utub_Members.query.count() == initial_num_user_utubs - 1
 
         # Ensure URL-UTub associations aren't removed
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == current_utub.id).all())
+            Utub_Urls.query.filter(Utub_Urls.utub_id == current_utub.id).count()
             == current_num_of_urls_in_utub
         )
 
         # Ensure URL-Tag associations aren't removed
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == current_utub.id
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(Utub_Url_Tags.utub_id == current_utub.id).count()
             == current_num_of_url_tags_in_utub
         )
 
         # Ensure all associations still correct
-        assert len(Utub_Url_Tags.query.all()) == all_urls_tag_associations
-        assert len(Utub_Urls.query.all()) == all_urls_utub_associations
+        assert Utub_Url_Tags.query.count() == all_urls_tag_associations
+        assert Utub_Urls.query.count() == all_urls_utub_associations
 
 
 def test_remove_self_from_utub_as_creator(
@@ -316,19 +302,10 @@ def test_remove_self_from_utub_as_creator(
         # Get the only UTub with two members
         current_utub: Utubs = Utubs.query.first()
 
-        # Ensure creator is currently logged in and is current user
-        assert current_utub.utub_creator == current_user.id
-
-        # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
-
         current_number_of_users_in_utub = len(current_utub.members)
 
-        # Ensure current user also in this UTub
-        assert current_user in [user.to_user for user in current_utub.members]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove self from UTub
     remove_user_response = client.delete(
@@ -363,7 +340,7 @@ def test_remove_self_from_utub_as_creator(
         assert current_user in [user.to_user for user in current_utub.members]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
 
 
 def test_remove_self_from_utub_no_csrf_token_as_member(
@@ -383,18 +360,11 @@ def test_remove_self_from_utub_no_csrf_token_as_member(
         # Get the only UTub with two members
         current_utub: Utubs = Utubs.query.first()
 
-        # Ensure creator is not currently logged in user
-        assert current_utub.utub_creator != current_user.id
-
         # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
         current_number_of_users_in_utub = len(current_utub.members)
 
-        # Ensure second user in this UTub
-        assert current_user in [user.to_user for user in current_utub.members]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove self from UTub
     remove_user_response = client.delete(
@@ -418,7 +388,7 @@ def test_remove_self_from_utub_no_csrf_token_as_member(
         assert current_user in [user.to_user for user in current_utub.members]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
 
 
 def test_remove_valid_user_from_utub_no_csrf_token_as_creator(
@@ -438,11 +408,7 @@ def test_remove_valid_user_from_utub_no_csrf_token_as_creator(
         # Get the only UTub with two members
         current_utub: Utubs = Utubs.query.first()
 
-        # Ensure creator is currently logged in
-        assert current_utub.utub_creator == current_user.id
-
         # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
         current_number_of_users_in_utub = len(current_utub.members)
 
         # Grab the second user from the members
@@ -452,11 +418,8 @@ def test_remove_valid_user_from_utub_no_csrf_token_as_creator(
         ).first()
         second_user_in_utub = second_user_in_utub_association.to_user
 
-        # Ensure second user in this UTub
-        assert second_user_in_utub in [user.to_user for user in current_utub.members]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove second user
     remove_user_response = client.delete(
@@ -483,7 +446,7 @@ def test_remove_valid_user_from_utub_no_csrf_token_as_creator(
         assert second_user_in_utub in [user.to_user for user in current_utub.members]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
 
 
 def test_remove_valid_user_from_invalid_utub_as_member_or_creator(
@@ -494,29 +457,19 @@ def test_remove_valid_user_from_invalid_utub_as_member_or_creator(
     WHEN the user requests to remove themselves from the UTub via a DELETE to "/utubs/<int:utub_id>/members/<int:user_id>"
     THEN ensure that a 404 status code response is given when the UTub cannot be found in the database
     """
+    NONEXISTENT_UTUB_ID = 999
 
     client, csrf_token_string, _, app = login_second_user_without_register
 
     with app.app_context():
-        # Get the only UTub with two members
-        all_current_utubs = Utubs.query.all()
-
-        invalid_utub_id = 0
-
-        while invalid_utub_id in [utub.id for utub in all_current_utubs]:
-            invalid_utub_id += 1
-
-        # Ensure given UTub does not exist
-        assert invalid_utub_id not in [utub.id for utub in all_current_utubs]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove self from UTub
     remove_user_response = client.delete(
         url_for(
             ROUTES.MEMBERS.REMOVE_MEMBER,
-            utub_id=invalid_utub_id,
+            utub_id=NONEXISTENT_UTUB_ID,
             user_id=current_user.id,
         ),
         data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
@@ -528,7 +481,9 @@ def test_remove_valid_user_from_invalid_utub_as_member_or_creator(
     # Ensure 404 response is given no matter what USER ID
     for num in range(10):
         remove_user_response = client.delete(
-            url_for(ROUTES.MEMBERS.REMOVE_MEMBER, utub_id=invalid_utub_id, user_id=num),
+            url_for(
+                ROUTES.MEMBERS.REMOVE_MEMBER, utub_id=NONEXISTENT_UTUB_ID, user_id=num
+            ),
             data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
         )
 
@@ -537,7 +492,7 @@ def test_remove_valid_user_from_invalid_utub_as_member_or_creator(
 
     with app.app_context():
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
 
 
 def test_remove_invalid_user_from_utub_as_creator(
@@ -555,38 +510,26 @@ def test_remove_invalid_user_from_utub_as_creator(
         STD_JSON.ERROR_CODE: 3
     }
     """
+    NONEXISTENT_USER_ID = 999
 
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
         # Get the only UTub with two members
-        current_utub: Utubs = Utubs.query.first()
-
-        # Ensure creator is currently logged in
-        assert current_utub.utub_creator == current_user.id
-
-        # Find a user id that isn't in this UTub
-        user_id_not_in_utub = 0
-        while user_id_not_in_utub in [user.user_id for user in current_utub.members]:
-            user_id_not_in_utub += 1
-
-        # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
-
-        # Ensure invalid user is not in this UTub
-        assert user_id_not_in_utub not in [
-            user.user_id for user in current_utub.members
-        ]
+        current_utub: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+        current_utub_member_count = len(current_utub.members)
 
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove self from UTub
     remove_user_response = client.delete(
         url_for(
             ROUTES.MEMBERS.REMOVE_MEMBER,
             utub_id=current_utub.id,
-            user_id=user_id_not_in_utub,
+            user_id=NONEXISTENT_USER_ID,
         ),
         data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -604,7 +547,13 @@ def test_remove_invalid_user_from_utub_as_creator(
 
     with app.app_context():
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
+        assert (
+            current_utub_member_count
+            == Utub_Members.query.filter(
+                Utub_Members.utub_id == current_utub.id
+            ).count()
+        )
 
 
 def test_remove_invalid_user_from_utub_as_member(
@@ -622,41 +571,26 @@ def test_remove_invalid_user_from_utub_as_member(
         STD_JSON.ERROR_CODE: 2
     }
     """
-
+    NONEXISTENT_USER_ID = 999
     client, csrf_token_string, _, app = login_second_user_without_register
 
     with app.app_context():
         # Get the only UTub with two members
-        current_utub: Utubs = Utubs.query.first()
-
-        # Ensure current user is not creator
-        assert current_user.id != current_utub.utub_creator
-
-        # Ensure current user is a member of this UTub
-        assert current_user in [user.to_user for user in current_utub.members]
-
-        # Find a user id that isn't in this UTub
-        user_id_not_in_utub = 0
-        while user_id_not_in_utub in [user.user_id for user in current_utub.members]:
-            user_id_not_in_utub += 1
-
-        # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 2
-
-        # Ensure invalid user is not in this UTub
-        assert user_id_not_in_utub not in [
-            user.user_id for user in current_utub.members
-        ]
+        current_utub_member: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role != Member_Role.CREATOR
+        ).first()
+        current_utub: Utubs = current_utub_member.to_utub
+        current_utub_member_count = len(current_utub.members)
 
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Remove invalid user from UTub
     remove_user_response = client.delete(
         url_for(
             ROUTES.MEMBERS.REMOVE_MEMBER,
             utub_id=current_utub.id,
-            user_id=user_id_not_in_utub,
+            user_id=NONEXISTENT_USER_ID,
         ),
         data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -675,7 +609,13 @@ def test_remove_invalid_user_from_utub_as_member(
 
     with app.app_context():
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
+        assert (
+            current_utub_member_count
+            == Utub_Members.query.filter(
+                Utub_Members.utub_id == current_utub.id
+            ).count()
+        )
 
 
 def test_remove_another_member_from_same_utub_as_member(
@@ -700,32 +640,29 @@ def test_remove_another_member_from_same_utub_as_member(
 
     with app.app_context():
         # Get the only UTub, which contains three members
-        current_utub: Utubs = Utubs.query.first()
-
-        # Ensure creator is not currently logged in user
-        assert current_utub.utub_creator != current_user.id
+        current_utub_member: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role == Member_Role.MEMBER
+        ).first()
+        current_utub: Utubs = current_utub_member.to_utub
 
         # Ensure multiple users in this Utubs
-        assert len(current_utub.members) == 3
         current_number_of_users_in_utub = len(current_utub.members)
 
-        # Ensure second user in this UTub
-        assert current_user in [user.to_user for user in current_utub.members]
-
         # Grab other user in this UTub
-        for user in current_utub.members:
-            if user != current_user and user.user_id != current_utub.utub_creator:
-                other_utub_member = user.to_user
+        other_utub_member: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role == Member_Role.MEMBER,
+            Utub_Members.user_id != current_user.id,
+        ).first()
 
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Attempt to remove other user from UTub as a member
     remove_user_response = client.delete(
         url_for(
             ROUTES.MEMBERS.REMOVE_MEMBER,
             utub_id=current_utub.id,
-            user_id=other_utub_member.id,
+            user_id=other_utub_member.user_id,
         ),
         data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -745,17 +682,19 @@ def test_remove_another_member_from_same_utub_as_member(
     # Ensure database is correctly updated
     with app.app_context():
         # Grab the UTub again
-        current_utub = Utubs.query.first()
+        current_utub = Utubs.query.get(current_utub.id)
         assert len(current_utub.members) == current_number_of_users_in_utub
 
         # Ensure logged in user in this UTub
         assert current_user in [user.to_user for user in current_utub.members]
 
         # Ensure the bystander member is still in the UTub
-        assert other_utub_member in [user.to_user for user in current_utub.members]
+        assert other_utub_member.user_id in [
+            user.user_id for user in current_utub.members
+        ]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
 
 
 def test_remove_member_from_another_utub_as_creator_of_another_utub(
@@ -786,39 +725,29 @@ def test_remove_member_from_another_utub_as_creator_of_another_utub(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        second_user_utub = Utubs.query.get(2)
-
-        # Assert second utub only has the second user in it
-        assert len(second_user_utub.members) == 1
+        second_user_utub_id = 2
+        second_user_utub = Utubs.query.get(second_user_utub_id)
 
         # Get the third user
-        third_user = Users.query.get(3)
-
-        # Assert third user not in second user's UTub
-        assert third_user not in [user.to_user for user in second_user_utub.members]
+        third_user_id = 3
+        third_user = Users.query.get(third_user_id)
 
         # Add third user to second user's UTub
         utub_user_association = Utub_Members()
         utub_user_association.to_user = third_user
+        utub_user_association.utub_id = second_user_utub_id
         second_user_utub.members.append(utub_user_association)
         db.session.commit()
 
-        # Now assert the third user in the second User's UTub
-        assert len(second_user_utub.members) == 2
-        assert third_user in [user.to_user for user in second_user_utub.members]
-
-        # Ensure logged in user is not in the second user's UTub
-        assert current_user not in [user.to_user for user in second_user_utub.members]
-
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Try to remove the third user from second user's UTub as the first user
     remove_user_response = client.delete(
         url_for(
             ROUTES.MEMBERS.REMOVE_MEMBER,
-            utub_id=second_user_utub.id,
-            user_id=third_user.id,
+            utub_id=second_user_utub_id,
+            user_id=third_user_id,
         ),
         data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -837,13 +766,13 @@ def test_remove_member_from_another_utub_as_creator_of_another_utub(
 
     # Ensure database still shows user 3 is member of utub 2
     with app.app_context():
-        second_user_utub = Utubs.query.get(2)
-        third_user = Users.query.get(3)
+        second_user_utub: Utubs = Utubs.query.get(second_user_utub_id)
+        third_user: Users = Users.query.get(third_user_id)
 
         assert third_user in [user.to_user for user in second_user_utub.members]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
 
 
 def test_remove_member_from_another_utub_as_member_of_another_utub(
@@ -878,17 +807,20 @@ def test_remove_member_from_another_utub_as_member_of_another_utub(
 
     with app.app_context():
         # Get the third user
-        third_user: Users = Users.query.get(3)
+        third_user_id = 3
+        third_user: Users = Users.query.get(third_user_id)
 
         # Have third user make another UTub
         new_utub_from_third_user: Utubs = Utubs(
-            name="Third User's UTub", utub_creator=third_user.id, utub_description=""
+            name="Third User's UTub", utub_creator=third_user_id, utub_description=""
         )
         creator = Utub_Members()
         creator.to_user = third_user
+        creator.member_role = Member_Role.CREATOR
         new_utub_from_third_user.members.append(creator)
 
-        first_user = Users.query.get(1)
+        first_user_id = 1
+        first_user = Users.query.get(first_user_id)
 
         new_utub_user = Utub_Members()
         new_utub_user.to_user = first_user
@@ -897,31 +829,20 @@ def test_remove_member_from_another_utub_as_member_of_another_utub(
         db.session.add(new_utub_from_third_user)
         db.session.commit()
 
-        # Ensure current user is not creator of any UTubs
-        all_utubs: list[Utubs] = Utubs.query.all()
-        for utub in all_utubs:
-            assert current_user.id != utub.utub_creator
-
-        # Ensure current user is not member of third user's UTub
-        assert current_user not in [
-            user.to_user for user in new_utub_from_third_user.members
-        ]
-
         # Ensure current user is a member of a UTub
-        all_utub_users = Utub_Members.query.filter(
-            Utub_Members.user_id == current_user.id
-        ).all()
-        assert len(all_utub_users) > 0
+        current_utub_member_count = Utub_Members.query.filter(
+            Utub_Members.utub_id == new_utub_from_third_user.id
+        ).count()
 
         # Count all user-utub associations in db
-        initial_num_user_utubs = len(Utub_Members.query.all())
+        initial_num_user_utubs = Utub_Members.query.count()
 
     # Try to remove the first user from second user's UTub as the first user
     remove_user_response = client.delete(
         url_for(
             ROUTES.MEMBERS.REMOVE_MEMBER,
             utub_id=new_utub_from_third_user.id,
-            user_id=first_user.id,
+            user_id=first_user_id,
         ),
         data={GENERAL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -940,13 +861,19 @@ def test_remove_member_from_another_utub_as_member_of_another_utub(
 
     # Ensure database still shows user 1 is member of utub 2
     with app.app_context():
-        third_user_utub = Utubs.query.get(2)
-        first_user = Users.query.get(1)
+        third_user_utub: Utubs = Utubs.query.get(2)
+        first_user: Users = Users.query.get(1)
 
         assert first_user in [user.to_user for user in third_user_utub.members]
 
         # Ensure counts of Utubs-User associations is correct
-        assert len(Utub_Members.query.all()) == initial_num_user_utubs
+        assert Utub_Members.query.count() == initial_num_user_utubs
+        assert (
+            current_utub_member_count
+            == Utub_Members.query.filter(
+                Utub_Members.utub_id == new_utub_from_third_user.id
+            ).count()
+        )
 
 
 def test_remove_valid_user_from_utub_updates_utub_last_updated(

--- a/tests/integration/utubs/test_add_utub_route.py
+++ b/tests/integration/utubs/test_add_utub_route.py
@@ -42,8 +42,8 @@ def test_add_utub_with_valid_form(login_first_user_with_register):
 
     # Make sure database is empty of UTubs and associated users
     with app.app_context():
-        assert len(Utubs.query.all()) == 0
-        assert len(Utub_Members.query.all()) == 0
+        initial_utub_count = Utubs.query.count()
+        initial_utub_member_count = Utub_Members.query.count()
 
     new_utub_form = {
         UTUB_FORM.CSRF_TOKEN: csrf_token,
@@ -72,7 +72,7 @@ def test_add_utub_with_valid_form(login_first_user_with_register):
     utub_id = int(new_utub_response_json[UTUB_SUCCESS.UTUB_ID])
     with app.app_context():
         utub_from_db: Utubs = Utubs.query.get(utub_id)
-        assert len(Utubs.query.all()) == 1
+        assert Utubs.query.count() == initial_utub_count + 1
 
         # Assert database creator is the same one who made it
         assert utub_from_db.utub_creator == user.id
@@ -94,7 +94,7 @@ def test_add_utub_with_valid_form(login_first_user_with_register):
         assert len(utub_from_db.utub_url_tags) == 0
 
         # Assert only one user and UTub association
-        assert len(Utub_Members.query.all()) == 1
+        assert Utub_Members.query.count() == initial_utub_member_count + 1
 
         # Assert the only Utubs-User association is valid
         current_utub_user_association: Utub_Members = Utub_Members.query.first()
@@ -160,7 +160,6 @@ def test_add_utub_with_same_name(
         == valid_empty_utub_1[UTUB_FORM.NAME]
     )
     assert new_utub_response_json[UTUB_SUCCESS.UTUB_CREATOR_ID] == user.id
-    assert isinstance(new_utub_response_json[UTUB_SUCCESS.UTUB_ID], int)
     utub_id = new_utub_response_json[UTUB_SUCCESS.UTUB_ID]
 
     # Validate the utub in the database
@@ -206,7 +205,7 @@ def test_add_utub_with_get_request(login_first_user_with_register):
 
     # Make sure no UTub in database
     with app.app_context():
-        assert len(Utubs.query.all()) == 0
+        assert Utubs.query.count() == 0
 
 
 def test_add_utub_with_invalid_form(login_first_user_with_register):
@@ -257,7 +256,7 @@ def test_add_utub_with_invalid_form(login_first_user_with_register):
 
     # Make sure no UTub in database
     with app.app_context():
-        assert len(Utubs.query.all()) == 0
+        assert Utubs.query.count() == 0
 
 
 def test_add_utub_with_no_csrf_token(login_first_user_with_register):
@@ -314,12 +313,11 @@ def test_add_multiple_valid_utubs(login_first_user_with_register):
             new_utub_response_json[UTUB_SUCCESS.UTUB_NAME] == valid_utub[UTUB_FORM.NAME]
         )
         assert new_utub_response_json[UTUB_SUCCESS.UTUB_CREATOR_ID] == user.id
-        assert isinstance(new_utub_response_json[UTUB_SUCCESS.UTUB_ID], int)
 
         # Validate the utub in the database
         utub_id = int(new_utub_response_json[UTUB_SUCCESS.UTUB_ID])
         with app.app_context():
-            utub_from_db: Utubs = Utubs.query.get_or_404(utub_id)
+            utub_from_db: Utubs = Utubs.query.get(utub_id)
 
             # Assert database creator is the same one who made it
             assert utub_from_db.utub_creator == user.id
@@ -341,4 +339,4 @@ def test_add_multiple_valid_utubs(login_first_user_with_register):
             assert len(utub_from_db.utub_url_tags) == 0
 
     # Check for all 3 test utubs added
-    assert len(Utubs.query.all()) == len(valid_utubs)
+    assert Utubs.query.count() == len(valid_utubs)

--- a/tests/integration/utubs/test_delete_utub_route.py
+++ b/tests/integration/utubs/test_delete_utub_route.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.engine.row import Row
 
 from src import db
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
@@ -109,7 +109,7 @@ def test_delete_existing_utub_with_members_but_no_urls_no_tags(
         initial_num_of_url_utubs_associations = len(Utub_Urls.query.all())
 
         num_of_tags_in_utub = len(utub_user_is_creator_of.utub_url_tags)
-        initial_num_of_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_of_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         initial_num_utubs = len(Utubs.query.all())
 
@@ -157,11 +157,16 @@ def test_delete_existing_utub_with_members_but_no_urls_no_tags(
         )
 
         assert (
-            len(Url_Tags.query.all())
+            len(Utub_Url_Tags.query.all())
             == initial_num_of_url_tag_associations - num_of_tags_in_utub
         )
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_id_to_delete).all()) == 0
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_to_delete
+                ).all()
+            )
+            == 0
         )
 
         assert len(Utubs.query.all()) == initial_num_utubs - 1
@@ -205,7 +210,7 @@ def test_delete_existing_utub_with_urls_no_tags(
         initial_num_of_url_utubs_associations = len(Utub_Urls.query.all())
 
         num_of_tags_in_utub = len(utub_user_is_creator_of.utub_url_tags)
-        initial_num_of_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_of_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         initial_num_utubs = len(Utubs.query.all())
 
@@ -253,11 +258,16 @@ def test_delete_existing_utub_with_urls_no_tags(
         )
 
         assert (
-            len(Url_Tags.query.all())
+            len(Utub_Url_Tags.query.all())
             == initial_num_of_url_tag_associations - num_of_tags_in_utub
         )
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_id_to_delete).all()) == 0
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_to_delete
+                ).all()
+            )
+            == 0
         )
 
         assert len(Utubs.query.all()) == initial_num_utubs - 1
@@ -301,7 +311,7 @@ def test_delete_existing_utub_with_urls_and_tags(
         initial_num_of_url_utubs_associations = len(Utub_Urls.query.all())
 
         num_of_tags_in_utub = len(utub_user_is_creator_of.utub_url_tags)
-        initial_num_of_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_of_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         initial_num_utubs = len(Utubs.query.all())
 
@@ -349,11 +359,16 @@ def test_delete_existing_utub_with_urls_and_tags(
         )
 
         assert (
-            len(Url_Tags.query.all())
+            len(Utub_Url_Tags.query.all())
             == initial_num_of_url_tag_associations - num_of_tags_in_utub
         )
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_id_to_delete).all()) == 0
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_to_delete
+                ).all()
+            )
+            == 0
         )
 
         assert len(Utubs.query.all()) == initial_num_utubs - 1

--- a/tests/integration/utubs/test_delete_utub_route.py
+++ b/tests/integration/utubs/test_delete_utub_route.py
@@ -1,7 +1,6 @@
 from flask import url_for
 from flask_login import current_user
 import pytest
-from sqlalchemy.engine.row import Row
 
 from src import db
 from src.models.utub_url_tags import Utub_Url_Tags
@@ -41,7 +40,7 @@ def test_delete_existing_utub_as_creator_no_tags_urls_members(
 
     with app.app_context():
         # Get initial count of UTubs
-        initial_num_utubs = len(Utubs.query.all())
+        initial_num_utubs = Utubs.query.count()
 
     delete_utub_response = client.delete(
         url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_id),
@@ -67,8 +66,8 @@ def test_delete_existing_utub_as_creator_no_tags_urls_members(
 
     with app.app_context():
         # Assert no UTubs and no UTub-User associations exist in the database after deletion
-        assert len(Utubs.query.all()) == initial_num_utubs - 1
-        assert len(Utub_Members.query.all()) == 0
+        assert Utubs.query.count() == initial_num_utubs - 1
+        assert Utub_Members.query.count() == 0
 
 
 def test_delete_existing_utub_with_members_but_no_urls_no_tags(
@@ -103,15 +102,15 @@ def test_delete_existing_utub_with_members_but_no_urls_no_tags(
         utub_description_to_delete = utub_user_is_creator_of.utub_description
 
         num_of_users_in_utub = len(utub_user_is_creator_of.members)
-        initial_num_of_user_utubs_associations = len(Utub_Members.query.all())
+        initial_num_of_user_utubs_associations = Utub_Members.query.count()
 
         num_of_urls_in_utub = len(utub_user_is_creator_of.utub_urls)
-        initial_num_of_url_utubs_associations = len(Utub_Urls.query.all())
+        initial_num_of_url_utubs_associations = Utub_Urls.query.count()
 
         num_of_tags_in_utub = len(utub_user_is_creator_of.utub_url_tags)
-        initial_num_of_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_of_url_tag_associations = Utub_Url_Tags.query.count()
 
-        initial_num_utubs = len(Utubs.query.all())
+        initial_num_utubs = Utubs.query.count()
 
     delete_utub_response = client.delete(
         url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_id_to_delete),
@@ -135,41 +134,34 @@ def test_delete_existing_utub_with_members_but_no_urls_no_tags(
     with app.app_context():
         # Ensure proper counting in DB of deleted associations
         assert (
-            len(Utub_Members.query.all())
+            Utub_Members.query.count()
             == initial_num_of_user_utubs_associations - num_of_users_in_utub
         )
         assert (
-            len(
-                Utub_Members.query.filter(
-                    Utub_Members.utub_id == utub_id_to_delete
-                ).all()
-            )
+            Utub_Members.query.filter(Utub_Members.utub_id == utub_id_to_delete).count()
             == 0
         )
 
         assert (
-            len(Utub_Urls.query.all())
+            Utub_Urls.query.count()
             == initial_num_of_url_utubs_associations - num_of_urls_in_utub
         )
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_delete).all())
-            == 0
+            Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_delete).count() == 0
         )
 
         assert (
-            len(Utub_Url_Tags.query.all())
+            Utub_Url_Tags.query.count()
             == initial_num_of_url_tag_associations - num_of_tags_in_utub
         )
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_to_delete
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_to_delete
+            ).count()
             == 0
         )
 
-        assert len(Utubs.query.all()) == initial_num_utubs - 1
+        assert Utubs.query.count() == initial_num_utubs - 1
 
 
 def test_delete_existing_utub_with_urls_no_tags(
@@ -204,15 +196,15 @@ def test_delete_existing_utub_with_urls_no_tags(
         utub_description_to_delete = utub_user_is_creator_of.utub_description
 
         num_of_users_in_utub = len(utub_user_is_creator_of.members)
-        initial_num_of_user_utubs_associations = len(Utub_Members.query.all())
+        initial_num_of_user_utubs_associations = Utub_Members.query.count()
 
         num_of_urls_in_utub = len(utub_user_is_creator_of.utub_urls)
-        initial_num_of_url_utubs_associations = len(Utub_Urls.query.all())
+        initial_num_of_url_utubs_associations = Utub_Urls.query.count()
 
         num_of_tags_in_utub = len(utub_user_is_creator_of.utub_url_tags)
-        initial_num_of_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_of_url_tag_associations = Utub_Url_Tags.query.count()
 
-        initial_num_utubs = len(Utubs.query.all())
+        initial_num_utubs = Utubs.query.count()
 
     delete_utub_response = client.delete(
         url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_id_to_delete),
@@ -236,41 +228,34 @@ def test_delete_existing_utub_with_urls_no_tags(
     with app.app_context():
         # Ensure proper counting in DB of deleted associations
         assert (
-            len(Utub_Members.query.all())
+            Utub_Members.query.count()
             == initial_num_of_user_utubs_associations - num_of_users_in_utub
         )
         assert (
-            len(
-                Utub_Members.query.filter(
-                    Utub_Members.utub_id == utub_id_to_delete
-                ).all()
-            )
+            Utub_Members.query.filter(Utub_Members.utub_id == utub_id_to_delete).count()
             == 0
         )
 
         assert (
-            len(Utub_Urls.query.all())
+            Utub_Urls.query.count()
             == initial_num_of_url_utubs_associations - num_of_urls_in_utub
         )
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_delete).all())
-            == 0
+            Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_delete).count() == 0
         )
 
         assert (
-            len(Utub_Url_Tags.query.all())
+            Utub_Url_Tags.query.count()
             == initial_num_of_url_tag_associations - num_of_tags_in_utub
         )
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_to_delete
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_to_delete
+            ).count()
             == 0
         )
 
-        assert len(Utubs.query.all()) == initial_num_utubs - 1
+        assert Utubs.query.count() == initial_num_utubs - 1
 
 
 def test_delete_existing_utub_with_urls_and_tags(
@@ -305,15 +290,15 @@ def test_delete_existing_utub_with_urls_and_tags(
         utub_description_to_delete = utub_user_is_creator_of.utub_description
 
         num_of_users_in_utub = len(utub_user_is_creator_of.members)
-        initial_num_of_user_utubs_associations = len(Utub_Members.query.all())
+        initial_num_of_user_utubs_associations = Utub_Members.query.count()
 
         num_of_urls_in_utub = len(utub_user_is_creator_of.utub_urls)
-        initial_num_of_url_utubs_associations = len(Utub_Urls.query.all())
+        initial_num_of_url_utubs_associations = Utub_Urls.query.count()
 
         num_of_tags_in_utub = len(utub_user_is_creator_of.utub_url_tags)
-        initial_num_of_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_of_url_tag_associations = Utub_Url_Tags.query.count()
 
-        initial_num_utubs = len(Utubs.query.all())
+        initial_num_utubs = Utubs.query.count()
 
     delete_utub_response = client.delete(
         url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_id_to_delete),
@@ -337,41 +322,34 @@ def test_delete_existing_utub_with_urls_and_tags(
     with app.app_context():
         # Ensure proper counting in DB of deleted associations
         assert (
-            len(Utub_Members.query.all())
+            Utub_Members.query.count()
             == initial_num_of_user_utubs_associations - num_of_users_in_utub
         )
         assert (
-            len(
-                Utub_Members.query.filter(
-                    Utub_Members.utub_id == utub_id_to_delete
-                ).all()
-            )
+            Utub_Members.query.filter(Utub_Members.utub_id == utub_id_to_delete).count()
             == 0
         )
 
         assert (
-            len(Utub_Urls.query.all())
+            Utub_Urls.query.count()
             == initial_num_of_url_utubs_associations - num_of_urls_in_utub
         )
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_delete).all())
-            == 0
+            Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_delete).count() == 0
         )
 
         assert (
-            len(Utub_Url_Tags.query.all())
+            Utub_Url_Tags.query.count()
             == initial_num_of_url_tag_associations - num_of_tags_in_utub
         )
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_to_delete
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_to_delete
+            ).count()
             == 0
         )
 
-        assert len(Utubs.query.all()) == initial_num_utubs - 1
+        assert Utubs.query.count() == initial_num_utubs - 1
 
 
 def test_delete_nonexistent_utub(login_first_user_with_register):
@@ -380,14 +358,11 @@ def test_delete_nonexistent_utub(login_first_user_with_register):
     WHEN the user requests to delete the UTub via a DELETE to "/utubs/1"
     THEN ensure that a 404 status code response is given when the UTub cannot be found in the database
     """
+    NONEXISTENT_UTUB_ID = 999
     client, csrf_token, _, app = login_first_user_with_register
 
-    # Assert no UTubs exist before nonexistent UTub is attempted to be removed
-    with app.app_context():
-        assert len(Utubs.query.all()) == 0
-
     delete_utub_response = client.delete(
-        url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=1),
+        url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=NONEXISTENT_UTUB_ID),
         data={UTUB_FORM.CSRF_TOKEN: csrf_token},
     )
 
@@ -396,7 +371,7 @@ def test_delete_nonexistent_utub(login_first_user_with_register):
 
     # Assert no UTub exists after nonexistent UTub is attempted to be removed
     with app.app_context():
-        assert len(Utubs.query.all()) == 0
+        assert Utubs.query.count() == 0
 
 
 def test_delete_utub_with_invalid_route(login_first_user_with_register):
@@ -410,10 +385,6 @@ def test_delete_utub_with_invalid_route(login_first_user_with_register):
     """
     client, csrf_token, _, app = login_first_user_with_register
 
-    # Assert no UTubs exist before nonexistent UTub is attempted to be removed
-    with app.app_context():
-        assert len(Utubs.query.all()) == 0
-
     delete_utub_response = client.delete(
         "/utubs/InvalidRoute", data={UTUB_FORM.CSRF_TOKEN: csrf_token}
     )
@@ -423,7 +394,7 @@ def test_delete_utub_with_invalid_route(login_first_user_with_register):
 
     # Assert no UTub exists after nonexistent UTub is attempted to be removed
     with app.app_context():
-        assert len(Utubs.query.all()) == 0
+        assert Utubs.query.count() == 0
 
 
 def test_delete_utub_with_no_csrf_token(add_single_utub_as_user_after_logging_in):
@@ -434,9 +405,8 @@ def test_delete_utub_with_no_csrf_token(add_single_utub_as_user_after_logging_in
     """
     client, utub_id, _, app = add_single_utub_as_user_after_logging_in
 
-    # Assert 1 UTub exists before nonexistent UTub is attempted to be removed
     with app.app_context():
-        assert len(Utubs.query.all()) == 1
+        initial_num_utubs = Utubs.query.count()
 
     delete_utub_response = client.delete(
         url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_id)
@@ -448,7 +418,7 @@ def test_delete_utub_with_no_csrf_token(add_single_utub_as_user_after_logging_in
 
     # Assert 1 UTub exists after nonexistent UTub is attempted to be removed
     with app.app_context():
-        assert len(Utubs.query.all()) == 1
+        assert Utubs.query.count() == initial_num_utubs
 
 
 def test_delete_utub_as_not_member_or_creator(
@@ -469,13 +439,12 @@ def test_delete_utub_as_not_member_or_creator(
 
     with app.app_context():
         # Get the UTubs from the database that this member is not a part of
-        user_not_in_these_utubs = (
-            Utub_Members.query.filter(Utub_Members.user_id != current_user.id)
-            .with_entities(Utub_Members.utub_id)
-            .all()
-        )
-        assert len(Utubs.query.all()) == 3
-        assert len(Utub_Members.query.all()) == 3
+        user_not_in_these_utubs: list[Utub_Members] = Utub_Members.query.filter(
+            Utub_Members.user_id != current_user.id
+        ).all()
+        users_not_in_these_utubs_count = len(user_not_in_these_utubs)
+        initial_num_utubs = Utubs.query.count()
+        initial_num_utub_members = Utub_Members.query.count()
 
         # Make sure that only 2 utubs-user associations exist, one for each utub/user combo
         assert len(user_not_in_these_utubs) == 2
@@ -496,19 +465,17 @@ def test_delete_utub_as_not_member_or_creator(
         )
 
         with app.app_context():
-            user_not_in_these_utubs = (
-                Utub_Members.query.filter(Utub_Members.user_id != current_user.id)
-                .with_entities(Utub_Members.utub_id)
-                .all()
-            )
+            user_not_in_these_utubs: list[Utub_Members] = Utub_Members.query.filter(
+                Utub_Members.user_id != current_user.id
+            ).all()
 
             # Make sure that only 2 utubs-user associations exist, one for each utub/user combo
-            assert len(user_not_in_these_utubs) == 2
+            assert len(user_not_in_these_utubs) == users_not_in_these_utubs_count
 
     with app.app_context():
         # Make sure all 3 test UTubs are still available in the database
-        assert len(Utubs.query.all()) == 3
-        assert len(Utub_Members.query.all()) == 3
+        assert Utubs.query.count() == initial_num_utubs
+        assert Utub_Members.query.count() == initial_num_utub_members
 
 
 def test_delete_utub_as_member_only(
@@ -530,14 +497,10 @@ def test_delete_utub_as_member_only(
 
     with app.app_context():
         # Get the UTubs from the database that this member is not a part of
-        user_not_in_these_utubs: list[Row] = (
-            Utub_Members.query.filter(Utub_Members.user_id != current_user.id)
-            .with_entities(Utub_Members.utub_id)
-            .all()
-        )
-
+        user_not_in_these_utubs: list[Utub_Members] = Utub_Members.query.filter(
+            Utub_Members.user_id != current_user.id
+        ).all()
         # Make sure that only 2 utubs-user associations exist, one for each utub/user combo
-        assert len(user_not_in_these_utubs) == 2
         original_count_of_user_not_in_utubs = len(user_not_in_these_utubs)
 
         # Add the current logged in user to the UTub's it is not a part of
@@ -553,23 +516,21 @@ def test_delete_utub_as_member_only(
         all_utubs: list[Utubs] = Utubs.query.all()
         for utub in all_utubs:
             assert (
-                len(
-                    Utub_Members.query.filter(
-                        Utub_Members.user_id == current_user.id,
-                        Utub_Members.utub_id == utub.id,
-                    ).all()
-                )
+                Utub_Members.query.filter(
+                    Utub_Members.user_id == current_user.id,
+                    Utub_Members.utub_id == utub.id,
+                ).count()
                 == 1
             )
 
-        initial_num_utubs = len(Utubs.query.all())
+        initial_num_utubs = Utubs.query.count()
 
-    # The logged in user should now be a member of the utubs they weren't a part of before
-    only_member_in_these_utubs = user_not_in_these_utubs
+        # The logged in user should now be a member of the utubs they weren't a part of before
+        only_member_in_these_utubs = [utub.utub_id for utub in user_not_in_these_utubs]
 
-    for utub_not_in in only_member_in_these_utubs:
+    for utub_id_not_in in only_member_in_these_utubs:
         delete_utub_response = client.delete(
-            url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_not_in.utub_id),
+            url_for(ROUTES.UTUBS.DELETE_UTUB, utub_id=utub_id_not_in),
             data={UTUB_FORM.CSRF_TOKEN: csrf_token},
         )
 
@@ -583,13 +544,11 @@ def test_delete_utub_as_member_only(
         )
 
         with app.app_context():
-            user_not_in_these_utubs = (
-                Utub_Members.query.filter(Utub_Members.user_id != current_user.id)
-                .with_entities(Utub_Members.utub_id)
-                .all()
-            )
+            user_not_in_these_utubs = Utub_Members.query.filter(
+                Utub_Members.user_id != current_user.id
+            ).all()
             assert len(user_not_in_these_utubs) == original_count_of_user_not_in_utubs
 
     with app.app_context():
         # Make sure all 3 test UTubs are still available in the database
-        assert len(Utubs.query.all()) == initial_num_utubs
+        assert Utubs.query.count() == initial_num_utubs

--- a/tests/integration/utubs/test_get_detailed_utub_info.py
+++ b/tests/integration/utubs/test_get_detailed_utub_info.py
@@ -170,7 +170,7 @@ def test_get_valid_utub_with_members_urls_no_tags(
         url_dict = {
             MODELS.CAN_DELETE: current_user.id == url.user_id
             or current_user.id == utub_user_is_member_of.utub_creator,
-            MODELS.URL_ID: url.id,
+            MODELS.UTUB_URL_ID: url.id,
             MODELS.URL_STRING: standalone_url.url_string,
             MODELS.URL_TAGS: [],
             MODELS.URL_TITLE: url.url_title,
@@ -237,7 +237,7 @@ def test_get_valid_utub_with_members_urls_tags(
         url_dict = {
             MODELS.CAN_DELETE: current_user.id == url.id
             or current_user.id == utub_user_is_creator_of.utub_creator,
-            MODELS.URL_ID: url.id,
+            MODELS.UTUB_URL_ID: url.id,
             MODELS.URL_STRING: url_string,
             MODELS.URL_TAGS: sorted([tag.id for tag in all_tags]),
             MODELS.URL_TITLE: f"This is {url_string}",

--- a/tests/integration/utubs/test_get_detailed_utub_info.py
+++ b/tests/integration/utubs/test_get_detailed_utub_info.py
@@ -170,7 +170,7 @@ def test_get_valid_utub_with_members_urls_no_tags(
         url_dict = {
             MODELS.CAN_DELETE: current_user.id == url.user_id
             or current_user.id == utub_user_is_member_of.utub_creator,
-            MODELS.URL_ID: url.url_id,
+            MODELS.URL_ID: url.id,
             MODELS.URL_STRING: standalone_url.url_string,
             MODELS.URL_TAGS: [],
             MODELS.URL_TITLE: url.url_title,
@@ -202,6 +202,9 @@ def test_get_valid_utub_with_members_urls_tags(
         utub_user_is_creator_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator == current_user.id
         ).first()
+        all_urls_in_utub: list[Utub_Urls] = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_is_creator_of.id
+        ).all()
 
     response = client.get(_build_get_utub_route(utub_user_is_creator_of.id))
     assert response.status_code == 200
@@ -227,14 +230,17 @@ def test_get_valid_utub_with_members_urls_tags(
         }
         assert user_dict in response_json[MODELS.MEMBERS]
 
-    for url in all_urls:
+    for url in all_urls_in_utub:
+        url_string = [
+            url_object for url_object in all_urls if url_object.id == url.url_id
+        ][-1].url_string
         url_dict = {
             MODELS.CAN_DELETE: current_user.id == url.id
             or current_user.id == utub_user_is_creator_of.utub_creator,
             MODELS.URL_ID: url.id,
-            MODELS.URL_STRING: url.url_string,
+            MODELS.URL_STRING: url_string,
             MODELS.URL_TAGS: sorted([tag.id for tag in all_tags]),
-            MODELS.URL_TITLE: f"This is {url.url_string}",
+            MODELS.URL_TITLE: f"This is {url_string}",
         }
         assert url_dict in response_json[MODELS.URLS]
 

--- a/tests/integration/utubs/test_update_utub_desc_route.py
+++ b/tests/integration/utubs/test_update_utub_desc_route.py
@@ -2,7 +2,7 @@ from flask import url_for
 from flask_login import current_user
 import pytest
 
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
@@ -55,7 +55,7 @@ def test_update_valid_utub_description_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -88,7 +88,7 @@ def test_update_valid_utub_description_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -152,7 +152,7 @@ def test_update_valid_empty_utub_description_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -185,7 +185,7 @@ def test_update_valid_empty_utub_description_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -249,7 +249,7 @@ def test_update_only_spaces_utub_description_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -282,7 +282,7 @@ def test_update_only_spaces_utub_description_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -343,7 +343,7 @@ def test_update_utub_description_with_same_description_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -376,7 +376,7 @@ def test_update_utub_description_with_same_description_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -439,7 +439,7 @@ def test_update_utub_description_as_member(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -472,7 +472,7 @@ def test_update_utub_description_as_member(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -542,7 +542,7 @@ def test_update_utub_description_as_creator_of_other_utub(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -575,7 +575,7 @@ def test_update_utub_description_as_creator_of_other_utub(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -628,7 +628,7 @@ def test_update_utub_description_of_invalid_utub(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -654,7 +654,7 @@ def test_update_utub_description_of_invalid_utub(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         all_final_utubs = Utubs.query.all()
         final_utub_names_and_descriptions = dict()
@@ -717,7 +717,7 @@ def test_update_utub_description_too_long(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -759,7 +759,7 @@ def test_update_utub_description_too_long(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -815,7 +815,7 @@ def test_update_utub_description_missing_description_field(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -850,7 +850,7 @@ def test_update_utub_description_missing_description_field(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -899,7 +899,7 @@ def test_update_utub_description_missing_csrf_token(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -925,7 +925,7 @@ def test_update_utub_description_missing_csrf_token(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name

--- a/tests/integration/utubs/test_update_utub_desc_route.py
+++ b/tests/integration/utubs/test_update_utub_desc_route.py
@@ -44,18 +44,13 @@ def test_update_valid_utub_description_as_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        current_utub_description = utub_of_user.utub_description
-
-        # Ensure the new description is not the current description
-        assert UPDATE_TEXT != current_utub_description
-
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -85,10 +80,10 @@ def test_update_valid_utub_description_as_creator(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -141,18 +136,13 @@ def test_update_valid_empty_utub_description_as_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        current_utub_description = utub_of_user.utub_description
-
-        # Ensure the new description is not the current description
-        assert UPDATE_TEXT != current_utub_description
-
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -182,10 +172,10 @@ def test_update_valid_empty_utub_description_as_creator(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -238,18 +228,13 @@ def test_update_only_spaces_utub_description_as_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        current_utub_description = utub_of_user.utub_description
-
-        # Ensure the new description is not the current description
-        assert UPDATE_TEXT != current_utub_description
-
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -279,10 +264,10 @@ def test_update_only_spaces_utub_description_as_creator(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -340,10 +325,10 @@ def test_update_utub_description_with_same_description_as_creator(
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -373,10 +358,10 @@ def test_update_utub_description_with_same_description_as_creator(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -425,21 +410,15 @@ def test_update_utub_description_as_member(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Ensure this user is in the UTub
-        assert current_user in [user.to_user for user in utub_of_user.members]
-
         current_utub_description = utub_of_user.utub_description
-
-        # Ensure the new description is not the current description
-        assert UPDATE_TEXT != current_utub_description
 
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -469,10 +448,10 @@ def test_update_utub_description_as_member(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -522,27 +501,15 @@ def test_update_utub_description_as_creator_of_other_utub(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Ensure this user is the creator of another UTub
-        utub_user_is_creator_of = Utubs.query.filter(
-            Utubs.utub_creator == current_user.id
-        ).first()
-        assert utub_user_is_creator_of is not None
-
-        # Ensure this user is in the UTub
-        assert current_user in [user.to_user for user in utub_of_user.members]
-
         current_utub_description = utub_of_user.utub_description
-
-        # Ensure the new description is not the current description
-        assert UPDATE_TEXT != current_utub_description
 
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -572,10 +539,10 @@ def test_update_utub_description_as_creator_of_other_utub(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -609,26 +576,14 @@ def test_update_utub_description_of_invalid_utub(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
+    NONEXISTENT_UTUB_ID = 999
     UPDATE_TEXT = "This is my new UTub description. 123456"
     # Grab this creator's UTub
     with app.app_context():
-        invalid_utub_id = 0
-        valid_utub_ids = [utub.id for utub in Utubs.query.all()]
-        while invalid_utub_id in valid_utub_ids:
-            invalid_utub_id += 1
-
-        # Ensure no UTub exists with this ID
-        assert Utubs.query.get(invalid_utub_id) is None
-        # Ensure this user is the creator of another UTub
-        utub_user_is_creator_of = Utubs.query.filter(
-            Utubs.utub_creator == current_user.id
-        ).first()
-        assert utub_user_is_creator_of is not None
-
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -642,7 +597,7 @@ def test_update_utub_description_of_invalid_utub(
     }
 
     edit_utub_desc_response = client.patch(
-        url_for(ROUTES.UTUBS.UPDATE_UTUB_DESC, utub_id=invalid_utub_id),
+        url_for(ROUTES.UTUBS.UPDATE_UTUB_DESC, utub_id=NONEXISTENT_UTUB_ID),
         data=utub_desc_form,
     )
 
@@ -651,10 +606,10 @@ def test_update_utub_description_of_invalid_utub(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         all_final_utubs = Utubs.query.all()
         final_utub_names_and_descriptions = dict()
@@ -708,16 +663,13 @@ def test_update_utub_description_too_long(
 
         current_utub_description = utub_of_user.utub_description
 
-        # Ensure the new description is not the current description
-        assert UPDATE_TEXT != current_utub_description
-
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -756,10 +708,10 @@ def test_update_utub_description_too_long(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -812,10 +764,10 @@ def test_update_utub_description_missing_description_field(
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -847,10 +799,10 @@ def test_update_utub_description_missing_description_field(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -896,10 +848,10 @@ def test_update_utub_description_missing_csrf_token(
         current_utub_id = utub_of_user.id
         current_utub_name = utub_of_user.name
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -922,10 +874,10 @@ def test_update_utub_description_missing_csrf_token(
 
     # Ensure database is consistent with just updating the UTub description
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name

--- a/tests/integration/utubs/test_update_utub_name_route.py
+++ b/tests/integration/utubs/test_update_utub_name_route.py
@@ -44,18 +44,13 @@ def test_update_valid_utub_name_as_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        current_utub_name = utub_of_user.name
-
-        # Ensure the new name is not equal to the old name
-        assert NEW_NAME != current_utub_name
-
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -85,10 +80,10 @@ def test_update_valid_utub_name_as_creator(
 
     # Ensure database is consistent with just updating the UTub name
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == NEW_NAME
@@ -142,16 +137,13 @@ def test_update_valid_utub_same_name_as_creator(
 
         NEW_NAME = utub_of_user.name
 
-        # Ensure the new name is  equal to the old name
-        assert NEW_NAME == utub_of_user.name
-
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -181,10 +173,10 @@ def test_update_valid_utub_same_name_as_creator(
 
     # Ensure database is consistent after user requested same name for UTub
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == NEW_NAME
@@ -243,16 +235,13 @@ def test_update_utub_empty_name_as_creator(
 
         current_utub_name = utub_of_user.name
 
-        # Ensure the new name is  equal to the old name
-        assert NEW_NAME != current_utub_name
-
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -289,10 +278,10 @@ def test_update_utub_empty_name_as_creator(
 
     # Ensure database is consistent after sending back invalid form response
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -351,16 +340,13 @@ def test_update_utub_name_only_spaces_as_creator(
 
         current_utub_name = utub_of_user.name
 
-        # Ensure the new name is  equal to the old name
-        assert NEW_NAME != current_utub_name
-
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -396,10 +382,10 @@ def test_update_utub_name_only_spaces_as_creator(
 
     # Ensure database is consistent after sending back invalid form response
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -452,21 +438,15 @@ def test_update_utub_name_as_member(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Ensure this user is in the UTub
-        assert current_user in [user.to_user for user in utub_of_user.members]
-
         current_utub_name = utub_of_user.name
-
-        # Ensure the new name is not equal to the old name
-        assert NEW_NAME != current_utub_name
 
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -496,10 +476,10 @@ def test_update_utub_name_as_member(
 
     # Ensure database is consistent with just updating the UTub name
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -546,27 +526,15 @@ def test_update_utub_name_as_creator_of_another_utub(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Ensure this user is in the UTub
-        assert current_user in [user.to_user for user in utub_of_user.members]
-
-        # Ensure this user is a creator of another UTub
-        assert (
-            Utubs.query.filter(Utubs.utub_creator == current_user.id).first()
-            is not None
-        )
-
         current_utub_name = utub_of_user.name
-
-        # Ensure the new name is not equal to the old name
-        assert NEW_NAME != current_utub_name
 
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -596,10 +564,10 @@ def test_update_utub_name_as_creator_of_another_utub(
 
     # Ensure database is consistent with just updating the UTub name
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -631,15 +599,9 @@ def test_update_name_of_invalid_utub(
         the server sends back a 404 HTTP status code
     """
     client, csrf_token_string, _, app = login_first_user_without_register
-    utub_id_to_test = 0
+    NONEXISTENT_UTUB_ID = 999
 
     with app.app_context():
-        all_utubs: list[Utubs] = Utubs.query.all()
-        all_utub_ids = [int(utub.id) for utub in all_utubs]
-
-        while utub_id_to_test in all_utub_ids:
-            utub_id_to_test += 1
-
         utub_of_user: Utubs = Utubs.query.filter(
             Utubs.utub_creator == current_user.id
         ).first()
@@ -649,10 +611,10 @@ def test_update_name_of_invalid_utub(
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -666,7 +628,7 @@ def test_update_name_of_invalid_utub(
     }
 
     edit_utub_name_response = client.patch(
-        url_for(ROUTES.UTUBS.UPDATE_UTUB_NAME, utub_id=utub_id_to_test),
+        url_for(ROUTES.UTUBS.UPDATE_UTUB_NAME, utub_id=NONEXISTENT_UTUB_ID),
         data=utub_name_form,
     )
 
@@ -675,10 +637,10 @@ def test_update_name_of_invalid_utub(
 
     # Ensure database is consistent after user requested same name for UTub
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -741,16 +703,13 @@ def test_update_name_of_utub_too_long_name(
 
         current_utub_name = utub_of_user.name
 
-        # Ensure new name is not equal to old name
-        assert NEW_NAME != current_utub_name
-
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -787,10 +746,10 @@ def test_update_name_of_utub_too_long_name(
 
     # Ensure database is consistent after user requested same name for UTub
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -850,10 +809,10 @@ def test_update_name_of_utub_missing_name_field_form(
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -889,10 +848,10 @@ def test_update_name_of_utub_missing_name_field_form(
 
     # Ensure database is consistent after user requested same name for UTub
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -940,16 +899,13 @@ def test_update_name_of_utub_missing_csrf_token(
 
         current_utub_name = utub_of_user.name
 
-        # Ensure the new name is not equal to the old name
-        assert NEW_NAME != current_utub_name
-
         current_utub_id = utub_of_user.id
         current_utub_description = utub_of_user.utub_description
 
-        current_num_of_utubs = len(Utubs.query.all())
-        current_num_of_utub_users = len(Utub_Members.query.all())
-        current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
+        current_num_of_utubs = Utubs.query.count()
+        current_num_of_utub_users = Utub_Members.query.count()
+        current_num_of_utub_urls = Utub_Urls.query.count()
+        current_num_of_url_tags = Utub_Url_Tags.query.count()
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -970,10 +926,10 @@ def test_update_name_of_utub_missing_csrf_token(
 
     # Ensure database is consistent with just updating the UTub name
     with app.app_context():
-        assert len(Utubs.query.all()) == current_num_of_utubs
-        assert len(Utub_Members.query.all()) == current_num_of_utub_users
-        assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
+        assert Utubs.query.count() == current_num_of_utubs
+        assert Utub_Members.query.count() == current_num_of_utub_users
+        assert Utub_Urls.query.count() == current_num_of_utub_urls
+        assert Utub_Url_Tags.query.count() == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name

--- a/tests/integration/utubs/test_update_utub_name_route.py
+++ b/tests/integration/utubs/test_update_utub_name_route.py
@@ -2,7 +2,7 @@ from flask import url_for
 from flask_login import current_user
 import pytest
 
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
@@ -55,7 +55,7 @@ def test_update_valid_utub_name_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -88,7 +88,7 @@ def test_update_valid_utub_name_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == NEW_NAME
@@ -151,7 +151,7 @@ def test_update_valid_utub_same_name_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -184,7 +184,7 @@ def test_update_valid_utub_same_name_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == NEW_NAME
@@ -252,7 +252,7 @@ def test_update_utub_empty_name_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -292,7 +292,7 @@ def test_update_utub_empty_name_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -360,7 +360,7 @@ def test_update_utub_name_only_spaces_as_creator(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -399,7 +399,7 @@ def test_update_utub_name_only_spaces_as_creator(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -466,7 +466,7 @@ def test_update_utub_name_as_member(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -499,7 +499,7 @@ def test_update_utub_name_as_member(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -566,7 +566,7 @@ def test_update_utub_name_as_creator_of_another_utub(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -599,7 +599,7 @@ def test_update_utub_name_as_creator_of_another_utub(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -652,7 +652,7 @@ def test_update_name_of_invalid_utub(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -678,7 +678,7 @@ def test_update_name_of_invalid_utub(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -750,7 +750,7 @@ def test_update_name_of_utub_too_long_name(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -790,7 +790,7 @@ def test_update_name_of_utub_too_long_name(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -853,7 +853,7 @@ def test_update_name_of_utub_missing_name_field_form(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -892,7 +892,7 @@ def test_update_name_of_utub_missing_name_field_form(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name
@@ -949,7 +949,7 @@ def test_update_name_of_utub_missing_csrf_token(
         current_num_of_utubs = len(Utubs.query.all())
         current_num_of_utub_users = len(Utub_Members.query.all())
         current_num_of_utub_urls = len(Utub_Urls.query.all())
-        current_num_of_url_tags = len(Url_Tags.query.all())
+        current_num_of_url_tags = len(Utub_Url_Tags.query.all())
 
         # Get all UTub names and descriptions in a dictionary for checking
         all_utub_names_and_descriptions = dict()
@@ -973,7 +973,7 @@ def test_update_name_of_utub_missing_csrf_token(
         assert len(Utubs.query.all()) == current_num_of_utubs
         assert len(Utub_Members.query.all()) == current_num_of_utub_users
         assert len(Utub_Urls.query.all()) == current_num_of_utub_urls
-        assert len(Url_Tags.query.all()) == current_num_of_url_tags
+        assert len(Utub_Url_Tags.query.all()) == current_num_of_url_tags
 
         final_check_utub_of_user: Utubs = Utubs.query.get(current_utub_id)
         assert final_check_utub_of_user.name == current_utub_name

--- a/tests/integration/utubtags/conftest.py
+++ b/tests/integration/utubtags/conftest.py
@@ -28,15 +28,13 @@ def add_one_url_to_each_utub_one_tag(
 
         for utub in all_utubs:
             url_in_utub = utub.utub_urls[0]
-            url_item_in_utub = url_in_utub.standalone_url
-            url_id_in_utub = url_item_in_utub.id
 
             new_tag_url_utub_association = Utub_Url_Tags()
             new_tag_url_utub_association.utub_containing_this_tag = utub
-            new_tag_url_utub_association.tagged_url = url_item_in_utub
+            new_tag_url_utub_association.tagged_url = url_in_utub
             new_tag_url_utub_association.tag_item = tag
             new_tag_url_utub_association.utub_id = utub.id
-            new_tag_url_utub_association.url_id = url_id_in_utub
+            new_tag_url_utub_association.utub_url_id = url_in_utub.id
             new_tag_url_utub_association.tag_id = tag.id
             utub.utub_url_tags.append(new_tag_url_utub_association)
 

--- a/tests/integration/utubtags/conftest.py
+++ b/tests/integration/utubtags/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 from src import db
 from src.models.tags import Tags
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 
 
@@ -31,7 +31,7 @@ def add_one_url_to_each_utub_one_tag(
             url_item_in_utub = url_in_utub.standalone_url
             url_id_in_utub = url_item_in_utub.id
 
-            new_tag_url_utub_association = Url_Tags()
+            new_tag_url_utub_association = Utub_Url_Tags()
             new_tag_url_utub_association.utub_containing_this_tag = utub
             new_tag_url_utub_association.tagged_url = url_item_in_utub
             new_tag_url_utub_association.tag_item = tag

--- a/tests/integration/utubtags/test_add_tag_to_url_route.py
+++ b/tests/integration/utubtags/test_add_tag_to_url_route.py
@@ -5,7 +5,7 @@ import pytest
 from src import db
 from src.models.tags import Tags
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
@@ -72,14 +72,14 @@ def test_add_fresh_tag_to_valid_url_as_utub_creator(
 
         # Ensure no Tag-URL association exists in this UTub
         init_num_of_tags_on_urls = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -120,16 +120,16 @@ def test_add_fresh_tag_to_valid_url_as_utub_creator(
         # Ensure a Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == init_num_of_tags_on_urls + 1
         )
 
         # Ensure correct total count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
 
 
 def test_add_fresh_tag_to_valid_url_as_utub_member(
@@ -189,16 +189,16 @@ def test_add_fresh_tag_to_valid_url_as_utub_member(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -236,16 +236,16 @@ def test_add_fresh_tag_to_valid_url_as_utub_member(
         # Ensure a Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 1
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
 
 
 def test_add_existing_tag_to_valid_url_as_utub_creator(
@@ -307,16 +307,16 @@ def test_add_existing_tag_to_valid_url_as_utub_creator(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -355,17 +355,17 @@ def test_add_existing_tag_to_valid_url_as_utub_creator(
         # Ensure a Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
-                    Url_Tags.tag_id == tag_that_exists.id,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
+                    Utub_Url_Tags.tag_id == tag_that_exists.id,
                 ).all()
             )
             == 1
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
 
 
 def test_add_existing_tag_to_valid_url_as_utub_member(
@@ -429,16 +429,16 @@ def test_add_existing_tag_to_valid_url_as_utub_member(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -477,17 +477,17 @@ def test_add_existing_tag_to_valid_url_as_utub_member(
         # Ensure a Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
-                    Url_Tags.tag_id == tag_that_exists.id,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
+                    Utub_Url_Tags.tag_id == tag_that_exists.id,
                 ).all()
             )
             == 1
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
 
 
 def test_add_duplicate_tag_to_valid_url_as_utub_creator(
@@ -537,24 +537,24 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
         # Ensure tag is already on this URL and pull that tag object
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             > 0
         )
 
         num_of_tag_associations_with_url_in_utub = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
-        tag_on_url_in_utub_association = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_creator_of,
-            Url_Tags.url_id == url_id_to_add_tag_to,
+        tag_on_url_in_utub_association = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.url_id == url_id_to_add_tag_to,
         ).first()
 
         tag_on_url_in_utub = tag_on_url_in_utub_association.tag_item
@@ -572,7 +572,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
         tag_to_add = tag_on_url_in_utub.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -603,9 +603,9 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
 
         # Ensure no new tags exist on this URL
         assert num_of_tag_associations_with_url_in_utub == len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
@@ -621,7 +621,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_duplicate_tag_to_valid_url_as_utub_member(
@@ -674,24 +674,24 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
         # Ensure tag is already on this URL and pull that tag object
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             > 0
         )
 
         num_of_tag_associations_with_url_in_utub = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_member_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
-        tag_on_url_in_utub_association = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_member_of,
-            Url_Tags.url_id == url_id_to_add_tag_to,
+        tag_on_url_in_utub_association = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+            Utub_Url_Tags.url_id == url_id_to_add_tag_to,
         ).first()
 
         tag_on_url_in_utub = tag_on_url_in_utub_association.tag_item
@@ -709,7 +709,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
         tag_to_add = tag_on_url_in_utub.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -740,9 +740,9 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
 
         # Ensure no new tags exist on this URL
         assert num_of_tag_associations_with_url_in_utub == len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_member_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
@@ -758,7 +758,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_nonexistent_url_as_utub_creator(
@@ -797,22 +797,22 @@ def test_add_tag_to_nonexistent_url_as_utub_creator(
         # Ensure no URL-Tag associations exist for this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of
                 ).all()
             )
             == 0
         )
 
         num_of_tag_associations_with_url_in_utub = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -841,8 +841,8 @@ def test_add_tag_to_nonexistent_url_as_utub_creator(
         # Ensure no URL-Tag associations exist for this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of
                 ).all()
             )
             == 0
@@ -850,14 +850,14 @@ def test_add_tag_to_nonexistent_url_as_utub_creator(
 
         # Ensure no new tags exist on this URL
         assert num_of_tag_associations_with_url_in_utub == len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_nonexistent_url_as_utub_member(
@@ -899,22 +899,22 @@ def test_add_tag_to_nonexistent_url_as_utub_member(
         # Ensure no URL-Tag associations exist for this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of
                 ).all()
             )
             == 0
         )
 
         num_of_tag_associations_with_url_in_utub = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_member_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -943,8 +943,8 @@ def test_add_tag_to_nonexistent_url_as_utub_member(
         # Ensure no URL-Tag associations exist for this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of
                 ).all()
             )
             == 0
@@ -952,14 +952,14 @@ def test_add_tag_to_nonexistent_url_as_utub_member(
 
         # Ensure no new tags exist on this URL
         assert num_of_tag_associations_with_url_in_utub == len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == utub_id_user_is_member_of,
-                Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.url_id == url_id_to_add_tag_to,
             ).all()
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_in_nonexistent_utub(
@@ -1005,7 +1005,7 @@ def test_add_tag_to_url_in_nonexistent_utub(
         url_id_to_add_tag_to = url_to_add_to.id
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1036,7 +1036,7 @@ def test_add_tag_to_url_in_nonexistent_utub(
         assert len(Utubs.query.all()) == num_of_utubs_in_db
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_in_utub_user_is_not_member_of(
@@ -1103,16 +1103,16 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
         # Ensure no tags on this URL already
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_that_user_not_member_of,
-                    Url_Tags.url_id == url_id_for_url_in_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_that_user_not_member_of,
+                    Utub_Url_Tags.url_id == url_id_for_url_in_utub,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1154,9 +1154,9 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
         # Ensure no tags on this URL still
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_that_user_not_member_of,
-                    Url_Tags.url_id == url_id_for_url_in_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_that_user_not_member_of,
+                    Utub_Url_Tags.url_id == url_id_for_url_in_utub,
                 ).all()
             )
             == 0
@@ -1174,7 +1174,7 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_not_in_utub(
@@ -1237,16 +1237,16 @@ def test_add_tag_to_url_not_in_utub(
         # Ensure no association with Tags, this URL, and this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_for_url_not_in_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_for_url_not_in_utub,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1290,16 +1290,16 @@ def test_add_tag_to_url_not_in_utub(
         # Ensure no association with Tags, this URL, and this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_for_url_not_in_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_for_url_not_in_utub,
                 ).all()
             )
             == 0
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_with_five_tags_as_utub_creator(
@@ -1349,7 +1349,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         # Add five tags to this URL
         for idx in range(5):
             previously_added_tag_to_add = all_tags[idx]
-            new_url_tag_association = Url_Tags()
+            new_url_tag_association = Utub_Url_Tags()
             new_url_tag_association.tag_id = previously_added_tag_to_add.id
             new_url_tag_association.url_id = url_id_in_this_utub
             new_url_tag_association.utub_id = utub_id_user_is_creator_of
@@ -1361,9 +1361,9 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         # Ensure 5 tags on this URL
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
                 ).all()
             )
             == 5
@@ -1386,17 +1386,17 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         # Ensure this tag isn't on the URL in this UTub already
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
-                    Url_Tags.tag_id == new_tag_id_to_add,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
+                    Utub_Url_Tags.tag_id == new_tag_id_to_add,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1427,10 +1427,10 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         # Ensure this tag isn't on the URL in this UTub already
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
-                    Url_Tags.tag_id == new_tag_id_to_add,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
+                    Utub_Url_Tags.tag_id == new_tag_id_to_add,
                 ).all()
             )
             == 0
@@ -1439,9 +1439,9 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         # Ensure 5 tags on this URL
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
                 ).all()
             )
             == 5
@@ -1458,7 +1458,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_with_five_tags_as_utub_member(
@@ -1508,7 +1508,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         # Add five tags to this URL
         for idx in range(5):
             previously_added_tag_to_add = all_tags[idx]
-            new_url_tag_association = Url_Tags()
+            new_url_tag_association = Utub_Url_Tags()
             new_url_tag_association.tag_id = previously_added_tag_to_add.id
             new_url_tag_association.url_id = url_id_in_this_utub
             new_url_tag_association.utub_id = utub_id_user_is_member_of
@@ -1520,9 +1520,9 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         # Ensure 5 tags on this URL
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
                 ).all()
             )
             == 5
@@ -1545,17 +1545,17 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         # Ensure this tag isn't on the URL in this UTub already
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
-                    Url_Tags.tag_id == new_tag_id_to_add,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
+                    Utub_Url_Tags.tag_id == new_tag_id_to_add,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1586,10 +1586,10 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         # Ensure this tag isn't on the URL in this UTub already
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
-                    Url_Tags.tag_id == new_tag_id_to_add,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
+                    Utub_Url_Tags.tag_id == new_tag_id_to_add,
                 ).all()
             )
             == 0
@@ -1598,9 +1598,9 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         # Ensure 5 tags on this URL
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_in_this_utub,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_in_this_utub,
                 ).all()
             )
             == 5
@@ -1617,7 +1617,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
@@ -1676,16 +1676,16 @@ def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1731,16 +1731,16 @@ def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
@@ -1799,16 +1799,16 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
     # Add tag to this URL
     add_tag_form = {
@@ -1844,16 +1844,16 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
         # Ensure no Tag-URL association exists in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == 0
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_add_fresh_tag_to_url_updates_utub_last_updated(
@@ -1998,9 +1998,9 @@ def test_add_duplicate_tag_to_url_does_not_update_utub_last_updated(
         url_in_this_utub: Urls = url_utub_association.standalone_url
         url_id_to_add_tag_to = url_in_this_utub.id
 
-        tag_on_url_in_utub_association = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_creator_of,
-            Url_Tags.url_id == url_id_to_add_tag_to,
+        tag_on_url_in_utub_association = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.url_id == url_id_to_add_tag_to,
         ).first()
 
         tag_on_url_in_utub = tag_on_url_in_utub_association.tag_item

--- a/tests/integration/utubtags/test_remove_tag_from_url_route.py
+++ b/tests/integration/utubtags/test_remove_tag_from_url_route.py
@@ -4,7 +4,6 @@ import pytest
 
 from src import db
 from src.models.tags import Tags
-from src.models.urls import Urls
 from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -60,24 +59,11 @@ def test_remove_tag_from_url_as_utub_creator(
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove: str = tag_url_utub_association.tag_item.tag_string
-        url_id_to_remove_tag_from = tag_url_utub_association.url_id
-
-        # Ensure the Tag-URL-UTub association does exists any longer
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
+        url_id_to_remove_tag_from = tag_url_utub_association.utub_url_id
 
         # Get URL serialization for checking
         utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_creator_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
         associated_tags = utub_url_association.associated_tags
 
@@ -98,7 +84,7 @@ def test_remove_tag_from_url_as_utub_creator(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_creator_of,
-            url_id=url_id_to_remove_tag_from,
+            utub_url_id=url_id_to_remove_tag_from,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -135,7 +121,7 @@ def test_remove_tag_from_url_as_utub_creator(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -144,8 +130,7 @@ def test_remove_tag_from_url_as_utub_creator(
 
         # Grab URL-UTub association
         final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_creator_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
         assert sorted(final_utub_url_association.associated_tags) == sorted(
             remove_tag_response_json[TAGS_SUCCESS.URL_TAGS]
@@ -197,24 +182,12 @@ def test_remove_tag_from_url_as_utub_member(
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove: str = tag_url_utub_association.tag_item.tag_string
-        url_id_to_remove_tag_from = tag_url_utub_association.url_id
-
-        # Ensure the Tag-URL-UTub association does exists any longer
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
+        url_id_to_remove_tag_from = tag_url_utub_association.utub_url_id
 
         # Get URL serialization for checking
         url_utub_association: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
         associated_tags = url_utub_association.associated_tags
 
@@ -235,7 +208,7 @@ def test_remove_tag_from_url_as_utub_member(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_member_of,
-            url_id=url_id_to_remove_tag_from,
+            utub_url_id=url_id_to_remove_tag_from,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -272,7 +245,7 @@ def test_remove_tag_from_url_as_utub_member(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -280,9 +253,8 @@ def test_remove_tag_from_url_as_utub_member(
         )
 
         # Grab URL-UTub association
-        final_utub_url_association = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+        final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
         assert sorted(final_utub_url_association.associated_tags) == sorted(
             remove_tag_response_json[TAGS_SUCCESS.URL_TAGS]
@@ -334,24 +306,12 @@ def test_remove_tag_from_url_with_one_tag(
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove = tag_url_utub_association.tag_item.tag_string
-        url_id_to_remove_tag_from = tag_url_utub_association.url_id
-
-        # Ensure the Tag-URL-UTub association does exist
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
+        url_id_to_remove_tag_from = tag_url_utub_association.utub_url_id
 
         # Get URL serialization for checking
         url_utub_association: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.id == url_id_to_remove_tag_from,
             Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
         ).first()
 
         associated_tags = url_utub_association.associated_tags
@@ -373,7 +333,7 @@ def test_remove_tag_from_url_with_one_tag(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_member_of,
-            url_id=url_id_to_remove_tag_from,
+            utub_url_id=url_id_to_remove_tag_from,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -410,7 +370,7 @@ def test_remove_tag_from_url_with_one_tag(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -418,9 +378,8 @@ def test_remove_tag_from_url_with_one_tag(
         )
 
         # Grab URL-UTub association
-        final_utub_url_association = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+        final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
 
         assert sorted(final_utub_url_association.associated_tags) == sorted(
@@ -475,24 +434,12 @@ def test_remove_last_tag_from_utub(
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove = tag_url_utub_association.tag_item.tag_string
-        url_id_to_remove_tag_from = tag_url_utub_association.url_id
-
-        # Ensure the Tag-URL-UTub association does exist
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
+        url_id_to_remove_tag_from = tag_url_utub_association.utub_url_id
 
         # Get URL serialization for checking
         url_utub_association: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.id == url_id_to_remove_tag_from,
             Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
         ).first()
         associated_tags = url_utub_association.associated_tags
 
@@ -513,7 +460,7 @@ def test_remove_last_tag_from_utub(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_member_of,
-            url_id=url_id_to_remove_tag_from,
+            utub_url_id=url_id_to_remove_tag_from,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -550,7 +497,7 @@ def test_remove_last_tag_from_utub(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -569,8 +516,7 @@ def test_remove_last_tag_from_utub(
 
         # Grab URL-UTub association
         final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
 
         assert sorted(final_utub_url_association.associated_tags) == sorted(
@@ -608,6 +554,7 @@ def test_remove_tag_from_url_with_five_tags(
         TAGS_SUCCESS.TAG_STILL_IN_UTUB: Boolean for whether this tag still exists in this UTub
     }
     """
+    MAX_NUM_TAGS = 5
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
@@ -626,43 +573,32 @@ def test_remove_tag_from_url_with_five_tags(
             Utub_Urls.utub_id == utub_id_this_user_member_of,
             Utub_Urls.user_id != current_user.id,
         ).first()
-        url_id_to_remove_tag_from = url_in_this_utub.url_id
+        url_id_to_remove_tag_from = url_in_this_utub.id
 
         # Add five tags to this URL
-        for idx in range(5):
+        for idx in range(MAX_NUM_TAGS):
             previously_added_tag_to_add = all_tags[idx]
             new_url_tag_association = Utub_Url_Tags()
             new_url_tag_association.tag_id = previously_added_tag_to_add.id
-            new_url_tag_association.url_id = url_id_to_remove_tag_from
+            new_url_tag_association.utub_url_id = url_id_to_remove_tag_from
             new_url_tag_association.utub_id = utub_id_this_user_member_of
 
             db.session.add(new_url_tag_association)
 
         db.session.commit()
 
-        # Ensure 5 tags on this URL
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                ).all()
-            )
-            == 5
-        )
-
         # Get ID of a tag to remove from this URL
         tag_to_remove: Utub_Url_Tags = Utub_Url_Tags.query.filter(
             Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-            Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+            Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
         ).first()
         tag_string_to_remove: str = tag_to_remove.tag_item.tag_string
         tag_id_to_remove = tag_to_remove.tag_id
 
-        # Get URL serialization for checking
+        # Get initial URL serialization
         url_utub_association: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
         associated_tags = url_utub_association.associated_tags
 
@@ -683,7 +619,7 @@ def test_remove_tag_from_url_with_five_tags(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_member_of,
-            url_id=url_id_to_remove_tag_from,
+            utub_url_id=url_id_to_remove_tag_from,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -721,15 +657,14 @@ def test_remove_tag_from_url_with_five_tags(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
                 ).all()
             )
-            == 4
+            == MAX_NUM_TAGS - 1
         )
         # Grab URL-UTub association
         final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
         assert sorted(final_utub_url_association.associated_tags) == sorted(
             remove_tag_response_json[TAGS_SUCCESS.URL_TAGS]
@@ -752,6 +687,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_creator(
     THEN ensure that the server responds with a 400 HTTP status code, and that the Tag-URL-UTub association still does not exist,
         that the tag does not exist exists, and that the association between URL, UTub, and Tag is recorded properly
     """
+    NONEXISTENT_TAG_ID = 999
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
@@ -762,30 +698,11 @@ def test_remove_nonexistent_tag_from_url_as_utub_creator(
         utub_id_this_user_creator_of = utub_this_user_creator_of.id
         creator_of_utub_id = utub_this_user_creator_of.utub_creator
 
-        # Get a tag ID that does not exist
-        tag_id_to_remove = 0
-        all_tags: list[Tags] = Tags.query.all()
-        all_tag_ids = [tag.id for tag in all_tags]
-        while tag_id_to_remove in all_tag_ids:
-            tag_id_to_remove += 1
-
         # Get a valid URL within this UTub
         valid_url_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_this_user_creator_of
         ).first()
-        url_id_to_remove_tag_from = valid_url_in_utub.url_id
-
-        # Ensure the Tag-URL-UTub association does not exist
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 0
-        )
+        url_id_to_remove_tag_from = valid_url_in_utub.id
 
         # Get URL serialization for checking
         initial_url_serialization = valid_url_in_utub.serialized(
@@ -801,8 +718,8 @@ def test_remove_nonexistent_tag_from_url_as_utub_creator(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_creator_of,
-            url_id=url_id_to_remove_tag_from,
-            tag_id=tag_id_to_remove,
+            utub_url_id=url_id_to_remove_tag_from,
+            tag_id=NONEXISTENT_TAG_ID,
         ),
         data=add_tag_form,
     )
@@ -810,25 +727,19 @@ def test_remove_nonexistent_tag_from_url_as_utub_creator(
     assert remove_tag_response.status_code == 404
 
     with app.app_context():
-        # Ensure tag still exists
-        assert Tags.query.get(tag_id_to_remove) is None
-
-        # Ensure the Tag-URL-UTub association does not exist any longer
+        # Ensure the Tag-URL-UTub association does not exist
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 0
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.tag_id == NONEXISTENT_TAG_ID,
+            ).first()
+            is None
         )
 
         # Grab URL-UTub association
         final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_creator_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
 
         # Ensure final and initial serialization do match
@@ -850,6 +761,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
     THEN ensure that the server responds with a 400 HTTP status code, and that the Tag-URL-UTub association still does not exist,
         that the tag does not exist exists, and that the association between URL, UTub, and Tag is recorded properly
     """
+    NONEXISTENT_TAG_ID = 999
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
@@ -860,30 +772,11 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
         utub_id_this_user_member_of = utub_this_user_member_of.id
         creator_of_utub_id = utub_this_user_member_of.utub_creator
 
-        # Get a tag ID that does not exist
-        tag_id_to_remove = 0
-        all_tags: list[Tags] = Tags.query.all()
-        all_tag_ids = [tag.id for tag in all_tags]
-        while tag_id_to_remove in all_tag_ids:
-            tag_id_to_remove += 1
-
         # Get a valid URL within this UTub
         valid_url_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_this_user_member_of
         ).first()
-        url_id_to_remove_tag_from = valid_url_in_utub.url_id
-
-        # Ensure the Tag-URL-UTub association does not exist
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 0
-        )
+        url_id_to_remove_tag_from = valid_url_in_utub.id
 
         # Get URL serialization for checking
         initial_url_serialization = valid_url_in_utub.serialized(
@@ -902,8 +795,8 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_member_of,
-            url_id=url_id_to_remove_tag_from,
-            tag_id=tag_id_to_remove,
+            utub_url_id=url_id_to_remove_tag_from,
+            tag_id=NONEXISTENT_TAG_ID,
         ),
         data=add_tag_form,
     )
@@ -911,16 +804,13 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
     assert remove_tag_response.status_code == 404
 
     with app.app_context():
-        # Ensure tag still exists
-        assert Tags.query.get(tag_id_to_remove) is None
-
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == NONEXISTENT_TAG_ID,
                 ).all()
             )
             == 0
@@ -928,8 +818,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
 
         # Grab URL-UTub association
         final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_this_user_member_of,
-            Utub_Urls.url_id == url_id_to_remove_tag_from,
+            Utub_Urls.id == url_id_to_remove_tag_from,
         ).first()
 
         # Ensure final and initial serialization do match
@@ -974,47 +863,27 @@ def test_remove_tag_from_url_but_not_member_of_utub(
         creator_of_utub_id = utub_user_association_not_member_of.to_utub.utub_creator
 
         # Grab a tag from db
-        tag_to_add: Tags = Tags.query.first()
-        tag_id_to_add = tag_to_add.id
+        tag_to_remove: Tags = Tags.query.first()
+        tag_id_to_remove = tag_to_remove.id
 
         # Find a URL in the database associated with this UTub
         url_utub_association: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_not_member_of
         ).first()
-        url_id_in_utub = url_utub_association.url_id
-
-        # Ensure tag does not exist on URL in UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_not_member_of
-                ).all()
-            )
-            == 0
-        )
+        url_id_in_utub = url_utub_association.id
 
         # Add tag to URL in UTub
         new_tag_url_association = Utub_Url_Tags()
         new_tag_url_association.utub_id = utub_id_not_member_of
-        new_tag_url_association.url_id = url_id_in_utub
-        new_tag_url_association.tag_id = tag_id_to_add
+        new_tag_url_association.utub_url_id = url_id_in_utub
+        new_tag_url_association.tag_id = tag_id_to_remove
 
         db.session.add(new_tag_url_association)
         db.session.commit()
 
-        # Ensure tag exists on URL in UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_not_member_of
-                ).all()
-            )
-            == 1
-        )
-
         initial_url_utub_association: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_not_member_of,
-            Utub_Urls.url_id == url_id_in_utub,
+            Utub_Urls.id == url_id_in_utub,
         ).first()
 
         initial_url_utub_serialization = initial_url_utub_association.serialized(
@@ -1030,8 +899,8 @@ def test_remove_tag_from_url_but_not_member_of_utub(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_not_member_of,
-            url_id=url_id_in_utub,
-            tag_id=tag_id_to_add,
+            utub_url_id=url_id_in_utub,
+            tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
     )
@@ -1047,21 +916,21 @@ def test_remove_tag_from_url_but_not_member_of_utub(
 
     with app.app_context():
         # Ensure tag exists
-        assert Tags.query.get(tag_id_to_add) is not None
+        assert Tags.query.get(tag_id_to_remove) is not None
 
         # Ensure tag exists on URL in UTub
         assert (
             len(
                 Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_not_member_of
+                    Utub_Url_Tags.utub_id == utub_id_not_member_of,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
         )
 
         final_url_utub_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_id_not_member_of,
-            Utub_Urls.url_id == url_id_in_utub,
+            Utub_Urls.id == url_id_in_utub,
         ).first()
 
         assert initial_url_utub_serialization == final_url_utub_association.serialized(
@@ -1082,60 +951,31 @@ def test_remove_tag_from_url_from_nonexistent_utub(
     THEN ensure that the server responds with a 404 HTTP status code, that the tag still exists,
         and that all associations between the URL and tags are still valid
     """
+    NONEXISTENT_UTUB_ID = 999
 
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
-        # Find UTub this user not a member of
-        nonexistent_utub_id = 0
-        all_utub_ids: list[int] = [utub.id for utub in Utubs.query.all()]
-        while nonexistent_utub_id in all_utub_ids:
-            nonexistent_utub_id += 1
-
         # Grab a valid URL and tag association
         valid_url_tag_association: Utub_Url_Tags = Utub_Url_Tags.query.first()
 
         tag_id_to_remove = valid_url_tag_association.tag_id
-        url_id_to_remove = valid_url_tag_association.url_id
+        url_id_to_remove = valid_url_tag_association.utub_url_id
         existing_utub_id = valid_url_tag_association.utub_id
         creator_of_existing_utub_id = (
             valid_url_tag_association.utub_containing_this_tag.utub_creator
         )
 
-        # Ensure URL-Tag association exists inside a valid UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
-
         num_of_url_tag_associations = len(
             Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.url_id == url_id_to_remove,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
                 Utub_Url_Tags.tag_id == tag_id_to_remove,
             ).all()
         )
 
-        # Ensure URL-Tag association does not exist in nonexistent UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == nonexistent_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 0
-        )
-
         # Grab initial UTub-URL serialization
         initial_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == existing_utub_id, Utub_Urls.url_id == url_id_to_remove
+            Utub_Urls.utub_id == existing_utub_id, Utub_Urls.id == url_id_to_remove
         ).first()
         initial_utub_url_serialization = initial_utub_url_association.serialized(
             current_user.id, creator_of_existing_utub_id
@@ -1152,8 +992,8 @@ def test_remove_tag_from_url_from_nonexistent_utub(
     remove_tag_response = client.delete(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
-            utub_id=nonexistent_utub_id,
-            url_id=url_id_to_remove,
+            utub_id=NONEXISTENT_UTUB_ID,
+            utub_url_id=url_id_to_remove,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -1167,7 +1007,7 @@ def test_remove_tag_from_url_from_nonexistent_utub(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -1178,9 +1018,7 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         assert Tags.query.get(tag_id_to_remove) is not None
 
         # Ensure URL-UTub association still exists
-        final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == existing_utub_id, Utub_Urls.url_id == url_id_to_remove
-        ).first()
+        final_utub_url_association: Utub_Urls = Utub_Urls.query.get(url_id_to_remove)
         final_utub_url_serialization = final_utub_url_association.serialized(
             current_user.id, creator_of_existing_utub_id
         )
@@ -1190,7 +1028,7 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         # Ensure URL tag associations are still same count
         assert num_of_url_tag_associations == len(
             Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.url_id == url_id_to_remove,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
                 Utub_Url_Tags.tag_id == tag_id_to_remove,
             ).all()
         )
@@ -1211,46 +1049,17 @@ def test_remove_tag_from_nonexistent_url_utub(
     THEN ensure that the server responds with a 404 HTTP status code, that the tag still exists, and the UTub
         still has proper associations with the valid tag
     """
+    NONEXISTENT_URL_ID = 999
 
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
-        # Find URL that does not exist
-        nonexistent_url_id = 0
-        all_url_ids = [utub.id for utub in Urls.query.all()]
-        while nonexistent_url_id in all_url_ids:
-            nonexistent_url_id += 1
-
         # Grab a valid URL and tag association
         valid_url_tag_association: Utub_Url_Tags = Utub_Url_Tags.query.first()
 
         tag_id_to_remove = valid_url_tag_association.tag_id
-        url_id_to_remove = valid_url_tag_association.url_id
+        url_id_to_remove = valid_url_tag_association.utub_url_id
         existing_utub_id = valid_url_tag_association.utub_id
-
-        # Ensure URL-Tag association exists inside UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
-
-        # Ensure nonexistent URL does not have URL-Tag association in valid UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == nonexistent_url_id,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 0
-        )
 
         # Initial number of Url-Tag associations
         initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
@@ -1264,7 +1073,7 @@ def test_remove_tag_from_nonexistent_url_utub(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=existing_utub_id,
-            url_id=nonexistent_url_id,
+            utub_url_id=NONEXISTENT_URL_ID,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -1278,7 +1087,7 @@ def test_remove_tag_from_nonexistent_url_utub(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -1290,14 +1099,12 @@ def test_remove_tag_from_nonexistent_url_utub(
 
         # Ensure nonexistent URL does not have URL-Tag association in valid UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == nonexistent_url_id,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 0
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == existing_utub_id,
+                Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_ID,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).first()
+            is None
         )
 
         assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
@@ -1330,20 +1137,8 @@ def test_remove_tag_with_no_csrf_token(
         valid_url_tag_association: Utub_Url_Tags = Utub_Url_Tags.query.first()
 
         tag_id_to_remove = valid_url_tag_association.tag_id
-        url_id_to_remove = valid_url_tag_association.url_id
+        url_id_to_remove = valid_url_tag_association.utub_url_id
         existing_utub_id = valid_url_tag_association.utub_id
-
-        # Ensure URL-Tag association exists inside UTub
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
-            == 1
-        )
 
         # Initial number of Url-Tag associations
         initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
@@ -1355,7 +1150,7 @@ def test_remove_tag_with_no_csrf_token(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=existing_utub_id,
-            url_id=url_id_to_remove,
+            utub_url_id=url_id_to_remove,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -1371,7 +1166,7 @@ def test_remove_tag_with_no_csrf_token(
             len(
                 Utub_Url_Tags.query.filter(
                     Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.utub_url_id == url_id_to_remove,
                     Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
@@ -1409,7 +1204,7 @@ def test_remove_tag_from_url_updates_utub_last_updated(
             Utub_Url_Tags.utub_id == utub_id_this_user_creator_of
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
-        url_id_to_remove_tag_from = tag_url_utub_association.url_id
+        url_id_to_remove_tag_from = tag_url_utub_association.utub_url_id
 
     # Remove tag from this URL
     add_tag_form = {
@@ -1420,7 +1215,7 @@ def test_remove_tag_from_url_updates_utub_last_updated(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_creator_of,
-            url_id=url_id_to_remove_tag_from,
+            utub_url_id=url_id_to_remove_tag_from,
             tag_id=tag_id_to_remove,
         ),
         data=add_tag_form,
@@ -1446,6 +1241,7 @@ def test_remove_nonexistent_tag_from_url_does_not_update_utub_last_updated(
     THEN ensure that the server responds with a 400 HTTP status code, and that the UTub's last updated field
         is not updated
     """
+    NONEXISTENT_TAG_ID = 999
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
@@ -1456,18 +1252,11 @@ def test_remove_nonexistent_tag_from_url_does_not_update_utub_last_updated(
         initial_last_updated = utub_this_user_creator_of.last_updated
         utub_id_this_user_creator_of = utub_this_user_creator_of.id
 
-        # Get a tag ID that does not exist
-        tag_id_to_remove = 0
-        all_tags: list[Tags] = Tags.query.all()
-        all_tag_ids = [tag.id for tag in all_tags]
-        while tag_id_to_remove in all_tag_ids:
-            tag_id_to_remove += 1
-
         # Get a valid URL within this UTub
         valid_url_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_id_this_user_creator_of
         ).first()
-        url_id_to_remove_tag_from = valid_url_in_utub.url_id
+        url_id_to_remove_tag_from = valid_url_in_utub.id
 
     # Remove tag from this URL
     add_tag_form = {
@@ -1478,8 +1267,8 @@ def test_remove_nonexistent_tag_from_url_does_not_update_utub_last_updated(
         url_for(
             ROUTES.TAGS.REMOVE_TAG,
             utub_id=utub_id_this_user_creator_of,
-            url_id=url_id_to_remove_tag_from,
-            tag_id=tag_id_to_remove,
+            utub_url_id=url_id_to_remove_tag_from,
+            tag_id=NONEXISTENT_TAG_ID,
         ),
         data=add_tag_form,
     )

--- a/tests/integration/utubtags/test_remove_tag_from_url_route.py
+++ b/tests/integration/utubtags/test_remove_tag_from_url_route.py
@@ -5,7 +5,7 @@ import pytest
 from src import db
 from src.models.tags import Tags
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
@@ -55,8 +55,8 @@ def test_remove_tag_from_url_as_utub_creator(
         utub_id_this_user_creator_of = utub_this_user_creator_of.id
 
         # Get a URL and tag association within this UTub
-        tag_url_utub_association: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_this_user_creator_of
+        tag_url_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_creator_of
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove: str = tag_url_utub_association.tag_item.tag_string
@@ -65,10 +65,10 @@ def test_remove_tag_from_url_as_utub_creator(
         # Ensure the Tag-URL-UTub association does exists any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -82,10 +82,10 @@ def test_remove_tag_from_url_as_utub_creator(
         associated_tags = utub_url_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Url_Tags.query.all())
+        initial_url_tag_count = len(Utub_Url_Tags.query.all())
 
         # Get tag count for this UTub and tag
-        tag_count = Url_Tags.query.filter_by(
+        tag_count = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_this_user_creator_of, tag_id=tag_id_to_remove
         ).count()
 
@@ -133,10 +133,10 @@ def test_remove_tag_from_url_as_utub_creator(
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -152,7 +152,7 @@ def test_remove_tag_from_url_as_utub_creator(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
 
 
 def test_remove_tag_from_url_as_utub_member(
@@ -192,8 +192,8 @@ def test_remove_tag_from_url_as_utub_member(
         utub_id_this_user_member_of = utub_this_user_member_of.id
 
         # Get a URL and tag association within this UTub
-        tag_url_utub_association: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_this_user_member_of
+        tag_url_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove: str = tag_url_utub_association.tag_item.tag_string
@@ -202,10 +202,10 @@ def test_remove_tag_from_url_as_utub_member(
         # Ensure the Tag-URL-UTub association does exists any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -219,10 +219,10 @@ def test_remove_tag_from_url_as_utub_member(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Url_Tags.query.all())
+        initial_url_tag_count = len(Utub_Url_Tags.query.all())
 
         # Get tag count for this UTub and tag
-        tag_count = Url_Tags.query.filter_by(
+        tag_count = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
         ).count()
 
@@ -270,10 +270,10 @@ def test_remove_tag_from_url_as_utub_member(
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -289,7 +289,7 @@ def test_remove_tag_from_url_as_utub_member(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
 
 
 def test_remove_tag_from_url_with_one_tag(
@@ -329,8 +329,8 @@ def test_remove_tag_from_url_with_one_tag(
         utub_id_this_user_member_of = utub_this_user_member_of.id
 
         # Get a URL and tag association within this UTub
-        tag_url_utub_association: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_this_user_member_of
+        tag_url_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove = tag_url_utub_association.tag_item.tag_string
@@ -339,10 +339,10 @@ def test_remove_tag_from_url_with_one_tag(
         # Ensure the Tag-URL-UTub association does exist
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -357,10 +357,10 @@ def test_remove_tag_from_url_with_one_tag(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Url_Tags.query.all())
+        initial_url_tag_count = len(Utub_Url_Tags.query.all())
 
         # Get tag count for this UTub and tag
-        tag_count = Url_Tags.query.filter_by(
+        tag_count = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
         ).count()
 
@@ -408,10 +408,10 @@ def test_remove_tag_from_url_with_one_tag(
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -428,7 +428,7 @@ def test_remove_tag_from_url_with_one_tag(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
 
 
 def test_remove_last_tag_from_utub(
@@ -470,8 +470,8 @@ def test_remove_last_tag_from_utub(
         utub_id_this_user_member_of = utub_this_user_member_of.id
 
         # Get a URL and tag association within this UTub
-        tag_url_utub_association: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_this_user_member_of
+        tag_url_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         tag_string_to_remove = tag_url_utub_association.tag_item.tag_string
@@ -480,10 +480,10 @@ def test_remove_last_tag_from_utub(
         # Ensure the Tag-URL-UTub association does exist
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -497,10 +497,10 @@ def test_remove_last_tag_from_utub(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Url_Tags.query.all())
+        initial_url_tag_count = len(Utub_Url_Tags.query.all())
 
         # Get tag count for this UTub and tag
-        tag_count = Url_Tags.query.filter_by(
+        tag_count = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
         ).count()
 
@@ -548,10 +548,10 @@ def test_remove_last_tag_from_utub(
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -560,8 +560,8 @@ def test_remove_last_tag_from_utub(
         # Ensure no tags remain in the UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of
                 ).all()
             )
             == 0
@@ -578,7 +578,7 @@ def test_remove_last_tag_from_utub(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
 
 
 def test_remove_tag_from_url_with_five_tags(
@@ -631,7 +631,7 @@ def test_remove_tag_from_url_with_five_tags(
         # Add five tags to this URL
         for idx in range(5):
             previously_added_tag_to_add = all_tags[idx]
-            new_url_tag_association = Url_Tags()
+            new_url_tag_association = Utub_Url_Tags()
             new_url_tag_association.tag_id = previously_added_tag_to_add.id
             new_url_tag_association.url_id = url_id_to_remove_tag_from
             new_url_tag_association.utub_id = utub_id_this_user_member_of
@@ -643,18 +643,18 @@ def test_remove_tag_from_url_with_five_tags(
         # Ensure 5 tags on this URL
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
                 ).all()
             )
             == 5
         )
 
         # Get ID of a tag to remove from this URL
-        tag_to_remove: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_this_user_member_of,
-            Url_Tags.url_id == url_id_to_remove_tag_from,
+        tag_to_remove: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+            Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
         ).first()
         tag_string_to_remove: str = tag_to_remove.tag_item.tag_string
         tag_id_to_remove = tag_to_remove.tag_id
@@ -667,10 +667,10 @@ def test_remove_tag_from_url_with_five_tags(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Url_Tags.query.all())
+        initial_url_tag_count = len(Utub_Url_Tags.query.all())
 
         # Get tag count for this UTub and tag
-        tag_count: int = Url_Tags.query.filter_by(
+        tag_count: int = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
         ).count()
 
@@ -719,9 +719,9 @@ def test_remove_tag_from_url_with_five_tags(
         # Ensure 4 tags on this URL
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
                 ).all()
             )
             == 4
@@ -736,7 +736,7 @@ def test_remove_tag_from_url_with_five_tags(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
 
 
 def test_remove_nonexistent_tag_from_url_as_utub_creator(
@@ -778,10 +778,10 @@ def test_remove_nonexistent_tag_from_url_as_utub_creator(
         # Ensure the Tag-URL-UTub association does not exist
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -816,10 +816,10 @@ def test_remove_nonexistent_tag_from_url_as_utub_creator(
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -876,10 +876,10 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
         # Ensure the Tag-URL-UTub association does not exist
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -891,7 +891,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
         )
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Url_Tags.query.all())
+        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
 
     # Remove tag from this URL
     add_tag_form = {
@@ -917,10 +917,10 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Url_Tags.url_id == url_id_to_remove_tag_from,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_remove_tag_from,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -937,7 +937,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
             current_user.id, creator_of_utub_id
         )
 
-        assert len(Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
 
 
 def test_remove_tag_from_url_but_not_member_of_utub(
@@ -985,12 +985,16 @@ def test_remove_tag_from_url_but_not_member_of_utub(
 
         # Ensure tag does not exist on URL in UTub
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_id_not_member_of).all())
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_not_member_of
+                ).all()
+            )
             == 0
         )
 
         # Add tag to URL in UTub
-        new_tag_url_association = Url_Tags()
+        new_tag_url_association = Utub_Url_Tags()
         new_tag_url_association.utub_id = utub_id_not_member_of
         new_tag_url_association.url_id = url_id_in_utub
         new_tag_url_association.tag_id = tag_id_to_add
@@ -1000,7 +1004,11 @@ def test_remove_tag_from_url_but_not_member_of_utub(
 
         # Ensure tag exists on URL in UTub
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_id_not_member_of).all())
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_not_member_of
+                ).all()
+            )
             == 1
         )
 
@@ -1043,7 +1051,11 @@ def test_remove_tag_from_url_but_not_member_of_utub(
 
         # Ensure tag exists on URL in UTub
         assert (
-            len(Url_Tags.query.filter(Url_Tags.utub_id == utub_id_not_member_of).all())
+            len(
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_not_member_of
+                ).all()
+            )
             == 1
         )
 
@@ -1081,7 +1093,7 @@ def test_remove_tag_from_url_from_nonexistent_utub(
             nonexistent_utub_id += 1
 
         # Grab a valid URL and tag association
-        valid_url_tag_association: Url_Tags = Url_Tags.query.first()
+        valid_url_tag_association: Utub_Url_Tags = Utub_Url_Tags.query.first()
 
         tag_id_to_remove = valid_url_tag_association.tag_id
         url_id_to_remove = valid_url_tag_association.url_id
@@ -1093,28 +1105,29 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         # Ensure URL-Tag association exists inside a valid UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
         )
 
         num_of_url_tag_associations = len(
-            Url_Tags.query.filter(
-                Url_Tags.url_id == url_id_to_remove, Url_Tags.tag_id == tag_id_to_remove
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.url_id == url_id_to_remove,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
             ).all()
         )
 
         # Ensure URL-Tag association does not exist in nonexistent UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == nonexistent_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == nonexistent_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
@@ -1129,7 +1142,7 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         )
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Url_Tags.query.all())
+        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
 
     # Remove tag from this URL
     add_tag_form = {
@@ -1152,10 +1165,10 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         # Ensure the valid Tag-URL-UTub association still exists
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -1176,12 +1189,13 @@ def test_remove_tag_from_url_from_nonexistent_utub(
 
         # Ensure URL tag associations are still same count
         assert num_of_url_tag_associations == len(
-            Url_Tags.query.filter(
-                Url_Tags.url_id == url_id_to_remove, Url_Tags.tag_id == tag_id_to_remove
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.url_id == url_id_to_remove,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
             ).all()
         )
 
-        assert len(Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
 
 
 def test_remove_tag_from_nonexistent_url_utub(
@@ -1208,7 +1222,7 @@ def test_remove_tag_from_nonexistent_url_utub(
             nonexistent_url_id += 1
 
         # Grab a valid URL and tag association
-        valid_url_tag_association: Url_Tags = Url_Tags.query.first()
+        valid_url_tag_association: Utub_Url_Tags = Utub_Url_Tags.query.first()
 
         tag_id_to_remove = valid_url_tag_association.tag_id
         url_id_to_remove = valid_url_tag_association.url_id
@@ -1217,10 +1231,10 @@ def test_remove_tag_from_nonexistent_url_utub(
         # Ensure URL-Tag association exists inside UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -1229,17 +1243,17 @@ def test_remove_tag_from_nonexistent_url_utub(
         # Ensure nonexistent URL does not have URL-Tag association in valid UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == nonexistent_url_id,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == nonexistent_url_id,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
         )
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Url_Tags.query.all())
+        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
 
     # Remove tag from this URL
     add_tag_form = {
@@ -1262,10 +1276,10 @@ def test_remove_tag_from_nonexistent_url_utub(
         # Ensure the valid Tag-URL-UTub association still exists
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
@@ -1277,16 +1291,16 @@ def test_remove_tag_from_nonexistent_url_utub(
         # Ensure nonexistent URL does not have URL-Tag association in valid UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == nonexistent_url_id,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == nonexistent_url_id,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 0
         )
 
-        assert len(Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
 
 
 def test_remove_tag_with_no_csrf_token(
@@ -1313,7 +1327,7 @@ def test_remove_tag_with_no_csrf_token(
 
     with app.app_context():
         # Grab a valid URL and tag association
-        valid_url_tag_association: Url_Tags = Url_Tags.query.first()
+        valid_url_tag_association: Utub_Url_Tags = Utub_Url_Tags.query.first()
 
         tag_id_to_remove = valid_url_tag_association.tag_id
         url_id_to_remove = valid_url_tag_association.url_id
@@ -1322,17 +1336,17 @@ def test_remove_tag_with_no_csrf_token(
         # Ensure URL-Tag association exists inside UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
         )
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Url_Tags.query.all())
+        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
 
     # Remove tag from this URL
     add_tag_form = {}
@@ -1355,16 +1369,16 @@ def test_remove_tag_with_no_csrf_token(
         # Ensure the valid Tag-URL-UTub association still exists
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == existing_utub_id,
-                    Url_Tags.url_id == url_id_to_remove,
-                    Url_Tags.tag_id == tag_id_to_remove,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == existing_utub_id,
+                    Utub_Url_Tags.url_id == url_id_to_remove,
+                    Utub_Url_Tags.tag_id == tag_id_to_remove,
                 ).all()
             )
             == 1
         )
 
-        assert len(Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
 
 
 def test_remove_tag_from_url_updates_utub_last_updated(
@@ -1391,8 +1405,8 @@ def test_remove_tag_from_url_updates_utub_last_updated(
         utub_id_this_user_creator_of = utub_this_user_creator_of.id
 
         # Get a URL and tag association within this UTub
-        tag_url_utub_association: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_this_user_creator_of
+        tag_url_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_creator_of
         ).first()
         tag_id_to_remove = tag_url_utub_association.tag_id
         url_id_to_remove_tag_from = tag_url_utub_association.url_id

--- a/tests/integration/utubtags/test_update_tag_on_url_route.py
+++ b/tests/integration/utubtags/test_update_tag_on_url_route.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.models.tags import Tags
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
@@ -71,13 +71,13 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_creator(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
@@ -86,7 +86,7 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_creator(
         assert len(Tags.query.filter(Tags.tag_string == NEW_TAG).all()) == 0
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -154,17 +154,17 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_creator(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
-        count_of_prev_tag_in_utub = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_creator_of,
-            Url_Tags.tag_id == curr_tag_id_on_url,
+        count_of_prev_tag_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.tag_id == curr_tag_id_on_url,
         ).count()
         assert (
             modify_tag_response_json[TAGS_SUCCESS.PREVIOUS_TAG][
@@ -175,7 +175,7 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_creator(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure UTub is updated
         current_utub: Utubs = Utubs.query.get(utub_id_user_is_creator_of)
@@ -245,13 +245,13 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_member(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
@@ -260,7 +260,7 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_member(
         assert len(Tags.query.filter(Tags.tag_string == NEW_TAG).all()) == 0
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -329,17 +329,17 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_member(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
-        count_of_prev_tag_in_utub = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_member_of,
-            Url_Tags.tag_id == curr_tag_id_on_url,
+        count_of_prev_tag_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+            Utub_Url_Tags.tag_id == curr_tag_id_on_url,
         ).count()
         assert (
             modify_tag_response_json[TAGS_SUCCESS.PREVIOUS_TAG][
@@ -350,7 +350,7 @@ def test_modify_tag_with_fresh_tag_on_valid_url_as_utub_member(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_modify_tag_with_other_tag_on_valid_url_as_utub_creator(
@@ -406,13 +406,13 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_creator(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
@@ -426,7 +426,7 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_creator(
         # Ensure this tag does not have an association with this URL on this UTub
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_creator_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=tag_to_replace_with.id,
@@ -436,7 +436,7 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_creator(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -493,17 +493,17 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_creator(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
-        count_of_prev_tag_in_utub = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_creator_of,
-            Url_Tags.tag_id == curr_tag_id_on_url,
+        count_of_prev_tag_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.tag_id == curr_tag_id_on_url,
         ).count()
         assert (
             modify_tag_response_json[TAGS_SUCCESS.PREVIOUS_TAG][
@@ -514,7 +514,7 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_creator(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_modify_tag_with_other_tag_on_valid_url_as_utub_member(
@@ -581,13 +581,13 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_member(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
@@ -600,7 +600,7 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_member(
         # Ensure this new tag does not have an association with this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_member_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=tag_from_database.id,
@@ -610,7 +610,7 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_member(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -668,16 +668,16 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_member(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
-        count_of_prev_tag_in_utub = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_member_of,
-            Url_Tags.tag_id == curr_tag_id_on_url,
+        count_of_prev_tag_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+            Utub_Url_Tags.tag_id == curr_tag_id_on_url,
         ).count()
         assert (
             modify_tag_response_json[TAGS_SUCCESS.PREVIOUS_TAG][
@@ -688,7 +688,7 @@ def test_modify_tag_with_other_tag_on_valid_url_as_utub_member(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_modify_tag_with_same_tag_on_valid_url_as_utub_creator(
@@ -733,20 +733,20 @@ def test_modify_tag_with_same_tag_on_valid_url_as_utub_creator(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
         ).first()
         tag_string_on_url: str = tag_on_url.tag_item.tag_string
         curr_tag_id_on_url = tag_on_url.tag_id
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -781,21 +781,21 @@ def test_modify_tag_with_same_tag_on_valid_url_as_utub_creator(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure tag still exists attached to this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_creator_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=curr_tag_id_on_url,
@@ -861,20 +861,20 @@ def test_modify_tag_with_same_tag_on_valid_url_as_utub_member(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
         curr_tag_string = tag_on_url.tag_item.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -909,21 +909,21 @@ def test_modify_tag_with_same_tag_on_valid_url_as_utub_member(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure tag still exists attached to this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_member_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=curr_tag_id_on_url,
@@ -974,28 +974,28 @@ def test_modify_tag_with_tag_already_on_url_as_utub_creator(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_creator_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
 
         # Get tag to change to on this URL
-        tag_to_change_to_on_url: Url_Tags = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_user_is_creator_of,
-            Url_Tags.url_id == url_id_to_add_tag_to,
-            Url_Tags.tag_id != curr_tag_id_on_url,
+        tag_to_change_to_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.url_id == url_id_to_add_tag_to,
+            Utub_Url_Tags.tag_id != curr_tag_id_on_url,
         ).first()
 
         tag_to_change_to_string: str = tag_to_change_to_on_url.tag_item.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -1031,21 +1031,21 @@ def test_modify_tag_with_tag_already_on_url_as_utub_creator(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure tag still exists attached to this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_creator_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=curr_tag_id_on_url,
@@ -1104,20 +1104,20 @@ def test_modify_tag_on_another_utub_url(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_not_member_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_not_member_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
         curr_tag_string: str = tag_on_url.tag_item.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -1156,21 +1156,21 @@ def test_modify_tag_on_another_utub_url(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_not_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_not_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure tag still exists attached to this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_not_member_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=curr_tag_id_on_url,
@@ -1216,7 +1216,7 @@ def test_modify_tag_on_invalid_url_as_utub_creator(
         invalid_url_id = -1
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -1240,7 +1240,7 @@ def test_modify_tag_on_invalid_url_as_utub_creator(
         assert len(Tags.query.all()) == num_tags
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_modify_tag_on_url_in_nonexistent_utub(
@@ -1266,7 +1266,7 @@ def test_modify_tag_on_url_in_nonexistent_utub(
 
     with app.app_context():
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -1290,7 +1290,7 @@ def test_modify_tag_on_url_in_nonexistent_utub(
         assert len(Tags.query.all()) == num_tags
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
 
 def test_modify_tag_with_missing_tag_field(
@@ -1346,19 +1346,19 @@ def test_modify_tag_with_missing_tag_field(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -1398,21 +1398,21 @@ def test_modify_tag_with_missing_tag_field(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure tag still exists attached to this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_member_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=curr_tag_id_on_url,
@@ -1464,20 +1464,20 @@ def test_modify_tag_with_missing_csrf_token(
 
         # Find number of tags on this URL in this UTub
         num_of_tags_on_url = len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
             ).all()
         )
 
         # Get a tag on this URL
-        tag_on_url: Url_Tags = Url_Tags.query.filter_by(
+        tag_on_url: Utub_Url_Tags = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id_user_is_member_of, url_id=url_id_to_add_tag_to
         ).first()
         curr_tag_id_on_url = tag_on_url.tag_id
         tag_string_of_tag: str = tag_on_url.tag_item.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Url_Tags.query.all())
+        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
 
         # Get initial number of tags
         num_tags = len(Tags.query.all())
@@ -1506,21 +1506,21 @@ def test_modify_tag_with_missing_csrf_token(
         # Ensure number of Tag-URL association do not change on this URL in this UTub
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Url_Tags.url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                    Utub_Url_Tags.url_id == url_id_to_add_tag_to,
                 ).all()
             )
             == num_of_tags_on_url
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
 
         # Ensure tag still exists attached to this URL
         assert (
             len(
-                Url_Tags.query.filter_by(
+                Utub_Url_Tags.query.filter_by(
                     utub_id=utub_id_user_is_member_of,
                     url_id=url_id_to_add_tag_to,
                     tag_id=curr_tag_id_on_url,

--- a/tests/integration/utuburls/conftest.py
+++ b/tests/integration/utuburls/conftest.py
@@ -47,16 +47,15 @@ def add_first_user_to_second_utub_and_add_tags_remove_first_utub(
         urls_in_utub: list[Utub_Urls] = [utub_url for utub_url in second_utub.utub_urls]
 
         for url_in_utub in urls_in_utub:
-            url_id = url_in_utub.url_id
-            url_in_this_utub = url_in_utub.standalone_url
+            url_id = url_in_utub.id
 
             for tag in all_tags:
                 new_tag_url_utub_association = Utub_Url_Tags()
                 new_tag_url_utub_association.utub_containing_this_tag = second_utub
-                new_tag_url_utub_association.tagged_url = url_in_this_utub
+                new_tag_url_utub_association.tagged_url = url_in_utub
                 new_tag_url_utub_association.tag_item = tag
                 new_tag_url_utub_association.utub_id = second_utub.id
-                new_tag_url_utub_association.url_id = url_id
+                new_tag_url_utub_association.utub_url_id = url_id
                 new_tag_url_utub_association.tag_id = tag.id
                 second_utub.utub_url_tags.append(new_tag_url_utub_association)
 
@@ -81,14 +80,15 @@ def add_two_url_and_all_users_to_each_utub_no_tags(
     """
     with app.app_context():
         current_utubs = Utubs.query.all()
-        current_users = Users.query.all()
 
         # Add all missing users to this UTub
         for utub in current_utubs:
             # Get URL in current UTUb
-            current_utub_url = Utub_Urls.query.filter_by(utub_id=utub.id).first()
+            current_utub_url: Utub_Urls = Utub_Urls.query.filter(
+                Utub_Urls.utub_id == utub.id
+            ).first()
             current_utub_id = current_utub_url.url_id
-            new_url = Urls.query.filter_by(id=((current_utub_id % 3) + 1)).first()
+            new_url: Urls = Urls.query.filter_by(id=((current_utub_id % 3) + 1)).first()
 
             new_utub_url_user_association = Utub_Urls()
 
@@ -98,8 +98,6 @@ def add_two_url_and_all_users_to_each_utub_no_tags(
             new_utub_url_user_association.utub = utub
             new_utub_url_user_association.utub_id = utub.id
 
-            user_added = [user for user in current_users if user.id == new_url.id].pop()
-            new_utub_url_user_association.user_that_added_url = user_added
             new_utub_url_user_association.user_id = new_url.id
 
             new_utub_url_user_association.url_title = f"This is {new_url.url_string}"
@@ -128,11 +126,9 @@ def add_one_url_and_all_users_to_each_utub_with_all_tags(
         current_utubs = Utubs.query.all()
         current_tags = Tags.query.all()
 
-        # Add all missing users to this UTub
+        # Add all missing tags to this UTub
         for utub in current_utubs:
-            current_utub_url = [
-                utub_url.standalone_url for utub_url in utub.utub_urls
-            ].pop()
+            current_utub_url = [utub_url for utub_url in utub.utub_urls].pop()
 
             for tag in current_tags:
                 new_tag_url_utub_association = Utub_Url_Tags()
@@ -140,7 +136,7 @@ def add_one_url_and_all_users_to_each_utub_with_all_tags(
                 new_tag_url_utub_association.tagged_url = current_utub_url
                 new_tag_url_utub_association.tag_item = tag
                 new_tag_url_utub_association.utub_id = utub.id
-                new_tag_url_utub_association.url_id = current_utub_url.id
+                new_tag_url_utub_association.utub_url_id = current_utub_url.id
                 new_tag_url_utub_association.tag_id = tag.id
                 utub.utub_url_tags.append(new_tag_url_utub_association)
 

--- a/tests/integration/utuburls/conftest.py
+++ b/tests/integration/utuburls/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from src import db
 from src.models.tags import Tags
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -51,7 +51,7 @@ def add_first_user_to_second_utub_and_add_tags_remove_first_utub(
             url_in_this_utub = url_in_utub.standalone_url
 
             for tag in all_tags:
-                new_tag_url_utub_association = Url_Tags()
+                new_tag_url_utub_association = Utub_Url_Tags()
                 new_tag_url_utub_association.utub_containing_this_tag = second_utub
                 new_tag_url_utub_association.tagged_url = url_in_this_utub
                 new_tag_url_utub_association.tag_item = tag
@@ -135,7 +135,7 @@ def add_one_url_and_all_users_to_each_utub_with_all_tags(
             ].pop()
 
             for tag in current_tags:
-                new_tag_url_utub_association = Url_Tags()
+                new_tag_url_utub_association = Utub_Url_Tags()
                 new_tag_url_utub_association.utub_containing_this_tag = utub
                 new_tag_url_utub_association.tagged_url = current_utub_url
                 new_tag_url_utub_association.tag_item = tag

--- a/tests/integration/utuburls/test_add_url_to_utub_route.py
+++ b/tests/integration/utuburls/test_add_url_to_utub_route.py
@@ -81,7 +81,8 @@ def test_add_valid_url_as_utub_member(
         add_url_json_response[MODEL_STRS.URL][URL_FORM.URL_STRING] == url_string_to_add
     )
     assert (
-        int(add_url_json_response[MODEL_STRS.URL][URL_SUCCESS.URL_ID]) == url_id_to_add
+        int(add_url_json_response[MODEL_STRS.URL][URL_SUCCESS.UTUB_URL_ID])
+        == url_id_to_add
     )
 
     with app.app_context():
@@ -127,7 +128,7 @@ def test_add_valid_url_as_utub_creator(
         STD_JSON.MESSAGE : URL_SUCCESS.URL_ADDED,
         MODEL_STRS.URL : {
             URL_FORM.URL_STRING: String representing the URL ,
-            URL_SUCCESS.URL_ID : Integer representing the URL ID
+            URL_SUCCESS.UTUB_URL_ID: Integer representing the URL ID
         },
         URL_SUCCESS.UTUB_ID : Integer representing the ID of the UTub added to,
         URL_SUCCESS.ADDED_BY : Integer representing the ID of current user who added this URL to this UTub
@@ -173,7 +174,8 @@ def test_add_valid_url_as_utub_creator(
         add_url_json_response[MODEL_STRS.URL][URL_FORM.URL_STRING] == url_string_to_add
     )
     assert (
-        int(add_url_json_response[MODEL_STRS.URL][URL_SUCCESS.URL_ID]) == url_id_to_add
+        int(add_url_json_response[MODEL_STRS.URL][URL_SUCCESS.UTUB_URL_ID])
+        == url_id_to_add
     )
 
     with app.app_context():
@@ -482,7 +484,7 @@ def test_add_fresh_url_to_utub(
         STD_JSON.MESSAGE : "New URL created and added to UTub",
         MODEL_STRS.URL : {
             URL_FORM.URL_STRING: String representing the URL,
-            URL_SUCCESS.URL_ID : Integer representing the URL ID
+            URL_SUCCESS.UTUB_URL_ID : Integer representing the URL ID
         },
         URL_SUCCESS.UTUB_ID : Integer representing the ID of the UTub added to,
         URL_SUCCESS.ADDED_BY : Integer representing the ID of current user who added this URL to this UTub
@@ -531,7 +533,7 @@ def test_add_fresh_url_to_utub(
     )
     assert int(add_url_json_response[URL_SUCCESS.ADDED_BY]) == current_user.id
 
-    url_id_added = int(add_url_json_response[MODEL_STRS.URL][URL_SUCCESS.URL_ID])
+    url_id_added = int(add_url_json_response[MODEL_STRS.URL][URL_SUCCESS.UTUB_URL_ID])
 
     with app.app_context():
         # Ensure new URL exists

--- a/tests/integration/utuburls/test_add_url_to_utub_route.py
+++ b/tests/integration/utuburls/test_add_url_to_utub_route.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.models.urls import Urls
 from src.models.utubs import Utubs
+from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
 from src.utils.strings.form_strs import URL_FORM
@@ -46,41 +47,17 @@ def test_add_valid_url_as_utub_member(
         current_utub_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
-        assert current_user in [user.to_user for user in current_utub_member_of.members]
-
-        # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
 
         # Grab a URL to add
         url_to_add: Urls = Urls.query.first()
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_db = Urls.query.count()
         url_id_to_add = url_to_add.id
         url_string_to_add = url_to_add.url_string
         url_title_to_add = f"This is {url_string_to_add}"
         utub_id_to_add_to = current_utub_member_of.id
 
-        # Ensure Url-Utubs-User association does not exist
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_to_add_to,
-                    Utub_Urls.url_id == url_id_to_add,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 0
-        )
-
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -109,7 +86,7 @@ def test_add_valid_url_as_utub_member(
 
     with app.app_context():
         # Ensure no new URL created
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
         # Get the UTub again
         current_utub_member_of: Utubs = Utubs.query.get(utub_id_to_add_to)
@@ -130,7 +107,7 @@ def test_add_valid_url_as_utub_member(
         # Ensure title updated appropriately
         assert url_in_utub[0].url_title == url_title_to_add
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls + 1
+        assert Utub_Urls.query.count() == initial_utub_urls + 1
 
 
 def test_add_valid_url_as_utub_creator(
@@ -164,39 +141,16 @@ def test_add_valid_url_as_utub_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
-
         # Grab a URL to add
         url_to_add: Urls = Urls.query.first()
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_db = Urls.query.count()
         url_id_to_add = url_to_add.id
         url_string_to_add = url_to_add.url_string
         url_title_to_add = f"This is {url_string_to_add}"
         utub_id_to_add_to = current_utub_member_of.id
 
-        # Ensure Url-Utubs-User association does not exist
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_to_add_to,
-                    Utub_Urls.url_id == url_id_to_add,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 0
-        )
-
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -224,7 +178,7 @@ def test_add_valid_url_as_utub_creator(
 
     with app.app_context():
         # Ensure no new URL created
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
         # Get the UTub again
         current_utub_member_of = Utubs.query.get(utub_id_to_add_to)
@@ -245,7 +199,7 @@ def test_add_valid_url_as_utub_creator(
         # Ensure title updated
         assert url_in_utub[0].url_title == url_title_to_add
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls + 1
+        assert Utub_Urls.query.count() == initial_utub_urls + 1
 
 
 def test_add_invalid_url_as_utub_member(
@@ -273,37 +227,14 @@ def test_add_invalid_url_as_utub_member(
         current_utub_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
-        assert current_user in [user.to_user for user in current_utub_member_of.members]
-
-        # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
 
         # Get current number of URLs
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_db = Urls.query.count()
 
         utub_id_to_add_to = current_utub_member_of.id
 
-        # Ensure Url-Utubs-User association does not exist
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_to_add_to,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 0
-        )
-
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Try to add the URL to the UTub
     add_url_form = {
@@ -328,7 +259,7 @@ def test_add_invalid_url_as_utub_member(
 
     with app.app_context():
         # Ensure no new URL created
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
         # Get the UTub again
         current_utub_member_of = Utubs.query.get(utub_id_to_add_to)
@@ -338,16 +269,14 @@ def test_add_invalid_url_as_utub_member(
 
         # Ensure Url-Utubs-User association does not exist
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_to_add_to,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == utub_id_to_add_to,
+                Utub_Urls.user_id == current_user.id,
+            ).count()
             == 0
         )
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_invalid_url_as_utub_creator(
@@ -376,35 +305,13 @@ def test_add_invalid_url_as_utub_creator(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
-
         # Get current number of URLs
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_db = Urls.query.count()
 
         utub_id_to_add_to = current_utub_member_of.id
 
-        # Ensure Url-Utubs-User association does not exist
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_to_add_to,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 0
-        )
-
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Try to add the URL to the UTub
     add_url_form = {
@@ -429,7 +336,7 @@ def test_add_invalid_url_as_utub_creator(
 
     with app.app_context():
         # Ensure no new URL created
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
         # Get the UTub again
         current_utub_member_of = Utubs.query.get(utub_id_to_add_to)
@@ -439,16 +346,14 @@ def test_add_invalid_url_as_utub_creator(
 
         # Ensure Url-Utubs-User association does not exist
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_to_add_to,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == utub_id_to_add_to,
+                Utub_Urls.user_id == current_user.id,
+            ).count()
             == 0
         )
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_valid_url_to_nonexistent_utub(
@@ -461,24 +366,17 @@ def test_add_valid_url_to_nonexistent_utub(
         - By POST to "/utubs/<int:utub_id>/urls" where "url_id" is an integer representing UTub ID
     THEN ensure that the server responds with a 404 HTTP status code
     """
+    NONEXISTENT_UTUB_ID = 999
     client, csrf_token, _, app = login_first_user_without_register
 
     with app.app_context():
-        # Find a UTub this current user is a member of (and not creator of)
-        utub_id_to_add_to = 0
-        utub_to_add_to: Utubs = Utubs.query.get(utub_id_to_add_to)
-        while utub_to_add_to is not None and current_user in [
-            user.to_user for user in utub_to_add_to.members
-        ]:
-            utub_id_to_add_to += 1
-
         # Get a valid URL
         valid_url_to_add: Urls = Urls.query.first()
         valid_url_string = valid_url_to_add.url_string
         valid_url_title = f"This is {valid_url_string}"
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -488,13 +386,13 @@ def test_add_valid_url_to_nonexistent_utub(
     }
 
     add_url_response = client.post(
-        url_for(ROUTES.URLS.ADD_URL, utub_id=utub_id_to_add_to), data=add_url_form
+        url_for(ROUTES.URLS.ADD_URL, utub_id=NONEXISTENT_UTUB_ID), data=add_url_form
     )
 
     assert add_url_response.status_code == 404
 
     with app.app_context():
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_valid_url_to_utub_not_a_member_of(
@@ -519,31 +417,19 @@ def test_add_valid_url_to_utub_not_a_member_of(
 
     with app.app_context():
         # Find a UTub this current user is not a member of
-        utub_not_member_of: Utubs = Utubs.query.filter(
-            Utubs.utub_creator != current_user.id
-        ).first()
-        assert current_user not in [user.to_user for user in utub_not_member_of.members]
+        utub_member_of_utub_user_not_member_of: Utub_Members = (
+            Utub_Members.query.filter(Utub_Members.user_id != current_user.id).first()
+        )
 
-        id_of_utub_not_member_of = utub_not_member_of.id
+        id_of_utub_not_member_of = utub_member_of_utub_user_not_member_of.utub_id
 
         # Get a valid URL
         valid_url_to_add: Urls = Urls.query.first()
         valid_url_string = valid_url_to_add.url_string
         valid_url_title = f"This is {valid_url_string}"
 
-        # Ensure URL not in UTub currently
-        assert len(utub_not_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_not_member_of
-                ).all()
-            )
-            == 0
-        )
-
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -570,15 +456,13 @@ def test_add_valid_url_to_utub_not_a_member_of(
         # Ensure URL not in UTub currently
         assert len(utub_not_member_of.utub_urls) == 0
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_not_member_of
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == id_of_utub_not_member_of
+            ).count()
             == 0
         )
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_fresh_url_to_utub(
@@ -615,32 +499,13 @@ def test_add_fresh_url_to_utub(
         id_of_utub_that_is_creator_of = utub_creator_of.id
 
         # Ensure URL not in UTub currently
-        assert len(utub_creator_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_that_is_creator_of
-                ).all()
-            )
-            == 0
-        )
-
-        # Ensure no URLs
-        assert len(Urls.query.all()) == 0
-
-        # Ensure no Url-Utubs-User association exists
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 0
-        )
+        initial_num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == id_of_utub_that_is_creator_of
+        ).count()
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
+        initial_urls = Urls.query.count()
 
     url_title_to_add = f"This is {valid_url_to_add}"
 
@@ -670,28 +535,28 @@ def test_add_fresh_url_to_utub(
 
     with app.app_context():
         # Ensure new URL exists
-        assert len(Urls.query.all()) == 1
-        assert len(Urls.query.filter(Urls.url_string == valid_url_to_add).all()) == 1
+        assert Urls.query.count() == initial_urls + 1
+        assert Urls.query.filter(Urls.url_string == valid_url_to_add).count() == 1
         assert Urls.query.get(url_id_added).url_string == valid_url_to_add
 
-        # Get the UTub again
-        current_utub_creator_of: Utubs = Utubs.query.get(id_of_utub_that_is_creator_of)
-
         # Ensure URL now in UTub
-        assert len(current_utub_creator_of.utub_urls) == 1
+        assert (
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
+                Utub_Urls.url_id == url_id_added,
+            ).count()
+            == initial_num_of_urls_in_utub + 1
+        )
 
         urls_in_utub: list[Utub_Urls] = Utub_Urls.query.filter(
             Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
             Utub_Urls.user_id == current_user.id,
         ).all()
 
-        # Ensure Url-Utubs-User association exists
-        assert len(urls_in_utub) == 1
-
         # Ensure title updated
         assert urls_in_utub[0].url_title == url_title_to_add
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls + 1
+        assert Utub_Urls.query.count() == initial_utub_urls + 1
 
 
 def test_add_duplicate_url_to_utub_as_same_user_who_added_url(
@@ -732,15 +597,13 @@ def test_add_duplicate_url_to_utub_as_same_user_who_added_url(
         url_string_to_add = url_that_user_added.url_string
         url_title_to_add = url_association_that_user_added.url_title
 
-        number_of_urls_in_utub = len(
-            Utub_Urls.query.filter(
-                Utub_Urls.utub_id == id_of_utub_that_is_creator_of
-            ).all()
-        )
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == id_of_utub_that_is_creator_of
+        ).count()
+        number_of_urls_in_db = Urls.query.count()
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -768,20 +631,18 @@ def test_add_duplicate_url_to_utub_as_same_user_who_added_url(
 
         # Ensure Url-UTub-UAser association still contains only the one associatisn
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
-                    Utub_Urls.user_id == current_user.id,
-                    Utub_Urls.url_id == url_id,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
+                Utub_Urls.user_id == current_user.id,
+                Utub_Urls.url_id == url_id,
+            ).count()
             == 1
         )
 
         # Ensure same number of URLs as before
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_duplicate_url_to_utub_as_creator_of_utub_not_url_adder(
@@ -824,15 +685,14 @@ def test_add_duplicate_url_to_utub_as_creator_of_utub_not_url_adder(
         url_string_to_add = url_that_user_did_not_add.url_string
         url_title_to_add = url_association_that_user_did_not_add.url_title
 
-        number_of_urls_in_utub = len(
-            Utub_Urls.query.filter(
-                Utub_Urls.utub_id == id_of_utub_that_is_creator_of
-            ).all()
-        )
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == id_of_utub_that_is_creator_of
+        ).count()
+
+        number_of_urls_in_db = Urls.query.count()
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -860,19 +720,17 @@ def test_add_duplicate_url_to_utub_as_creator_of_utub_not_url_adder(
 
         # Ensure Url-UTub-UAser association still contains only the one associatisn
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
-                    Utub_Urls.url_id == url_id,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == id_of_utub_that_is_creator_of,
+                Utub_Urls.url_id == url_id,
+            ).count()
             == 1
         )
 
         # Ensure same number of URLs as before
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_duplicate_url_to_utub_as_member_of_utub_not_url_adder(
@@ -902,9 +760,6 @@ def test_add_duplicate_url_to_utub_as_member_of_utub_not_url_adder(
         ).first()
         id_of_utub_that_is_member_of = utub_member_of.id
 
-        # Ensure user is member of this UTub
-        assert current_user in [user.to_user for user in utub_member_of.members]
-
         # Find the first URL in this UTub that this user added
         url_association_that_user_did_not_add: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == id_of_utub_that_is_member_of,
@@ -918,15 +773,14 @@ def test_add_duplicate_url_to_utub_as_member_of_utub_not_url_adder(
         url_string_to_add = url_that_user_did_not_add.url_string
         url_title_to_add = url_association_that_user_did_not_add.url_title
 
-        number_of_urls_in_utub = len(
-            Utub_Urls.query.filter(
-                Utub_Urls.utub_id == id_of_utub_that_is_member_of
-            ).all()
-        )
-        number_of_urls_in_db = len(Urls.query.all())
+        number_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == id_of_utub_that_is_member_of
+        ).count()
+
+        number_of_urls_in_db = Urls.query.count()
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -954,19 +808,17 @@ def test_add_duplicate_url_to_utub_as_member_of_utub_not_url_adder(
 
         # Ensure Url-UTub-UAser association still contains only the one associatisn
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_that_is_member_of,
-                    Utub_Urls.url_id == url_id,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == id_of_utub_that_is_member_of,
+                Utub_Urls.url_id == url_id,
+            ).count()
             == 1
         )
 
         # Ensure same number of URLs as before
-        assert len(Urls.query.all()) == number_of_urls_in_db
+        assert Urls.query.count() == number_of_urls_in_db
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_url_missing_url(
@@ -997,18 +849,11 @@ def test_add_url_missing_url(
         current_utub_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
-        assert current_user in [user.to_user for user in current_utub_member_of.members]
 
         # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
+        num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == current_utub_member_of.id
+        ).count()
 
         # Grab a URL to add
         url_to_add: Urls = Urls.query.first()
@@ -1017,7 +862,7 @@ def test_add_url_missing_url(
         utub_id_to_add_to = current_utub_member_of.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -1043,11 +888,11 @@ def test_add_url_missing_url(
 
     with app.app_context():
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_add_to).all())
-            == 0
+            Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_add_to).count()
+            == num_of_urls_in_utub
         )
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_url_missing_url_title(
@@ -1077,18 +922,11 @@ def test_add_url_missing_url_title(
         current_utub_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
-        assert current_user in [user.to_user for user in current_utub_member_of.members]
 
         # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
+        initial_num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == current_utub_member_of.id
+        ).count()
 
         # Grab a URL to add
         url_to_add: Urls = Urls.query.first()
@@ -1096,7 +934,7 @@ def test_add_url_missing_url_title(
         utub_id_to_add_to = current_utub_member_of.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -1122,11 +960,11 @@ def test_add_url_missing_url_title(
 
     with app.app_context():
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_add_to).all())
-            == 0
+            Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_add_to).count()
+            == initial_num_of_urls_in_utub
         )
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_url_missing_csrf_token(
@@ -1157,18 +995,11 @@ def test_add_url_missing_csrf_token(
         current_utub_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
-        assert current_user in [user.to_user for user in current_utub_member_of.members]
 
         # Ensure no URLs in this UTub
-        assert len(current_utub_member_of.utub_urls) == 0
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_utub_member_of.id
-                ).all()
-            )
-            == 0
-        )
+        initial_num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == current_utub_member_of.id
+        ).count()
 
         # Grab a URL to add
         url_to_add: Urls = Urls.query.first()
@@ -1176,7 +1007,7 @@ def test_add_url_missing_csrf_token(
         utub_id_to_add_to = current_utub_member_of.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Add the URL to the UTub
     add_url_form = {
@@ -1194,11 +1025,11 @@ def test_add_url_missing_csrf_token(
 
     with app.app_context():
         assert (
-            len(Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_add_to).all())
-            == 0
+            Utub_Urls.query.filter(Utub_Urls.utub_id == utub_id_to_add_to).count()
+            == initial_num_of_urls_in_utub
         )
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_add_valid_url_updates_utub_last_updated(

--- a/tests/integration/utuburls/test_remove_url_from_utub_route.py
+++ b/tests/integration/utuburls/test_remove_url_from_utub_route.py
@@ -4,7 +4,7 @@ import pytest
 
 from src import db
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
@@ -528,15 +528,15 @@ def test_remove_url_as_utub_creator_with_tag(
         ).first()
 
         # Find a URL with tags on it in this UTub
-        current_utub_url_tags: list[Url_Tags] = current_utub.utub_url_tags
-        current_url_in_utub_with_tags: Url_Tags = current_utub_url_tags[0]
+        current_utub_url_tags: list[Utub_Url_Tags] = current_utub.utub_url_tags
+        current_url_in_utub_with_tags: Utub_Url_Tags = current_utub_url_tags[0]
 
         # Ensure this URL has tags associated with it
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == current_utub.id,
-                    Url_Tags.url_id == current_url_in_utub_with_tags.url_id,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == current_utub.id,
+                    Utub_Url_Tags.url_id == current_url_in_utub_with_tags.url_id,
                 ).all()
             )
             > 0
@@ -558,13 +558,13 @@ def test_remove_url_as_utub_creator_with_tag(
         initial_utub_urls = len(Utub_Urls.query.all())
 
         # Get initial number of Url-Tag associations
-        initial_tag_urls = len(Url_Tags.query.all())
+        initial_tag_urls = len(Utub_Url_Tags.query.all())
 
         # Get count of tags on this URL in this UTub
         tags_on_url_in_utub = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == current_utub.id,
-                Url_Tags.url_id == current_url_in_utub_with_tags.url_id,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == current_utub.id,
+                Utub_Url_Tags.url_id == current_url_in_utub_with_tags.url_id,
             ).all()
         )
 
@@ -616,9 +616,9 @@ def test_remove_url_as_utub_creator_with_tag(
         )
 
         # Assert the UTUB-URL-TAG association is deleted
-        tags_in_utub: list[Url_Tags] = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_to_remove_url_from,
-            Url_Tags.url_id == url_id_to_remove,
+        tags_in_utub: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_to_remove_url_from,
+            Utub_Url_Tags.url_id == url_id_to_remove,
         ).all()
 
         assert len(tags_in_utub) == 0
@@ -630,7 +630,7 @@ def test_remove_url_as_utub_creator_with_tag(
 
         # Ensure counts of Url-Utubs-Tag associations are correct
         assert len(Utub_Urls.query.all()) == initial_utub_urls - 1
-        assert len(Url_Tags.query.all()) == initial_tag_urls - tags_on_url_in_utub
+        assert len(Utub_Url_Tags.query.all()) == initial_tag_urls - tags_on_url_in_utub
 
 
 def test_remove_url_as_utub_member_with_tags(
@@ -677,9 +677,9 @@ def test_remove_url_as_utub_member_with_tags(
         # Make sure this URL has tags on it
         assert (
             len(
-                Url_Tags.query.filter(
-                    Url_Tags.utub_id == current_user_utub.id,
-                    Url_Tags.url_id == current_url_in_utub.url_id,
+                Utub_Url_Tags.query.filter(
+                    Utub_Url_Tags.utub_id == current_user_utub.id,
+                    Utub_Url_Tags.url_id == current_url_in_utub.url_id,
                 ).all()
             )
             > 0
@@ -696,13 +696,13 @@ def test_remove_url_as_utub_member_with_tags(
         initial_utub_urls = len(Utub_Urls.query.all())
 
         # Get initial number of Url-Tag associations
-        initial_tag_urls = len(Url_Tags.query.all())
+        initial_tag_urls = len(Utub_Url_Tags.query.all())
 
         # Get count of tags on this URL in this UTub
         tags_on_url_in_utub = len(
-            Url_Tags.query.filter(
-                Url_Tags.utub_id == current_user_utub.id,
-                Url_Tags.url_id == url_id_to_remove,
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == current_user_utub.id,
+                Utub_Url_Tags.url_id == url_id_to_remove,
             ).all()
         )
 
@@ -758,15 +758,15 @@ def test_remove_url_as_utub_member_with_tags(
         )
 
         # Assert the UTUB-URL-TAG association is deleted
-        tags_in_utub_on_url: list[Url_Tags] = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_to_remove_url_from,
-            Url_Tags.url_id == url_id_to_remove,
+        tags_in_utub_on_url: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_to_remove_url_from,
+            Utub_Url_Tags.url_id == url_id_to_remove,
         ).all()
 
         assert len(tags_in_utub_on_url) == 0
 
-        tags_in_utub: list[Url_Tags] = Url_Tags.query.filter(
-            Url_Tags.utub_id == utub_id_to_remove_url_from
+        tags_in_utub: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_to_remove_url_from
         ).all()
         tag_ids_in_utub: list[int] = [tag.tag_id for tag in tags_in_utub]
         tags_array_response = [
@@ -778,7 +778,7 @@ def test_remove_url_as_utub_member_with_tags(
 
         # Ensure counts of Url-Utubs-Tag associations are correct
         assert len(Utub_Urls.query.all()) == initial_utub_urls - 1
-        assert len(Url_Tags.query.all()) == initial_tag_urls - tags_on_url_in_utub
+        assert len(Utub_Url_Tags.query.all()) == initial_tag_urls - tags_on_url_in_utub
 
 
 def test_remove_url_from_utub_no_csrf_token(

--- a/tests/integration/utuburls/test_remove_url_from_utub_route.py
+++ b/tests/integration/utuburls/test_remove_url_from_utub_route.py
@@ -2,7 +2,6 @@ from flask import url_for
 from flask_login import current_user
 import pytest
 
-from src import db
 from src.models.urls import Urls
 from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
@@ -48,26 +47,11 @@ def test_remove_url_as_utub_creator_no_tags(
             Utubs.utub_creator == current_user.id
         ).first()
 
-        # Assert there is a URL in the UTub
-        assert len(current_user_utub.utub_urls) == 1
-
         url_utub_user_association: Utub_Urls = current_user_utub.utub_urls[0]
-        url_id_to_remove = url_utub_user_association.url_id
-
-        # Assert the single UTUB-URL-USER association exists
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.url_id == url_id_to_remove,
-                    Utub_Urls.user_id == current_user.id,
-                    Utub_Urls.utub_id == current_user_utub.id,
-                ).all()
-            )
-            == 1
-        )
+        url_id_to_remove = url_utub_user_association.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
         url_object: Urls = url_utub_user_association.standalone_url
 
     # Remove URL from UTub as UTub creator
@@ -75,7 +59,7 @@ def test_remove_url_as_utub_creator_no_tags(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=current_user_utub.id,
-            url_id=url_id_to_remove,
+            utub_url_id=url_id_to_remove,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -105,29 +89,20 @@ def test_remove_url_as_utub_creator_no_tags(
     # Ensure proper removal from database
     with app.app_context():
         # Assert url still in database
-        assert Urls.query.get(url_id_to_remove) is not None
+        assert Urls.query.get(url_object.id) is not None
 
         # Assert the URL-USER-UTUB association is deleted
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.url_id == url_id_to_remove,
-                    Utub_Urls.user_id == current_user.id,
-                    Utub_Urls.utub_id == current_user_utub.id,
-                ).all()
-            )
-            == 0
-        )
+        assert Utub_Urls.query.get(url_id_to_remove) is None
 
         # Ensure UTub has no URLs left
         current_user_utub = Utubs.query.get(current_user_utub.id)
         assert len(current_user_utub.utub_urls) == 0
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls - 1
+        assert Utub_Urls.query.count() == initial_utub_urls - 1
 
 
 def test_remove_url_as_utub_member_no_tags(
-    add_one_url_and_all_users_to_each_utub_no_tags, login_first_user_without_register
+    add_all_urls_and_users_to_each_utub_no_tags, login_first_user_without_register
 ):
     """
     GIVEN a logged-in member of a UTub who has added a valid URL to their UTub, with no tags
@@ -151,73 +126,32 @@ def test_remove_url_as_utub_member_no_tags(
     }
     """
     client, csrf_token_string, _, app = login_first_user_without_register
-    NEW_URL_TITLE = "This is my new URL title"
 
     with app.app_context():
-        # Get first UTub where current logged in user is not the creator
-        current_user_utub: Utubs = Utubs.query.filter(
-            Utubs.utub_creator != current_user.id
+        # Get URL that this user did not add to a UTub
+        current_url_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.user_id == current_user.id
         ).first()
 
-        # Assert there is a URL in the UTub
-        assert len(current_user_utub.utub_urls) == 1
-        current_url_in_utub = current_user_utub.utub_urls[0]
+        current_user_utub_id = current_url_in_utub.utub_id
+        current_num_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == current_user_utub_id
+        ).count()
 
-        # Assert current user did not add this URL
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == current_user_utub.id,
-                    Utub_Urls.url_id == current_url_in_utub.url_id,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 0
-        )
-
-        # Find a URL that the current user did not add
-        missing_url_association: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.user_id != current_user.id,
-            Utub_Urls.utub_id != current_user_utub.id,
-        ).first()
-
-        missing_url: Urls = missing_url_association.standalone_url
-
-        # Have current user add the missing URL to the current UTub
-        new_utub_url_association = Utub_Urls()
-        new_utub_url_association.url_id = missing_url.id
-        new_utub_url_association.standalone_url = missing_url
-        new_utub_url_association.utub_id = current_user_utub.id
-        new_utub_url_association.utub = current_user_utub
-        new_utub_url_association.user_id = current_user.id
-        new_utub_url_association.user_that_added_url = current_user
-        new_utub_url_association.url_title = NEW_URL_TITLE
-
-        db.session.add(new_utub_url_association)
-        db.session.commit()
-
-        # Assert this URL was added
-        current_user_utub = Utubs.query.get(current_user_utub.id)
-        assert len(current_user_utub.utub_urls) == 2
-
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.url_id == missing_url.id,
-                    Utub_Urls.utub_id == current_user_utub.id,
-                    Utub_Urls.user_id == current_user.id,
-                ).all()
-            )
-            == 1
-        )
+        url_object: Urls = current_url_in_utub.standalone_url
+        url_object_id = url_object.id
+        current_url_string = url_object.url_string
+        current_url_title = current_url_in_utub.url_title
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Remove URL from UTub as UTub member
     remove_url_response = client.delete(
         url_for(
-            ROUTES.URLS.REMOVE_URL, utub_id=current_user_utub.id, url_id=missing_url.id
+            ROUTES.URLS.REMOVE_URL,
+            utub_id=current_user_utub_id,
+            utub_url_id=current_url_in_utub.id,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -230,41 +164,34 @@ def test_remove_url_as_utub_member_no_tags(
 
     assert remove_url_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert remove_url_response_json[STD_JSON.MESSAGE] == URL_SUCCESS.URL_REMOVED
-    assert int(remove_url_response_json[URL_SUCCESS.UTUB_ID]) == current_user_utub.id
+    assert int(remove_url_response_json[URL_SUCCESS.UTUB_ID]) == current_user_utub_id
     assert (
-        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_ID] == missing_url.id
+        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_ID]
+        == current_url_in_utub.id
     )
     assert (
         remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_STRING]
-        == missing_url.url_string
+        == current_url_string
     )
     assert (
         remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_TITLE]
-        == NEW_URL_TITLE
+        == current_url_title
     )
     assert remove_url_response_json[MODELS.TAGS] == []
 
     # Ensure proper removal from database
     with app.app_context():
         # Assert url still in database
-        assert Urls.query.get(missing_url.id) is not None
+        assert Urls.query.get(url_object_id) is not None
 
         # Assert the URL-UTUB association is deleted
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.url_id == missing_url.id,
-                    Utub_Urls.utub_id == current_user_utub.id,
-                ).all()
-            )
-            == 0
-        )
+        assert Utub_Urls.query.get(current_url_in_utub.id) is None
 
-        # Ensure UTub has one left
-        current_user_utub = Utubs.query.get(current_user_utub.id)
-        assert len(current_user_utub.utub_urls) == 1
+        # Ensure UTub has decremented URLs
+        current_user_utub = Utubs.query.get(current_user_utub_id)
+        assert len(current_user_utub.utub_urls) == current_num_urls_in_utub - 1
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls - 1
+        assert Utub_Urls.query.count() == initial_utub_urls - 1
 
 
 def test_remove_url_from_utub_not_member_of(
@@ -290,31 +217,24 @@ def test_remove_url_from_utub_not_member_of(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Ensure the currently logged in user is not in this UTub
-        assert current_user not in [
-            user.to_user for user in utub_current_user_not_part_of.members
-        ]
-
-        # Ensure there exists a URL in this UTub
-        assert len(utub_current_user_not_part_of.utub_urls) > 0
         current_num_of_urls_in_utub = len(utub_current_user_not_part_of.utub_urls)
 
         # Get the URL to remove
         url_to_remove_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_current_user_not_part_of.id
         ).first()
-        url_to_remove = url_to_remove_in_utub.standalone_url
-        url_to_remove_id = url_to_remove.id
+
+        url_to_remove_id = url_to_remove_in_utub.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Remove the URL from the other user's UTub while logged in as member of another UTub
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=utub_current_user_not_part_of.id,
-            url_id=url_to_remove_id,
+            utub_url_id=url_to_remove_id,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -331,19 +251,19 @@ def test_remove_url_from_utub_not_member_of(
 
     # Ensure database is not affected
     with app.app_context():
-        utub_current_user_not_part_of = Utubs.query.filter(
-            Utubs.id == utub_current_user_not_part_of.id
-        ).first()
-
+        utub_in_url: Utub_Urls = Utub_Urls.query.get(url_to_remove_id)
         assert (
-            len(utub_current_user_not_part_of.utub_urls) == current_num_of_urls_in_utub
+            utub_in_url is not None
+            and utub_in_url.utub_id == utub_current_user_not_part_of.id
         )
-        current_utub_urls_id = [
-            url.url_id for url in utub_current_user_not_part_of.utub_urls
-        ]
-        assert url_to_remove_id in current_utub_urls_id
+        assert Utub_Urls.query.count() == initial_utub_urls
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        utub_current_user_not_part_of: Utubs = Utubs.query.get(
+            utub_current_user_not_part_of.id
+        )
+        assert current_num_of_urls_in_utub == len(
+            utub_current_user_not_part_of.utub_urls
+        )
 
 
 def test_remove_invalid_nonexistant_url_as_utub_creator(
@@ -354,6 +274,7 @@ def test_remove_invalid_nonexistant_url_as_utub_creator(
     WHEN the user wishes to remove a nonexistant URL from the UTub by making a DELETE to "/utubs/<int:utub_id>/urls/<int:url_id>"
     THEN the server responds with a 404 HTTP status code, and the database has no changes
     """
+    NONEXISTENT_URL_IN_UTUB_ID = 999
 
     client, csrf_token_string, _, app = login_first_user_without_register
 
@@ -364,41 +285,18 @@ def test_remove_invalid_nonexistant_url_as_utub_creator(
         ).first()
         id_of_utub_current_user_creator_of = utub_current_user_creator_of.id
 
-        all_urls: list[Urls] = Urls.query.all()
-        all_url_ids = [url.id for url in all_urls]
-        all_urls_in_utub: list[Utub_Urls] = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == id_of_utub_current_user_creator_of
-        ).all()
-        all_urls_ids_in_utub = [url.url_id for url in all_urls_in_utub]
-
-        # Find ID of URL that doesn't exist as URL or in UTub
-        id_of_url_to_remove = 0
-        while (
-            id_of_url_to_remove in all_url_ids
-            and id_of_url_to_remove in all_urls_ids_in_utub
-        ):
-            id_of_url_to_remove += 1
-
         # Ensure not in UTub and nonexistant
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_current_user_creator_of,
-                    Utub_Urls.url_id == id_of_url_to_remove,
-                ).all()
-            )
-            == 0
-        )
+        assert Utub_Urls.query.get(NONEXISTENT_URL_IN_UTUB_ID) is None
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Attempt to remove nonexistant URL from UTub as creator of UTub
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=id_of_utub_current_user_creator_of,
-            url_id=id_of_url_to_remove,
+            utub_url_id=NONEXISTENT_URL_IN_UTUB_ID,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -408,17 +306,8 @@ def test_remove_invalid_nonexistant_url_as_utub_creator(
 
     with app.app_context():
         # Ensure not in UTub and nonexistant
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_current_user_creator_of,
-                    Utub_Urls.url_id == id_of_url_to_remove,
-                ).all()
-            )
-            == 0
-        )
-
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.get(NONEXISTENT_URL_IN_UTUB_ID) is None
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_remove_invalid_nonexistant_url_as_utub_member(
@@ -429,50 +318,27 @@ def test_remove_invalid_nonexistant_url_as_utub_member(
     WHEN the user wishes to remove a nonexistant URL from the UTub by making a DELETE to "/utubs/<int:utub_id>/urls/<int:url_id>"
     THEN the server responds with a 404 HTTP status code, and the database has no changes
     """
+    NONEXISTENT_URL_IN_UTUB_ID = 999
     client, csrf_token_string, _, app = login_first_user_without_register
 
-    # Find the first UTub this logged in user is a creator of
     with app.app_context():
         utub_current_user_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
         id_of_utub_current_user_member_of = utub_current_user_member_of.id
 
-        all_urls: list[Urls] = Urls.query.all()
-        all_url_ids = [url.id for url in all_urls]
-        all_urls_in_utub: list[Utub_Urls] = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == id_of_utub_current_user_member_of
-        ).all()
-        all_urls_ids_in_utub = [url.url_id for url in all_urls_in_utub]
-
-        # Find ID of URL that doesn't exist as URL or in UTub
-        id_of_url_to_remove = 0
-        while (
-            id_of_url_to_remove in all_url_ids
-            and id_of_url_to_remove in all_urls_ids_in_utub
-        ):
-            id_of_url_to_remove += 1
-
         # Ensure not in UTub and nonexistant
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_current_user_member_of,
-                    Utub_Urls.url_id == id_of_url_to_remove,
-                ).all()
-            )
-            == 0
-        )
+        assert Utub_Urls.query.get(NONEXISTENT_URL_IN_UTUB_ID) is None
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Attempt to remove nonexistant URL from UTub as creator of UTub
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=id_of_utub_current_user_member_of,
-            url_id=id_of_url_to_remove,
+            utub_url_id=NONEXISTENT_URL_IN_UTUB_ID,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -482,17 +348,8 @@ def test_remove_invalid_nonexistant_url_as_utub_member(
 
     with app.app_context():
         # Ensure not in UTub and nonexistant
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == id_of_utub_current_user_member_of,
-                    Utub_Urls.url_id == id_of_url_to_remove,
-                ).all()
-            )
-            == 0
-        )
-
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.get(NONEXISTENT_URL_IN_UTUB_ID) is None
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_remove_url_as_utub_creator_with_tag(
@@ -531,49 +388,35 @@ def test_remove_url_as_utub_creator_with_tag(
         current_utub_url_tags: list[Utub_Url_Tags] = current_utub.utub_url_tags
         current_url_in_utub_with_tags: Utub_Url_Tags = current_utub_url_tags[0]
 
-        # Ensure this URL has tags associated with it
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == current_utub.id,
-                    Utub_Url_Tags.url_id == current_url_in_utub_with_tags.url_id,
-                ).all()
-            )
-            > 0
-        )
-
         # Get the Utubs-URL association
-        url_in_utub: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == current_utub.id,
-            Utub_Urls.url_id == current_url_in_utub_with_tags.url_id,
-        ).first()
+        url_in_utub: Utub_Urls = Utub_Urls.query.get(
+            current_url_in_utub_with_tags.utub_url_id
+        )
         url_object: Urls = url_in_utub.standalone_url
         url_string_to_remove = url_object.url_string
         associated_tags = url_in_utub.associated_tags
 
-        url_id_to_remove = current_url_in_utub_with_tags.url_id
+        url_id_to_remove = url_in_utub.id
         utub_id_to_remove_url_from = current_utub.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
         # Get initial number of Url-Tag associations
-        initial_tag_urls = len(Utub_Url_Tags.query.all())
+        initial_tag_urls = Utub_Url_Tags.query.count()
 
         # Get count of tags on this URL in this UTub
-        tags_on_url_in_utub = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == current_utub.id,
-                Utub_Url_Tags.url_id == current_url_in_utub_with_tags.url_id,
-            ).all()
-        )
+        tags_on_url_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == current_utub.id,
+            Utub_Url_Tags.utub_url_id == current_url_in_utub_with_tags.utub_url_id,
+        ).count()
 
     # Attempt to remove URL that contains tag from UTub as creator of UTub
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=utub_id_to_remove_url_from,
-            url_id=url_id_to_remove,
+            utub_url_id=url_id_to_remove,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -604,24 +447,16 @@ def test_remove_url_as_utub_creator_with_tag(
         assert Urls.query.get(url_id_to_remove) is not None
 
         # Assert the URL-USER-UTUB association is deleted
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.url_id == url_id_to_remove,
-                    Utub_Urls.user_id == current_user.id,
-                    Utub_Urls.utub_id == utub_id_to_remove_url_from,
-                ).all()
-            )
-            == 0
-        )
+        assert Utub_Urls.query.get(url_id_to_remove) is None
 
         # Assert the UTUB-URL-TAG association is deleted
-        tags_in_utub: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
-            Utub_Url_Tags.utub_id == utub_id_to_remove_url_from,
-            Utub_Url_Tags.url_id == url_id_to_remove,
-        ).all()
-
-        assert len(tags_in_utub) == 0
+        assert (
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_to_remove_url_from,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
+            ).count()
+            == 0
+        )
 
         assert remove_url_response_json[MODELS.TAGS] == [
             {MODELS.ID: tag_id, URL_SUCCESS.TAG_IN_UTUB: False}
@@ -629,8 +464,8 @@ def test_remove_url_as_utub_creator_with_tag(
         ]
 
         # Ensure counts of Url-Utubs-Tag associations are correct
-        assert len(Utub_Urls.query.all()) == initial_utub_urls - 1
-        assert len(Utub_Url_Tags.query.all()) == initial_tag_urls - tags_on_url_in_utub
+        assert Utub_Urls.query.count() == initial_utub_urls - 1
+        assert Utub_Url_Tags.query.count() == initial_tag_urls - tags_on_url_in_utub
 
 
 def test_remove_url_as_utub_member_with_tags(
@@ -665,53 +500,37 @@ def test_remove_url_as_utub_member_with_tags(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Assert there is a URL in the UTub
-        assert len(current_user_utub.utub_urls) > 0
-
         # Find a URL this user has added
         current_url_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == current_user_utub.id,
             Utub_Urls.user_id == current_user.id,
         ).first()
 
-        # Make sure this URL has tags on it
-        assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == current_user_utub.id,
-                    Utub_Url_Tags.url_id == current_url_in_utub.url_id,
-                ).all()
-            )
-            > 0
-        )
-
         utub_id_to_remove_url_from = current_user_utub.id
-        url_id_to_remove = current_url_in_utub.url_id
+        url_id_to_remove = current_url_in_utub.id
         url_object: Urls = current_url_in_utub.standalone_url
         url_string_to_remove = url_object.url_string
         url_title_to_remove = current_url_in_utub.url_title
         associated_tags: list[int] = current_url_in_utub.associated_tags
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
         # Get initial number of Url-Tag associations
-        initial_tag_urls = len(Utub_Url_Tags.query.all())
+        initial_tag_urls = Utub_Url_Tags.query.count()
 
         # Get count of tags on this URL in this UTub
-        tags_on_url_in_utub = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == current_user_utub.id,
-                Utub_Url_Tags.url_id == url_id_to_remove,
-            ).all()
-        )
+        tags_on_url_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == current_user_utub.id,
+            Utub_Url_Tags.utub_url_id == url_id_to_remove,
+        ).count()
 
     # Remove URL from UTub as UTub member
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=utub_id_to_remove_url_from,
-            url_id=url_id_to_remove,
+            utub_url_id=url_id_to_remove,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -744,26 +563,19 @@ def test_remove_url_as_utub_member_with_tags(
     # Ensure proper removal from database
     with app.app_context():
         # Assert url still in database
-        assert Urls.query.get(url_id_to_remove) is not None
+        assert Urls.query.get(url_object.id) is not None
 
         # Assert the URL-USER-UTUB association is deleted
-        assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.url_id == url_id_to_remove,
-                    Utub_Urls.utub_id == utub_id_to_remove_url_from,
-                ).all()
-            )
-            == 0
-        )
+        assert Utub_Urls.query.get(url_id_to_remove) is None
 
         # Assert the UTUB-URL-TAG association is deleted
-        tags_in_utub_on_url: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
-            Utub_Url_Tags.utub_id == utub_id_to_remove_url_from,
-            Utub_Url_Tags.url_id == url_id_to_remove,
-        ).all()
-
-        assert len(tags_in_utub_on_url) == 0
+        assert (
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_to_remove_url_from,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
+            ).count()
+            == 0
+        )
 
         tags_in_utub: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
             Utub_Url_Tags.utub_id == utub_id_to_remove_url_from
@@ -777,8 +589,8 @@ def test_remove_url_as_utub_member_with_tags(
         assert tags_array_response == remove_url_response_json[MODELS.TAGS]
 
         # Ensure counts of Url-Utubs-Tag associations are correct
-        assert len(Utub_Urls.query.all()) == initial_utub_urls - 1
-        assert len(Utub_Url_Tags.query.all()) == initial_tag_urls - tags_on_url_in_utub
+        assert Utub_Urls.query.count() == initial_utub_urls - 1
+        assert Utub_Url_Tags.query.count() == initial_tag_urls - tags_on_url_in_utub
 
 
 def test_remove_url_from_utub_no_csrf_token(
@@ -799,31 +611,25 @@ def test_remove_url_from_utub_no_csrf_token(
             Utubs.utub_creator != current_user.id
         ).first()
 
-        # Ensure the currently logged in user is not in this UTub and is not the creator of this UTub
-        assert current_user not in [
-            user.to_user for user in utub_current_user_not_part_of.members
-        ]
-
-        # Ensure there exists a URL in this UTub
-        assert len(utub_current_user_not_part_of.utub_urls) > 0
-        current_num_of_urls_in_utub = len(utub_current_user_not_part_of.utub_urls)
+        current_num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_current_user_not_part_of.id
+        ).count()
 
         # Get the URL to remove
         url_to_remove_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_current_user_not_part_of.id
         ).first()
-        url_to_remove: Urls = url_to_remove_in_utub.standalone_url
-        url_to_remove_id = url_to_remove.id
+        url_to_remove_id = url_to_remove_in_utub.id
 
         # Get initial number of UTub-URL associations
-        initial_utub_urls = len(Utub_Urls.query.all())
+        initial_utub_urls = Utub_Urls.query.count()
 
     # Remove the URL from the other user's UTub while logged in as member of another UTub
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=utub_current_user_not_part_of.id,
-            url_id=url_to_remove_id,
+            utub_url_id=url_to_remove_id,
         ),
         data={},
     )
@@ -842,11 +648,11 @@ def test_remove_url_from_utub_no_csrf_token(
             len(utub_current_user_not_part_of.utub_urls) == current_num_of_urls_in_utub
         )
         current_utub_urls_id = [
-            url.url_id for url in utub_current_user_not_part_of.utub_urls
+            url.id for url in utub_current_user_not_part_of.utub_urls
         ]
         assert url_to_remove_id in current_utub_urls_id
 
-        assert len(Utub_Urls.query.all()) == initial_utub_urls
+        assert Utub_Urls.query.count() == initial_utub_urls
 
 
 def test_remove_url_updates_utub_last_updated(
@@ -867,14 +673,14 @@ def test_remove_url_updates_utub_last_updated(
         initial_last_updated = current_user_utub.last_updated
 
         url_utub_user_association: Utub_Urls = current_user_utub.utub_urls[0]
-        url_id_to_remove = url_utub_user_association.url_id
+        url_id_to_remove = url_utub_user_association.id
 
     # Remove URL from UTub as UTub creator
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=current_user_utub.id,
-            url_id=url_id_to_remove,
+            utub_url_id=url_id_to_remove,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )
@@ -910,16 +716,16 @@ def test_remove_invalid_url_does_not_update_utub_last_updated(
         id_of_utub_current_user_creator_of = utub_current_user_creator_of.id
 
         url_not_in_utub: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.utub_id != id_of_utub_current_user_creator_of
+            Utub_Urls.utub_id != id_of_utub_current_user_creator_of,
         ).first()
-        id_of_url_to_remove = url_not_in_utub.url_id
+        id_of_url_to_remove = url_not_in_utub.id
 
     # Attempt to remove nonexistant URL from UTub as creator of UTub
     remove_url_response = client.delete(
         url_for(
             ROUTES.URLS.REMOVE_URL,
             utub_id=id_of_utub_current_user_creator_of,
-            url_id=id_of_url_to_remove,
+            utub_url_id=id_of_url_to_remove,
         ),
         data={URL_FORM.CSRF_TOKEN: csrf_token_string},
     )

--- a/tests/integration/utuburls/test_remove_url_from_utub_route.py
+++ b/tests/integration/utuburls/test_remove_url_from_utub_route.py
@@ -31,7 +31,7 @@ def test_remove_url_as_utub_creator_no_tags(
         URL_SUCCESS.UTUB_ID : Integer representing the UTub ID where the URL was removed from,
         URL_SUCCESS.URL : Serialized information of the URL that was removed, as follows:
         {
-            "urlID": Integer representing ID of the URL,
+            "utubUrlID": Integer representing ID of the URL,
             "urlString": String representing the URL itself,
             "urlTitle": String representing the title associated with the URL,
         }
@@ -73,7 +73,7 @@ def test_remove_url_as_utub_creator_no_tags(
     assert remove_url_response_json[STD_JSON.MESSAGE] == URL_SUCCESS.URL_REMOVED
     assert int(remove_url_response_json[URL_SUCCESS.UTUB_ID]) == current_user_utub.id
     assert (
-        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_ID]
+        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.UTUB_URL_ID]
         == url_id_to_remove
     )
     assert (
@@ -117,7 +117,7 @@ def test_remove_url_as_utub_member_no_tags(
         URL_SUCCESS.UTUB_ID : Integer representing the UTub ID where the URL was removed from,
         URL_SUCCESS.URL : Serialized information of the URL that was removed, as follows:
         {
-            "urlID": Integer representing ID of the URL,
+            "utubUrlID": Integer representing ID of the URL,
             "urlString": String representing the URL itself,
             "urlTitle": String representing the title associated with the URL,
         }
@@ -166,7 +166,7 @@ def test_remove_url_as_utub_member_no_tags(
     assert remove_url_response_json[STD_JSON.MESSAGE] == URL_SUCCESS.URL_REMOVED
     assert int(remove_url_response_json[URL_SUCCESS.UTUB_ID]) == current_user_utub_id
     assert (
-        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_ID]
+        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.UTUB_URL_ID]
         == current_url_in_utub.id
     )
     assert (
@@ -368,7 +368,7 @@ def test_remove_url_as_utub_creator_with_tag(
         URL_SUCCESS.UTUB_ID : Integer representing the UTub ID where the URL was removed from,
         URL_SUCCESS.URL : Serialized information of the URL that was removed, as follows:
         {
-            "urlID": Integer representing ID of the URL,
+            "utubUrlID": Integer representing ID of the URL,
             "urlString": String representing the URL itself,
             "urlTitle": String representing the title associated with the URL,
         }
@@ -429,7 +429,7 @@ def test_remove_url_as_utub_creator_with_tag(
         int(remove_url_response_json[URL_SUCCESS.UTUB_ID]) == utub_id_to_remove_url_from
     )
     assert (
-        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_ID]
+        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.UTUB_URL_ID]
         == url_id_to_remove
     )
     assert (
@@ -484,7 +484,7 @@ def test_remove_url_as_utub_member_with_tags(
         URL_SUCCESS.UTUB_ID : Integer representing the UTub ID where the URL was removed from,
         URL_SUCCESS.URL : Serialized information of the URL that was removed, as follows:
         {
-            "urlID": Integer representing ID of the URL,
+            "utubUrlID": Integer representing ID of the URL,
             "urlString": String representing the URL itself,
             "urlTitle": String representing the title associated with the URL,
         }
@@ -548,7 +548,7 @@ def test_remove_url_as_utub_member_with_tags(
         int(remove_url_response_json[URL_SUCCESS.UTUB_ID]) == utub_id_to_remove_url_from
     )
     assert (
-        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.URL_ID]
+        remove_url_response_json[URL_SUCCESS.URL][URL_SUCCESS.UTUB_URL_ID]
         == url_id_to_remove
     )
     assert (

--- a/tests/integration/utuburls/test_update_url_route.py
+++ b/tests/integration/utuburls/test_update_url_route.py
@@ -5,6 +5,7 @@ import pytest
 from src.models.urls import Urls
 from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
+from src.models.utub_members import Member_Role, Utub_Members
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
 from src.utils.strings.form_strs import URL_FORM
@@ -46,8 +47,8 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
 
     NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Verify URL to modify to is not already in database
@@ -55,29 +56,22 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
         assert Urls.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
         current_title = url_in_this_utub.url_title
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.url_id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_in_this_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -88,7 +82,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_in_this_utub.url_id,
+            utub_url_id=url_in_this_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -99,10 +93,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert (
-        int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        != url_in_this_utub.url_id
-    )
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub.id
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == validated_new_fresh_url
     )
@@ -111,41 +102,41 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls + 1 == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls + 1 == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity no longer exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub.id,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_title == current_title,
+                Utub_Urls.url_id == current_url_id,
+            ).count()
             == 0
         )
 
         # Assert newest entity exist
+        new_url_object: Urls = Urls.query.filter(
+            Urls.url_string == validated_new_fresh_url
+        ).first()
         new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=new_url_id,
-                    url_title=current_title,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub.id,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_title == current_title,
+                Utub_Urls.url_id == new_url_object.id,
+            ).count()
             == 1
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=new_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == new_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
@@ -184,32 +175,23 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
 
         # Verify URL to modify to is not already in database
         validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
-        assert Urls.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
         url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
             utub_id=utub_member_of.id, user_id=current_user.id
         ).first()
         current_title = url_in_this_utub.url_title
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.url_id
 
         # Find associated tags with this url
         associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
+            utub_id=utub_member_of.id, utub_url_id=url_in_this_utub.id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -220,7 +202,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_member_of.id,
-            url_id=url_in_this_utub.url_id,
+            utub_url_id=url_in_this_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -231,10 +213,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert (
-        int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        != url_in_this_utub.url_id
-    )
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub.id
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == validated_new_fresh_url
     )
@@ -242,41 +221,41 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls + 1 == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls + 1 == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity no longer exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == 0
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub.id,
+                Utub_Urls.utub_id == utub_member_of.id,
+                Utub_Urls.url_title == current_title,
+                Utub_Urls.url_id == current_url_id,
+            ).first()
+            is None
         )
 
         # Assert newest entity exist
+        new_url_object: Urls = Urls.query.filter(
+            Urls.url_string == validated_new_fresh_url
+        ).first()
         new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=new_url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == new_url_id,
+                Utub_Urls.utub_id == utub_member_of.id,
+                Utub_Urls.url_title == current_title,
+                Utub_Urls.url_id == new_url_object.id,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=new_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == new_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_previously_added_url_as_utub_creator(
@@ -307,48 +286,36 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Grab URL that already exists in database and is not in this UTub
         url_not_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id != utub_creator_of.id
         ).first()
-        assert (
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=url_not_in_utub.url_id
-            ).first()
-            is None
-        )
         url_string_of_url_not_in_utub = url_not_in_utub.standalone_url.url_string
-        url_id_of_url_not_in_utub = url_not_in_utub.url_id
+        url_id_of_url_not_in_utub = url_not_in_utub.id
 
         # Grab URL that already exists in this UTub
-        url_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
-        id_of_url_in_utub = url_in_utub.url_id
+        id_of_url_in_utub = url_in_utub.id
+        id_of_url_object_in_utub = url_in_utub.url_id
         current_title = url_in_utub.url_title
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_in_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Find associated tags with this url already in UTub
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_in_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_utub.id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -359,7 +326,7 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_in_utub.url_id,
+            utub_url_id=id_of_url_in_utub,
         ),
         data=edit_url_string_form,
     )
@@ -370,11 +337,7 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) != id_of_url_in_utub
-    assert (
-        int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        == url_id_of_url_not_in_utub
-    )
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == id_of_url_in_utub
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING]
         == url_string_of_url_not_in_utub
@@ -383,40 +346,37 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity no longer exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=id_of_url_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 0
+            Utub_Urls.query.filter(
+                Utub_Urls.id == id_of_url_in_utub,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_title == current_title,
+                Utub_Urls.url_id == id_of_url_object_in_utub,
+            ).first()
+            is None
         )
 
         # Assert newest entity exist
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=url_id_of_url_not_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == id_of_url_in_utub,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_title == current_title,
+                Utub_Urls.url_id == url_id_of_url_not_in_utub,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=url_id_of_url_not_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_previously_added_url_as_url_adder(
@@ -446,47 +406,33 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        all_utubs_urls: list[Utub_Urls] = Utub_Urls.query.all()
-        for utub_urls in all_utubs_urls:
-            utub: Utubs = utub_urls.utub
-            utub_members = [member.user_id for member in utub.members]
-
-            user_in_utub: bool = current_user.id in utub_members
-            user_added_url: bool = current_user.id == utub_urls.user_id
-            user_not_creator: bool = current_user.id != utub.utub_creator
-
-            if user_in_utub and user_added_url and user_not_creator:
-                utub_member_of = utub
-                url_in_this_utub = utub_urls
-                url_id_of_url_in_this_utub = url_in_this_utub.url_id
-                current_title = url_in_this_utub.url_title
-                break
+        utub_member_of_not_created_utub: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role != Member_Role.CREATOR
+        ).first()
+        utub_id = utub_member_of_not_created_utub.utub_id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.user_id == current_user.id, Utub_Urls.utub_id == utub_id
+        ).first()
+        current_title = url_in_this_utub.url_title
+        current_url_id = url_in_this_utub.url_id
+        url_in_this_utub_id = url_in_this_utub.id
 
         # Get a URL that isn't in this UTub
         url_not_in_utub: Utub_Urls = Utub_Urls.query.filter(
-            Utub_Urls.user_id != current_user.id, Utub_Urls.utub_id != utub_member_of.id
+            Utub_Urls.user_id != current_user.id, Utub_Urls.utub_id != utub_id
         ).first()
         url_string_of_url_not_in_utub: str = url_not_in_utub.standalone_url.url_string
         url_id_of_url_not_in_utub = url_not_in_utub.url_id
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Find associated tags with this url
         associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
+            utub_id=utub_id, utub_url_id=url_in_this_utub.id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -496,8 +442,8 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
     edit_url_string_form = client.patch(
         url_for(
             ROUTES.URLS.EDIT_URL,
-            utub_id=utub_member_of.id,
-            url_id=url_in_this_utub.url_id,
+            utub_id=utub_id,
+            utub_url_id=url_in_this_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -508,10 +454,7 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert (
-        int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        == url_id_of_url_not_in_utub
-    )
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub_id
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING]
         == url_string_of_url_not_in_utub
@@ -520,40 +463,37 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity no longer exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_id_of_url_in_this_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 0
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub_id,
+                Utub_Urls.utub_id == utub_id,
+                Utub_Urls.url_id == current_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is None
         )
 
         # Assert newest entity exist
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_id_of_url_not_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub_id,
+                Utub_Urls.utub_id == utub_id,
+                Utub_Urls.url_id == url_id_of_url_not_in_utub,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=url_id_of_url_not_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_same_url_as_utub_creator(
@@ -584,39 +524,30 @@ def test_update_valid_url_with_same_url_as_utub_creator(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
-
-        # Verify logged in user is creator of this UTub
-        assert utub_creator_of.utub_creator == current_user.id
 
         # Grab URL that already exists in this UTub
-        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
-        id_of_url_in_utub = url_already_in_utub.url_id
+        id_of_url_in_utub = url_already_in_utub.id
         url_in_utub_string: str = url_already_in_utub.standalone_url.url_string
         current_title = url_already_in_utub.url_title
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_already_in_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        url_object_id = url_already_in_utub.url_id
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -627,7 +558,7 @@ def test_update_valid_url_with_same_url_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_already_in_utub.url_id,
+            utub_url_id=id_of_url_in_utub,
         ),
         data=edit_url_string_form,
     )
@@ -644,28 +575,26 @@ def test_update_valid_url_with_same_url_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=id_of_url_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == id_of_url_in_utub,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_id == url_object_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_same_url_as_url_adder(
@@ -695,52 +624,39 @@ def test_update_valid_url_with_same_url_as_url_adder(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        all_utubs_urls: list[Utub_Urls] = Utub_Urls.query.all()
-        for utub_urls in all_utubs_urls:
-            utub: Utubs = utub_urls.utub
-            utub_members = [member.user_id for member in utub.members]
-
-            user_in_utub: bool = current_user.id in utub_members
-            user_added_url: bool = current_user.id == utub_urls.user_id
-            user_not_creator: bool = current_user.id != utub.utub_creator
-
-            if user_in_utub and user_added_url and user_not_creator:
-                utub_member_of = utub
-                url_in_this_utub = utub_urls
-                url_id_of_url_in_this_utub = url_in_this_utub.url_id
-                current_title = url_in_this_utub.url_title
-                url_string_of_url_in_utub = url_in_this_utub.standalone_url.url_string
-                break
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        utub_member_of_not_created_utub: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role != Member_Role.CREATOR
+        ).first()
+        utub_id = utub_member_of_not_created_utub.utub_id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.user_id == current_user.id, Utub_Urls.utub_id == utub_id
+        ).first()
+        current_title = url_in_this_utub.url_title
+        current_url_string = url_in_this_utub.standalone_url.url_string
+        current_url_id = url_in_this_utub.url_id
+        url_in_this_utub_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
-        URL_FORM.URL_STRING: url_string_of_url_in_utub,
+        URL_FORM.URL_STRING: current_url_string,
     }
 
     edit_url_string_form = client.patch(
         url_for(
             ROUTES.URLS.EDIT_URL,
-            utub_id=utub_member_of.id,
-            url_id=url_id_of_url_in_this_utub,
+            utub_id=utub_id,
+            utub_url_id=url_in_this_utub_id,
         ),
         data=edit_url_string_form,
     )
@@ -751,39 +667,32 @@ def test_update_valid_url_with_same_url_as_url_adder(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.NO_CHANGE
     assert json_response[STD_JSON.MESSAGE] == URL_NO_CHANGE.URL_NOT_MODIFIED
-    assert (
-        int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        == url_id_of_url_in_this_utub
-    )
-    assert (
-        json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == url_string_of_url_in_utub
-    )
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub_id
+    assert json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == current_url_string
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_id_of_url_in_this_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub_id,
+                Utub_Urls.utub_id == utub_id,
+                Utub_Urls.url_id == current_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=url_id_of_url_in_this_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_invalid_url_as_utub_creator(
@@ -809,37 +718,28 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
-
-        # Verify logged in user is creator of this UTub
-        assert utub_creator_of.utub_creator == current_user.id
 
         # Grab URL that already exists in this UTub
-        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
-        id_of_url_in_utub = url_already_in_utub.url_id
+        id_of_url_in_utub = url_already_in_utub.id
         current_title = url_already_in_utub.url_title
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_already_in_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_already_in_utub.url_id
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -850,7 +750,7 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_already_in_utub.url_id,
+            utub_url_id=id_of_url_in_utub,
         ),
         data=edit_url_string_form,
     )
@@ -865,28 +765,25 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=id_of_url_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == id_of_url_in_utub,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_id == current_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter_by(
+            utub_id=utub_creator_of.id, utub_url_id=id_of_url_in_utub
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_invalid_url_as_url_adder(
@@ -912,39 +809,26 @@ def test_update_valid_url_with_invalid_url_as_url_adder(
 
     INVALID_URL = "AAAAA"
     with app.app_context():
-        all_utubs_urls: list[Utub_Urls] = Utub_Urls.query.all()
-        for utub_urls in all_utubs_urls:
-            utub: Utubs = utub_urls.utub
-            utub_members = [member.user_id for member in utub.members]
-
-            user_in_utub: bool = current_user.id in utub_members
-            user_added_url: bool = current_user.id == utub_urls.user_id
-            user_not_creator: bool = current_user.id != utub.utub_creator
-
-            if user_in_utub and user_added_url and user_not_creator:
-                utub_member_of = utub
-                url_in_this_utub = utub_urls
-                url_id_of_url_in_this_utub = url_in_this_utub.url_id
-                current_title = url_in_this_utub.url_title
-                break
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        utub_member_of_not_created_utub: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role != Member_Role.CREATOR
+        ).first()
+        utub_id = utub_member_of_not_created_utub.utub_id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.user_id == current_user.id, Utub_Urls.utub_id == utub_id
+        ).first()
+        current_title = url_in_this_utub.url_title
+        current_url_id = url_in_this_utub.url_id
+        url_in_this_utub_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -954,8 +838,8 @@ def test_update_valid_url_with_invalid_url_as_url_adder(
     edit_url_string_form = client.patch(
         url_for(
             ROUTES.URLS.EDIT_URL,
-            utub_id=utub_member_of.id,
-            url_id=url_id_of_url_in_this_utub,
+            utub_id=utub_id,
+            utub_url_id=url_in_this_utub_id,
         ),
         data=edit_url_string_form,
     )
@@ -970,28 +854,26 @@ def test_update_valid_url_with_invalid_url_as_url_adder(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_id_of_url_in_this_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub_id,
+                Utub_Urls.utub_id == utub_id,
+                Utub_Urls.url_id == current_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=url_id_of_url_in_this_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_empty_url_as_utub_creator(
@@ -1022,34 +904,28 @@ def test_update_valid_url_with_empty_url_as_utub_creator(
 
     NEW_URL = ""
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Grab URL that already exists in this UTub
-        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
-        id_of_url_in_utub = url_already_in_utub.url_id
+        id_of_url_in_utub = url_already_in_utub.id
         current_title = url_already_in_utub.url_title
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_already_in_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_already_in_utub.url_id
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
-        ).all()
+        associated_tags: int = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == url_already_in_utub.id,
+        ).count()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1060,7 +936,7 @@ def test_update_valid_url_with_empty_url_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_already_in_utub.url_id,
+            utub_url_id=id_of_url_in_utub,
         ),
         data=edit_url_string_form,
     )
@@ -1079,28 +955,29 @@ def test_update_valid_url_with_empty_url_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=id_of_url_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == id_of_url_in_utub,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_id == current_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert (
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_creator_of.id,
+                Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
+            ).count()
+            == associated_tags
+        )
 
 
 def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
@@ -1134,34 +1011,25 @@ def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
 
         # Verify URL to modify to is not already in database
         validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
-        assert Urls.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL in this UTub
         url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_member_of.id, Utub_Urls.user_id != current_user.id
         ).first()
         current_title = url_in_this_utub.url_title
+        url_in_this_utub_id = url_in_this_utub.id
         url_in_utub_serialized_originally = url_in_this_utub.serialized_on_string_edit
-        original_user_id = url_in_this_utub.user_id
         original_url_id = url_in_this_utub.url_id
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1172,7 +1040,7 @@ def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_member_of.id,
-            url_id=url_in_this_utub.url_id,
+            utub_url_id=url_in_this_utub_id,
         ),
         data=edit_url_string_form,
     )
@@ -1186,51 +1054,32 @@ def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
     assert int(json_response[STD_JSON.ERROR_CODE]) == 1
 
     with app.app_context():
-        # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        # Assert database is consistent after not modifying URL
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == num_of_url_utub_associations
-        )
+        utub_url_object: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.id == url_in_this_utub_id,
+            Utub_Urls.utub_id == utub_member_of.id,
+            Utub_Urls.url_id == original_url_id,
+            Utub_Urls.url_title == current_title,
+        ).first()
 
+        # Verify original entry still exists
+        assert utub_url_object is not None
+
+        # Verify original serialization still exists
         assert (
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=original_url_id,
-                user_id=original_user_id,
-            )
-            .first()
-            .serialized_on_string_edit
+            utub_url_object.serialized_on_string_edit
             == url_in_utub_serialized_originally
         )
 
-        # Assert previous entity exists
-        assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
-        )
-
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_with_fresh_valid_url_as_other_utub_member(
@@ -1238,8 +1087,8 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
     login_first_user_without_register,
 ):
     """
-    GIVEN a valid member of a UTub that has members, URLs, and tags associated with each URL
-    WHEN the member attempts to modify the URL title and change the URL for a URL of another UTub, via a PATCH to:
+    GIVEN a valid member of another UTub that has members, URLs, and tags associated with each URL
+    WHEN the member attempts to modify the URL title and change the URL for a URL of UTub they are not a member of, via a PATCH to:
         "/utubs/<int:utub_id>/urls/<int:url_id>" with valid form data, following this format:
             URL_FORM.CSRF_TOKEN: String containing CSRF token for validation
             URL_FORM.URL_STRING: String of URL to add
@@ -1261,51 +1110,31 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
         # Get UTub this user is not a member of
         utub_user_not_member_of: Utubs = Utubs.query.get(3)
 
-        all_utubs: list[Utubs] = Utubs.query.all()
-        for utub in all_utubs:
-            assert current_user.id != utub.utub_creator
-
-        # Verify logged in user is not member of this UTub
-        assert current_user.id not in [
-            chosen_utub_member.user_id
-            for chosen_utub_member in utub_user_not_member_of.members
-        ]
-
         # Verify URL to modify to is not already in database
         validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
-        assert Urls.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL not in this UTub
         url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_user_not_member_of.id
         ).first()
-        current_title = url_in_this_utub.url_title
         url_in_utub_serialized_originally = url_in_this_utub.serialized_on_string_edit
         original_user_id = url_in_this_utub.user_id
-        original_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_user_not_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        original_url_id = url_in_this_utub.id
 
         # Get number of URLs in this UTub
-        num_of_urls_in_utub = len(
-            Utub_Urls.query.filter_by(utub_id=utub_user_not_member_of.id).all()
-        )
+        num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_not_member_of.id
+        ).count()
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_user_not_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1316,7 +1145,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_user_not_member_of.id,
-            url_id=url_in_this_utub.url_id,
+            utub_url_id=url_in_this_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -1331,55 +1160,35 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         assert (
-            len(Utub_Urls.query.filter_by(utub_id=utub_user_not_member_of.id).all())
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == utub_user_not_member_of.id
+            ).count()
             == num_of_urls_in_utub
         )
 
         # Assert url-utub association hasn't changed
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_user_not_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == num_of_url_utub_associations
-        )
-        assert (
-            Utub_Urls.query.filter_by(
-                utub_id=utub_user_not_member_of.id,
-                url_id=original_url_id,
-                user_id=original_user_id,
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_in_this_utub.id,
+                Utub_Urls.utub_id == utub_user_not_member_of.id,
+                Utub_Urls.url_id == original_url_id,
+                Utub_Urls.user_id == original_user_id,
             )
             .first()
             .serialized_on_string_edit
             == url_in_utub_serialized_originally
         )
 
-        # Assert previous entity exists
-        assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_user_not_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
-        )
-
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_user_not_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_with_fresh_valid_url_as_other_utub_creator(
@@ -1407,33 +1216,13 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
     NEW_FRESH_URL = "yahoo.com"
     with app.app_context():
         # Get UTub this user is not a member of
-        all_utubs: list[Utubs] = Utubs.query.all()
-        i = 0
-        while (
-            current_user.id
-            in [utub_member.user_id for utub_member in all_utubs[i].members]
-            and current_user.id == all_utubs[i].utub_creator
-        ):
-            i += 1
+        utub_member_user_not_member_of: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.user_id != current_user.id
+        ).first()
+        utub_user_not_member_of: Utubs = utub_member_user_not_member_of.to_utub
 
-        utub_user_not_member_of = all_utubs[i]
-
-        # Verify logged in user is not member of this UTub
-        assert current_user.id not in [
-            chosen_utub_member.user_id
-            for chosen_utub_member in utub_user_not_member_of.members
-        ]
-
-        # Verify user is creator of a UTub
-        i = 0
-        while all_utubs[i].utub_creator != current_user.id:
-            i += 1
-
-        assert all_utubs[i].utub_creator == current_user.id
-
-        # Verify URL to modify to is not already in database
+        # Use URL not already in database
         validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
-        assert Urls.query.filter_by(url_string=validated_new_fresh_url).first() is None
 
         # Get the URL not in this UTub
         url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
@@ -1444,28 +1233,20 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
         original_user_id = url_in_this_utub.user_id
         original_url_id = url_in_this_utub.url_id
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_user_not_member_of.id,
-                url_id=url_in_this_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Get number of URLs in this UTub
-        num_of_urls_in_utub = len(
-            Utub_Urls.query.filter_by(utub_id=utub_user_not_member_of.id).all()
-        )
+        num_of_urls_in_utub = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_not_member_of.id
+        ).count()
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_user_not_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1476,7 +1257,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_user_not_member_of.id,
-            url_id=url_in_this_utub.url_id,
+            utub_url_id=url_in_this_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -1491,55 +1272,38 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         assert (
-            len(Utub_Urls.query.filter_by(utub_id=utub_user_not_member_of.id).all())
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == utub_user_not_member_of.id
+            ).count()
             == num_of_urls_in_utub
         )
 
+        utub_url_object: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.id == url_in_this_utub.id,
+            Utub_Urls.utub_id == utub_user_not_member_of.id,
+            Utub_Urls.url_id == original_url_id,
+            Utub_Urls.user_id == original_user_id,
+            Utub_Urls.url_title == current_title,
+        ).first()
+
         # Assert url-utub association hasn't changed
+        assert utub_url_object is not None
+
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_user_not_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == num_of_url_utub_associations
-        )
-        assert (
-            Utub_Urls.query.filter_by(
-                utub_id=utub_user_not_member_of.id,
-                url_id=original_url_id,
-                user_id=original_user_id,
-            )
-            .first()
-            .serialized_on_string_edit
+            utub_url_object.serialized_on_string_edit
             == url_in_utub_serialized_originally
         )
 
-        # Assert previous entity exists
-        assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_user_not_member_of.id,
-                    url_id=url_in_this_utub.url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
-        )
-
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_user_not_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_missing_url_field_as_utub_creator(
@@ -1567,34 +1331,28 @@ def test_update_valid_url_with_missing_url_field_as_utub_creator(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Grab URL that already exists in this UTub
-        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
-        id_of_url_in_utub = url_already_in_utub.url_id
+        id_of_url_in_utub = url_already_in_utub.id
+        original_url_id = url_already_in_utub.url_id
         current_title = url_already_in_utub.url_title
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_already_in_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Find associated tags with this url already in UTub
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == url_already_in_utub.id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1604,7 +1362,7 @@ def test_update_valid_url_with_missing_url_field_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_already_in_utub.url_id,
+            utub_url_id=url_already_in_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -1623,28 +1381,26 @@ def test_update_valid_url_with_missing_url_field_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=id_of_url_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == url_already_in_utub.id,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_id == original_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_with_valid_url_missing_csrf(
@@ -1664,34 +1420,28 @@ def test_update_valid_url_with_valid_url_missing_csrf(
 
     NEW_URL = "yahoo.com"
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Grab URL that already exists in this UTub
-        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_already_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
-        id_of_url_in_utub = url_already_in_utub.url_id
+        id_of_url_in_utub = url_already_in_utub.id
+        original_url_id = url_already_in_utub.url_id
         current_title = url_already_in_utub.url_title
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=url_already_in_utub.url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Find associated tags with this url already in UTub
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == url_already_in_utub.id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_form = {
         URL_FORM.URL_STRING: NEW_URL,
@@ -1701,7 +1451,7 @@ def test_update_valid_url_with_valid_url_missing_csrf(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_already_in_utub.url_id,
+            utub_url_id=url_already_in_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -1712,28 +1462,26 @@ def test_update_valid_url_with_valid_url_missing_csrf(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert previous entity exists
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_creator_of.id,
-                    url_id=id_of_url_in_utub,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
+            Utub_Urls.query.filter(
+                Utub_Urls.id == id_of_url_in_utub,
+                Utub_Urls.utub_id == utub_creator_of.id,
+                Utub_Urls.url_id == original_url_id,
+                Utub_Urls.url_title == current_title,
+            ).first()
+            is not None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
+        ).count() == len(associated_tags)
 
 
 def test_update_valid_url_updates_utub_last_updated(
@@ -1752,8 +1500,8 @@ def test_update_valid_url_updates_utub_last_updated(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
         initial_last_updated = utub_creator_of.last_updated
 
@@ -1761,17 +1509,12 @@ def test_update_valid_url_updates_utub_last_updated(
         url_not_in_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id != utub_creator_of.id
         ).first()
-        assert (
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=url_not_in_utub.url_id
-            ).first()
-            is None
-        )
         url_string_of_url_not_in_utub: str = url_not_in_utub.standalone_url.url_string
 
         # Grab URL that already exists in this UTub
-        url_in_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, user_id=current_user.id
+        url_in_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id,
+            Utub_Urls.user_id == current_user.id,
         ).first()
 
     edit_url_string_form = {
@@ -1783,7 +1526,7 @@ def test_update_valid_url_updates_utub_last_updated(
         url_for(
             ROUTES.URLS.EDIT_URL,
             utub_id=utub_creator_of.id,
-            url_id=url_in_utub.url_id,
+            utub_url_id=url_in_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -1812,20 +1555,14 @@ def test_update_valid_url_with_invalid_url_does_not_update_utub_last_updated(
 
     INVALID_URL = "AAAAA"
     with app.app_context():
-        all_utubs_urls: list[Utub_Urls] = Utub_Urls.query.all()
-        for utub_urls in all_utubs_urls:
-            utub: Utubs = utub_urls.utub
-            utub_members = [member.user_id for member in utub.members]
-
-            user_in_utub: bool = current_user.id in utub_members
-            user_added_url: bool = current_user.id == utub_urls.user_id
-            user_not_creator: bool = current_user.id != utub.utub_creator
-
-            if user_in_utub and user_added_url and user_not_creator:
-                utub_member_of = utub
-                url_in_this_utub = utub_urls
-                url_id_of_url_in_this_utub = url_in_this_utub.url_id
-                break
+        utub_member_of_not_created_utub: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.member_role != Member_Role.CREATOR
+        ).first()
+        utub_member_of: Utubs = utub_member_of_not_created_utub.to_utub
+        utub_id = utub_member_of_not_created_utub.utub_id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.user_id == current_user.id, Utub_Urls.utub_id == utub_id
+        ).first()
 
         initial_last_updated = utub_member_of.last_updated
 
@@ -1837,8 +1574,8 @@ def test_update_valid_url_with_invalid_url_does_not_update_utub_last_updated(
     edit_url_string_form = client.patch(
         url_for(
             ROUTES.URLS.EDIT_URL,
-            utub_id=utub_member_of.id,
-            url_id=url_id_of_url_in_this_utub,
+            utub_id=utub_id,
+            utub_url_id=url_in_this_utub.id,
         ),
         data=edit_url_string_form,
     )
@@ -1846,5 +1583,5 @@ def test_update_valid_url_with_invalid_url_does_not_update_utub_last_updated(
     assert edit_url_string_form.status_code == 400
 
     with app.app_context():
-        current_utub: Utubs = Utubs.query.get(utub_member_of.id)
+        current_utub: Utubs = Utubs.query.get(utub_id)
         assert current_utub.last_updated == initial_last_updated

--- a/tests/integration/utuburls/test_update_url_route.py
+++ b/tests/integration/utuburls/test_update_url_route.py
@@ -93,7 +93,10 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub.id
+    assert (
+        int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID])
+        == url_in_this_utub.id
+    )
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == validated_new_fresh_url
     )
@@ -121,10 +124,10 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
         new_url_object: Urls = Urls.query.filter(
             Urls.url_string == validated_new_fresh_url
         ).first()
-        new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
+        new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID])
         assert (
             Utub_Urls.query.filter(
-                Utub_Urls.id == url_in_this_utub.id,
+                Utub_Urls.id == new_url_id,
                 Utub_Urls.utub_id == utub_creator_of.id,
                 Utub_Urls.url_title == current_title,
                 Utub_Urls.url_id == new_url_object.id,
@@ -213,7 +216,10 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub.id
+    assert (
+        int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID])
+        == url_in_this_utub.id
+    )
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == validated_new_fresh_url
     )
@@ -240,7 +246,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
         new_url_object: Urls = Urls.query.filter(
             Urls.url_string == validated_new_fresh_url
         ).first()
-        new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
+        new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID])
         assert (
             Utub_Urls.query.filter(
                 Utub_Urls.id == new_url_id,
@@ -337,7 +343,9 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == id_of_url_in_utub
+    assert (
+        int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID]) == id_of_url_in_utub
+    )
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING]
         == url_string_of_url_not_in_utub
@@ -454,7 +462,10 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub_id
+    assert (
+        int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID])
+        == url_in_this_utub_id
+    )
     assert (
         json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING]
         == url_string_of_url_not_in_utub
@@ -569,7 +580,9 @@ def test_update_valid_url_with_same_url_as_utub_creator(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.NO_CHANGE
     assert json_response[STD_JSON.MESSAGE] == URL_NO_CHANGE.URL_NOT_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == id_of_url_in_utub
+    assert (
+        int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID]) == id_of_url_in_utub
+    )
     assert json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == url_in_utub_string
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 
@@ -667,7 +680,10 @@ def test_update_valid_url_with_same_url_as_url_adder(
     json_response = edit_url_string_form.json
     assert json_response[STD_JSON.STATUS] == STD_JSON.NO_CHANGE
     assert json_response[STD_JSON.MESSAGE] == URL_NO_CHANGE.URL_NOT_MODIFIED
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == url_in_this_utub_id
+    assert (
+        int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID])
+        == url_in_this_utub_id
+    )
     assert json_response[URL_SUCCESS.URL][URL_FORM.URL_STRING] == current_url_string
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 

--- a/tests/integration/utuburls/test_update_url_route.py
+++ b/tests/integration/utuburls/test_update_url_route.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 import pytest
 
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
@@ -70,12 +70,12 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_in_this_utub.url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -112,7 +112,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls + 1 == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity no longer exists
@@ -142,7 +142,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=new_url_id
             ).all()
         ) == len(associated_tags)
@@ -202,12 +202,12 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -243,7 +243,7 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls + 1 == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity no longer exists
@@ -273,7 +273,9 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(utub_id=utub_member_of.id, url_id=new_url_id).all()
+            Utub_Url_Tags.query.filter_by(
+                utub_id=utub_member_of.id, url_id=new_url_id
+            ).all()
         ) == len(associated_tags)
 
 
@@ -339,12 +341,12 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_in_utub.url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -382,7 +384,7 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity no longer exists
@@ -411,7 +413,7 @@ def test_update_valid_url_with_previously_added_url_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=url_id_of_url_not_in_utub
             ).all()
         ) == len(associated_tags)
@@ -477,12 +479,12 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -519,7 +521,7 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity no longer exists
@@ -548,7 +550,7 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_member_of.id, url_id=url_id_of_url_not_in_utub
             ).all()
         ) == len(associated_tags)
@@ -607,12 +609,12 @@ def test_update_valid_url_with_same_url_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -643,7 +645,7 @@ def test_update_valid_url_with_same_url_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -660,7 +662,7 @@ def test_update_valid_url_with_same_url_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
             ).all()
         ) == len(associated_tags)
@@ -720,12 +722,12 @@ def test_update_valid_url_with_same_url_as_url_adder(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -761,7 +763,7 @@ def test_update_valid_url_with_same_url_as_url_adder(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -778,7 +780,7 @@ def test_update_valid_url_with_same_url_as_url_adder(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_member_of.id, url_id=url_id_of_url_in_this_utub
             ).all()
         ) == len(associated_tags)
@@ -831,11 +833,11 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -864,7 +866,7 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -881,7 +883,7 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
             ).all()
         ) == len(associated_tags)
@@ -936,11 +938,11 @@ def test_update_valid_url_with_invalid_url_as_url_adder(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -969,7 +971,7 @@ def test_update_valid_url_with_invalid_url_as_url_adder(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -986,7 +988,7 @@ def test_update_valid_url_with_invalid_url_as_url_adder(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_member_of.id, url_id=url_id_of_url_in_this_utub
             ).all()
         ) == len(associated_tags)
@@ -1041,11 +1043,11 @@ def test_update_valid_url_with_empty_url_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1078,7 +1080,7 @@ def test_update_valid_url_with_empty_url_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -1095,7 +1097,7 @@ def test_update_valid_url_with_empty_url_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
             ).all()
         ) == len(associated_tags)
@@ -1153,11 +1155,11 @@ def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1186,7 +1188,7 @@ def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         assert (
@@ -1225,7 +1227,7 @@ def test_update_url_string_with_fresh_valid_url_as_another_current_utub_member(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_member_of.id, url_id=url_in_this_utub.url_id
             ).all()
         ) == len(associated_tags)
@@ -1297,11 +1299,11 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
         )
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1330,7 +1332,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         assert (
@@ -1374,7 +1376,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_member(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
             ).all()
         ) == len(associated_tags)
@@ -1457,11 +1459,11 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
         )
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1490,7 +1492,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         assert (
@@ -1534,7 +1536,7 @@ def test_update_url_with_fresh_valid_url_as_other_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_user_not_member_of.id, url_id=url_in_this_utub.url_id
             ).all()
         ) == len(associated_tags)
@@ -1586,11 +1588,11 @@ def test_update_valid_url_with_missing_url_field_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1622,7 +1624,7 @@ def test_update_valid_url_with_missing_url_field_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -1639,7 +1641,7 @@ def test_update_valid_url_with_missing_url_field_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
             ).all()
         ) == len(associated_tags)
@@ -1683,11 +1685,11 @@ def test_update_valid_url_with_valid_url_missing_csrf(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url already in UTub
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=url_already_in_utub.url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1711,7 +1713,7 @@ def test_update_valid_url_with_valid_url_missing_csrf(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert previous entity exists
@@ -1728,7 +1730,7 @@ def test_update_valid_url_with_valid_url_missing_csrf(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=id_of_url_in_utub
             ).all()
         ) == len(associated_tags)

--- a/tests/integration/utuburls/test_update_url_title_route.py
+++ b/tests/integration/utuburls/test_update_url_title_route.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 import pytest
 
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.utils.all_routes import ROUTES
@@ -67,12 +67,12 @@ def test_update_url_title_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=current_url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -103,7 +103,7 @@ def test_update_url_title_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
@@ -114,7 +114,7 @@ def test_update_url_title_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=current_url_id
             ).all()
         ) == len(associated_tags)
@@ -172,12 +172,12 @@ def test_update_url_title_url_adder(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=current_url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -209,7 +209,7 @@ def test_update_url_title_url_adder(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert entity exists
@@ -227,7 +227,9 @@ def test_update_url_title_url_adder(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(utub_id=utub_member_of.id, url_id=new_url_id).all()
+            Utub_Url_Tags.query.filter_by(
+                utub_id=utub_member_of.id, url_id=new_url_id
+            ).all()
         ) == len(associated_tags)
 
 
@@ -281,12 +283,12 @@ def test_update_url_title_with_same_title_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=current_url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -317,7 +319,7 @@ def test_update_url_title_with_same_title_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
@@ -328,7 +330,7 @@ def test_update_url_title_with_same_title_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=current_url_id
             ).all()
         ) == len(associated_tags)
@@ -385,12 +387,12 @@ def test_update_url_title_with_same_title_url_adder(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=current_url_id
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -422,7 +424,7 @@ def test_update_url_title_with_same_title_url_adder(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert entity exists
@@ -440,7 +442,9 @@ def test_update_url_title_with_same_title_url_adder(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(utub_id=utub_member_of.id, url_id=new_url_id).all()
+            Utub_Url_Tags.query.filter_by(
+                utub_id=utub_member_of.id, url_id=new_url_id
+            ).all()
         ) == len(associated_tags)
 
 
@@ -491,11 +495,11 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_member_of.id, url_id=current_url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -525,7 +529,7 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
     with app.app_context():
         # Assert database is consistent after not modifying URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         # Assert entity does not exist
@@ -542,7 +546,7 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_member_of.id, url_id=current_url_id
             ).all()
         ) == len(associated_tags)
@@ -598,11 +602,11 @@ def test_update_url_title_with_empty_title_as_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=current_url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -635,7 +639,7 @@ def test_update_url_title_with_empty_title_as_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
@@ -646,7 +650,7 @@ def test_update_url_title_with_empty_title_as_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=current_url_id
             ).all()
         ) == len(associated_tags)
@@ -701,11 +705,11 @@ def test_update_url_title_as_member_of_other_utub(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_id, url_id=current_url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -734,7 +738,7 @@ def test_update_url_title_as_member_of_other_utub(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
@@ -745,7 +749,7 @@ def test_update_url_title_as_member_of_other_utub(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(utub_id=utub_id, url_id=current_url_id).all()
+            Utub_Url_Tags.query.filter_by(utub_id=utub_id, url_id=current_url_id).all()
         ) == len(associated_tags)
 
 
@@ -797,11 +801,11 @@ def test_update_url_title_with_missing_title_field_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=current_url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -833,7 +837,7 @@ def test_update_url_title_with_missing_title_field_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
@@ -844,7 +848,7 @@ def test_update_url_title_with_missing_title_field_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=current_url_id
             ).all()
         ) == len(associated_tags)
@@ -890,11 +894,11 @@ def test_update_url_title_with_missing_csrf_field_utub_creator(
         assert num_of_url_utub_associations == 1
 
         # Find associated tags with this url
-        associated_tags: list[Url_Tags] = Url_Tags.query.filter_by(
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
             utub_id=utub_creator_of.id, url_id=current_url_id
         ).all()
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -915,7 +919,7 @@ def test_update_url_title_with_missing_csrf_field_utub_creator(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
         new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
@@ -926,7 +930,7 @@ def test_update_url_title_with_missing_csrf_field_utub_creator(
 
         # Check associated tags
         assert len(
-            Url_Tags.query.filter_by(
+            Utub_Url_Tags.query.filter_by(
                 utub_id=utub_creator_of.id, url_id=current_url_id
             ).all()
         ) == len(associated_tags)
@@ -961,7 +965,7 @@ def test_update_url_title_of_nonexistent_url(
         # Get the URL of another UTub
         NONEXISTENT_URL_ID = 999
 
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -987,7 +991,7 @@ def test_update_url_title_of_nonexistent_url(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
 
@@ -1017,7 +1021,7 @@ def test_update_url_title_in_nonexistent_utub(
     NONEXISTENT_URL_ID = 999
 
     with app.app_context():
-        num_of_url_tag_assocs = len(Url_Tags.query.all())
+        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
         num_of_urls = len(Urls.query.all())
         num_of_url_utubs_assocs = len(Utub_Urls.query.all())
 
@@ -1043,7 +1047,7 @@ def test_update_url_title_in_nonexistent_utub(
     with app.app_context():
         # Assert database is consistent after newly modified URL
         assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Url_Tags.query.all())
+        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
         assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
 
 

--- a/tests/integration/utuburls/test_update_url_title_route.py
+++ b/tests/integration/utuburls/test_update_url_title_route.py
@@ -46,35 +46,26 @@ def test_update_url_title_utub_creator(
 
     NEW_TITLE = "This is my newest facebook.com!"
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
-        current_title = url_in_this_utub.url_title
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -85,7 +76,7 @@ def test_update_url_title_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -102,22 +93,18 @@ def test_update_url_title_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
-        ).first()
+        new_url_item: Utub_Urls = Utub_Urls.query.get(current_url_id)
         assert new_url_item.url_title == NEW_TITLE
-        assert new_url_item.url_id == current_url_id
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=current_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_url_adder(
@@ -155,31 +142,22 @@ def test_update_url_title_url_adder(
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_member_of.id, user_id=current_user.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_member_of.id, Utub_Urls.user_id == current_user.id
         ).first()
-        current_title = url_in_this_utub.url_title
         current_url: str = url_in_this_utub.standalone_url.url_string
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -191,7 +169,7 @@ def test_update_url_title_url_adder(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_member_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -208,29 +186,19 @@ def test_update_url_title_url_adder(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert entity exists
-        new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=new_url_id,
-                    url_title=NEW_TITLE,
-                ).all()
-            )
-            == 1
-        )
+        utub_url_object: Utub_Urls = Utub_Urls.query.get(current_url_id)
+        assert utub_url_object.url_title == NEW_TITLE
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=new_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_with_same_title_utub_creator(
@@ -262,35 +230,27 @@ def test_update_url_title_with_same_title_utub_creator(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
         current_title = url_in_this_utub.url_title
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -301,7 +261,7 @@ def test_update_url_title_with_same_title_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -318,22 +278,18 @@ def test_update_url_title_with_same_title_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
-        ).first()
+        new_url_item: Utub_Urls = Utub_Urls.query.get(current_url_id)
         assert new_url_item.url_title == current_title
-        assert new_url_item.url_id == current_url_id
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=current_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_with_same_title_url_adder(
@@ -370,31 +326,23 @@ def test_update_url_title_with_same_title_url_adder(
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_member_of.id, user_id=current_user.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_member_of.id, Utub_Urls.user_id == current_user.id
         ).first()
         current_title = url_in_this_utub.url_title
         current_url = url_in_this_utub.standalone_url.url_string
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -406,7 +354,7 @@ def test_update_url_title_with_same_title_url_adder(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_member_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -423,29 +371,19 @@ def test_update_url_title_with_same_title_url_adder(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert entity exists
-        new_url_id = int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID])
-        assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=new_url_id,
-                    url_title=current_title,
-                ).all()
-            )
-            == 1
-        )
+        utub_url_object: Utub_Urls = Utub_Urls.query.get(current_url_id)
+        assert utub_url_object.url_title == current_title
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=new_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_as_utub_member_not_adder_or_creator(
@@ -481,27 +419,18 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
         url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_member_of.id, Utub_Urls.user_id != current_user.id
         ).first()
-        current_title = url_in_this_utub.url_title
         current_url = url_in_this_utub.standalone_url.url_string
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_member_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -513,7 +442,7 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_member_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -528,28 +457,25 @@ def test_update_url_title_as_utub_member_not_adder_or_creator(
 
     with app.app_context():
         # Assert database is consistent after not modifying URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
         # Assert entity does not exist
         assert (
-            len(
-                Utub_Urls.query.filter_by(
-                    utub_id=utub_member_of.id,
-                    url_id=current_url_id,
-                    url_title=NEW_TITLE,
-                ).all()
-            )
-            == 0
+            Utub_Urls.query.filter(
+                Utub_Urls.id == current_url_id,
+                Utub_Urls.utub_id == utub_member_of.id,
+                Utub_Urls.url_title == NEW_TITLE,
+            ).first()
+            is None
         )
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_member_of.id, url_id=current_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_with_empty_title_as_utub_creator(
@@ -581,34 +507,26 @@ def test_update_url_title_with_empty_title_as_utub_creator(
 
     NEW_TITLE = ""
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
         current_title = url_in_this_utub.url_title
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -619,7 +537,7 @@ def test_update_url_title_with_empty_title_as_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -638,22 +556,18 @@ def test_update_url_title_with_empty_title_as_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
-        ).first()
-        assert new_url_item.url_title == current_title
-        assert new_url_item.url_id == current_url_id
+        utub_url_object: Utub_Urls = Utub_Urls.query.get(current_url_id)
+        assert utub_url_object.url_title == current_title
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=current_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_as_member_of_other_utub(
@@ -682,8 +596,8 @@ def test_update_url_title_as_member_of_other_utub(
 
     NEW_TITLE = "This is my newest facebook.com."
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Get the URL of another UTub
@@ -692,26 +606,18 @@ def test_update_url_title_as_member_of_other_utub(
             Utub_Urls.user_id != current_user.id,
         ).first()
         utub_id = url_not_in_this_utub.utub_id
-        current_url_id = url_not_in_this_utub.url_id
+        current_url_id = url_not_in_this_utub.id
         current_title = url_not_in_this_utub.url_title
 
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
-
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -722,7 +628,7 @@ def test_update_url_title_as_member_of_other_utub(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -737,20 +643,18 @@ def test_update_url_title_as_member_of_other_utub(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_id, url_id=current_url_id
-        ).first()
-        assert new_url_item.url_title == current_title
-        assert new_url_item.url_id == current_url_id
+        utub_url_object: Utub_Urls = Utub_Urls.query.get(current_url_id)
+        assert utub_url_object.url_title == current_title
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(utub_id=utub_id, url_id=current_url_id).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_with_missing_title_field_utub_creator(
@@ -780,34 +684,26 @@ def test_update_url_title_with_missing_title_field_utub_creator(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
         current_title = url_in_this_utub.url_title
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -817,7 +713,7 @@ def test_update_url_title_with_missing_title_field_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -836,22 +732,18 @@ def test_update_url_title_with_missing_title_field_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
-        ).first()
-        assert new_url_item.url_title == current_title
-        assert new_url_item.url_id == current_url_id
+        utub_url_object: Utub_Urls = Utub_Urls.query.get(current_url_id)
+        assert utub_url_object.url_title == current_title
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=current_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_with_missing_csrf_field_utub_creator(
@@ -873,34 +765,26 @@ def test_update_url_title_with_missing_csrf_field_utub_creator(
     client, _, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
         current_title = url_in_this_utub.url_title
-        current_url_id = url_in_this_utub.url_id
-
-        num_of_url_utub_associations = len(
-            Utub_Urls.query.filter_by(
-                utub_id=utub_creator_of.id,
-                url_id=current_url_id,
-                url_title=current_title,
-            ).all()
-        )
-        assert num_of_url_utub_associations == 1
+        current_url_id = url_in_this_utub.id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
         ).all()
 
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {URL_FORM.URL_TITLE: current_title + "AAA"}
 
@@ -908,7 +792,7 @@ def test_update_url_title_with_missing_csrf_field_utub_creator(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -918,22 +802,18 @@ def test_update_url_title_with_missing_csrf_field_utub_creator(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
-        new_url_item: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id, url_id=current_url_id
-        ).first()
-        assert new_url_item.url_title == current_title
-        assert new_url_item.url_id == current_url_id
+        utub_url_object: Utub_Urls = Utub_Urls.query.get(current_url_id)
+        assert utub_url_object.url_title == current_title
 
         # Check associated tags
-        assert len(
-            Utub_Url_Tags.query.filter_by(
-                utub_id=utub_creator_of.id, url_id=current_url_id
-            ).all()
-        ) == len(associated_tags)
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == current_url_id,
+        ).count() == len(associated_tags)
 
 
 def test_update_url_title_of_nonexistent_url(
@@ -955,19 +835,17 @@ def test_update_url_title_of_nonexistent_url(
     """
     client, csrf_token_string, _, app = login_first_user_without_register
 
+    NONEXISTENT_URL_ID = 999
     NEW_TITLE = "This is my newest facebook.com."
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
         utub_id = utub_creator_of.id
 
-        # Get the URL of another UTub
-        NONEXISTENT_URL_ID = 999
-
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -978,7 +856,7 @@ def test_update_url_title_of_nonexistent_url(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_id,
-            url_id=NONEXISTENT_URL_ID,
+            utub_url_id=NONEXISTENT_URL_ID,
         ),
         data=edit_url_string_title_form,
     )
@@ -990,9 +868,9 @@ def test_update_url_title_of_nonexistent_url(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
 
 def test_update_url_title_in_nonexistent_utub(
@@ -1021,9 +899,9 @@ def test_update_url_title_in_nonexistent_utub(
     NONEXISTENT_URL_ID = 999
 
     with app.app_context():
-        num_of_url_tag_assocs = len(Utub_Url_Tags.query.all())
-        num_of_urls = len(Urls.query.all())
-        num_of_url_utubs_assocs = len(Utub_Urls.query.all())
+        num_of_url_tag_assocs = Utub_Url_Tags.query.count()
+        num_of_urls = Urls.query.count()
+        num_of_url_utubs_assocs = Utub_Urls.query.count()
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1034,7 +912,7 @@ def test_update_url_title_in_nonexistent_utub(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=NONEXISTENT_UTUB_ID,
-            url_id=NONEXISTENT_URL_ID,
+            utub_url_id=NONEXISTENT_URL_ID,
         ),
         data=edit_url_string_title_form,
     )
@@ -1046,9 +924,9 @@ def test_update_url_title_in_nonexistent_utub(
 
     with app.app_context():
         # Assert database is consistent after newly modified URL
-        assert num_of_urls == len(Urls.query.all())
-        assert num_of_url_tag_assocs == len(Utub_Url_Tags.query.all())
-        assert num_of_url_utubs_assocs == len(Utub_Urls.query.all())
+        assert num_of_urls == Urls.query.count()
+        assert num_of_url_tag_assocs == Utub_Url_Tags.query.count()
+        assert num_of_url_utubs_assocs == Utub_Urls.query.count()
 
 
 def test_update_url_title_updates_utub_last_updated(
@@ -1067,16 +945,16 @@ def test_update_url_title_updates_utub_last_updated(
 
     NEW_TITLE = "This is my newest facebook.com!"
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
         initial_last_updated = utub_creator_of.last_updated
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
-        current_url_id = url_in_this_utub.url_id
+        current_url_id = url_in_this_utub.id
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1087,7 +965,7 @@ def test_update_url_title_updates_utub_last_updated(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )
@@ -1114,17 +992,17 @@ def test_update_url_title_with_same_title_does_not_update_utub_last_updated(
     client, csrf_token_string, _, app = login_first_user_without_register
 
     with app.app_context():
-        utub_creator_of: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        utub_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
         initial_last_updated = utub_creator_of.last_updated
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_creator_of.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_creator_of.id
         ).first()
         current_title = url_in_this_utub.url_title
-        current_url_id = url_in_this_utub.url_id
+        current_url_id = url_in_this_utub.id
 
     edit_url_string_title_form = {
         URL_FORM.CSRF_TOKEN: csrf_token_string,
@@ -1135,7 +1013,7 @@ def test_update_url_title_with_same_title_does_not_update_utub_last_updated(
         url_for(
             ROUTES.URLS.EDIT_URL_TITLE,
             utub_id=utub_creator_of.id,
-            url_id=current_url_id,
+            utub_url_id=current_url_id,
         ),
         data=edit_url_string_title_form,
     )

--- a/tests/integration/utuburls/test_update_url_title_route.py
+++ b/tests/integration/utuburls/test_update_url_title_route.py
@@ -88,7 +88,7 @@ def test_update_url_title_utub_creator(
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_TITLE_MODIFIED
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TITLE] == NEW_TITLE
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == current_url_id
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID]) == current_url_id
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 
     with app.app_context():
@@ -181,7 +181,7 @@ def test_update_url_title_url_adder(
     assert json_response[STD_JSON.STATUS] == STD_JSON.SUCCESS
     assert json_response[STD_JSON.MESSAGE] == URL_SUCCESS.URL_TITLE_MODIFIED
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TITLE] == NEW_TITLE
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == current_url_id
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID]) == current_url_id
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 
     with app.app_context():
@@ -273,7 +273,7 @@ def test_update_url_title_with_same_title_utub_creator(
     assert json_response[STD_JSON.STATUS] == STD_JSON.NO_CHANGE
     assert json_response[STD_JSON.MESSAGE] == URL_NO_CHANGE.URL_TITLE_NOT_MODIFIED
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TITLE] == current_title
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == current_url_id
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID]) == current_url_id
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 
     with app.app_context():
@@ -366,7 +366,7 @@ def test_update_url_title_with_same_title_url_adder(
     assert json_response[STD_JSON.STATUS] == STD_JSON.NO_CHANGE
     assert json_response[STD_JSON.MESSAGE] == URL_NO_CHANGE.URL_TITLE_NOT_MODIFIED
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TITLE] == current_title
-    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.URL_ID]) == current_url_id
+    assert int(json_response[URL_SUCCESS.URL][MODEL_STRS.UTUB_URL_ID]) == current_url_id
     assert json_response[URL_SUCCESS.URL][MODEL_STRS.URL_TAGS] == associated_tag_ids
 
     with app.app_context():

--- a/tests/models_for_test.py
+++ b/tests/models_for_test.py
@@ -74,21 +74,27 @@ all_tag_strings = [tag[MODEL_STRS.TAG_STRING] for tag in all_tags]
 Valid URLs used for testing, without tags
 """
 valid_url_without_tag_1 = {
-    MODEL_STRS.ID: 1,
-    MODEL_STRS.URL: "https://www.google.com/",
-    MODEL_STRS.TAGS: [],
+    MODEL_STRS.UTUB_URL_ID: 1,
+    MODEL_STRS.URL_STRING: "https://www.google.com/",
+    MODEL_STRS.URL_TAGS: [],
+    MODEL_STRS.URL_TITLE: "",
+    MODEL_STRS.CAN_DELETE: True,
 }
 
 valid_url_without_tag_2 = {
-    MODEL_STRS.ID: 2,
-    MODEL_STRS.URL: "https://github.com/",
-    MODEL_STRS.TAGS: [],
+    MODEL_STRS.UTUB_URL_ID: 2,
+    MODEL_STRS.URL_STRING: "https://github.com/",
+    MODEL_STRS.URL_TAGS: [],
+    MODEL_STRS.URL_TITLE: "",
+    MODEL_STRS.CAN_DELETE: True,
 }
 
 valid_url_without_tag_3 = {
-    MODEL_STRS.ID: 3,
-    MODEL_STRS.URL: "https://www.microsoft.com/",
-    MODEL_STRS.TAGS: [],
+    MODEL_STRS.UTUB_URL_ID: 3,
+    MODEL_STRS.URL_STRING: "https://www.microsoft.com/",
+    MODEL_STRS.URL_TAGS: [],
+    MODEL_STRS.URL_TITLE: "",
+    MODEL_STRS.CAN_DELETE: True,
 }
 
 all_urls_no_tags = (
@@ -98,7 +104,7 @@ all_urls_no_tags = (
 )
 
 valid_url_strings = [
-    url[MODEL_STRS.URL]
+    url[MODEL_STRS.URL_STRING]
     for url in (
         valid_url_without_tag_1,
         valid_url_without_tag_2,
@@ -110,7 +116,7 @@ valid_url_strings = [
 Valid URLs used for testing, with tags
 """
 valid_url_with_tag_1 = {
-    MODEL_STRS.URL_ID: 1,
+    MODEL_STRS.UTUB_URL_ID: 1,
     MODEL_STRS.URL_STRING: "https://www.google.com/",
     MODEL_STRS.URL_TAGS: valid_tag_ids,
     MODEL_STRS.URL_TITLE: "",
@@ -118,7 +124,7 @@ valid_url_with_tag_1 = {
 }
 
 valid_url_with_tag_2 = {
-    MODEL_STRS.URL_ID: 2,
+    MODEL_STRS.UTUB_URL_ID: 2,
     MODEL_STRS.URL_STRING: "https://github.com/",
     MODEL_STRS.URL_TAGS: valid_tag_ids,
     MODEL_STRS.URL_TITLE: "",
@@ -126,7 +132,7 @@ valid_url_with_tag_2 = {
 }
 
 valid_url_with_tag_3 = {
-    MODEL_STRS.URL_ID: 3,
+    MODEL_STRS.UTUB_URL_ID: 3,
     MODEL_STRS.URL_STRING: "https://www.microsoft.com/",
     MODEL_STRS.URL_TAGS: valid_tag_ids,
     MODEL_STRS.URL_TITLE: "",
@@ -225,10 +231,10 @@ for utub, user, url in zip(all_empty_utubs, valid_users, all_urls_no_tags):
             ],
             MODEL_STRS.URLS: [
                 {
-                    MODEL_STRS.URL_ID: url[MODEL_STRS.ID],
-                    MODEL_STRS.URL_STRING: url[MODEL_STRS.URL],
+                    MODEL_STRS.UTUB_URL_ID: url[MODEL_STRS.UTUB_URL_ID],
+                    MODEL_STRS.URL_STRING: url[MODEL_STRS.URL_STRING],
                     MODEL_STRS.URL_TAGS: [],
-                    MODEL_STRS.URL_TITLE: f"This is {url[MODEL_STRS.URL]}",
+                    MODEL_STRS.URL_TITLE: f"This is {url[MODEL_STRS.URL_STRING]}",
                     MODEL_STRS.CAN_DELETE: False,
                 }
             ],
@@ -256,10 +262,10 @@ for utub in all_empty_utubs:
             ],
             MODEL_STRS.URLS: [
                 {
-                    MODEL_STRS.URL_ID: url[MODEL_STRS.ID],
-                    MODEL_STRS.URL_STRING: url[MODEL_STRS.URL],
+                    MODEL_STRS.UTUB_URL_ID: url[MODEL_STRS.UTUB_URL_ID],
+                    MODEL_STRS.URL_STRING: url[MODEL_STRS.URL_STRING],
                     MODEL_STRS.URL_TAGS: [tag[MODEL_STRS.ID] for tag in all_tags],
-                    MODEL_STRS.URL_TITLE: f"This is {url[MODEL_STRS.URL]}",
+                    MODEL_STRS.URL_TITLE: f"This is {url[MODEL_STRS.URL_STRING]}",
                     MODEL_STRS.CAN_DELETE: True,
                 }
                 for url in all_urls_no_tags

--- a/tests/models_for_test.py
+++ b/tests/models_for_test.py
@@ -265,5 +265,6 @@ for utub in all_empty_utubs:
                 for url in all_urls_no_tags
             ],
             MODEL_STRS.TAGS: [tag for tag in all_tags],
+            MODEL_STRS.IS_CREATOR: True,
         }
     )

--- a/tests/unit/test_db_exists.py
+++ b/tests/unit/test_db_exists.py
@@ -4,7 +4,7 @@ from sqlalchemy import inspect
 from src import db
 from src.models.tags import Tags
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -29,5 +29,5 @@ def test_db_created_correctly(app):
         assert inspector.has_table(Utubs.__tablename__)
         assert inspector.has_table(Utub_Members.__tablename__)
         assert inspector.has_table(Utub_Urls.__tablename__)
-        assert inspector.has_table(Url_Tags.__tablename__)
+        assert inspector.has_table(Utub_Url_Tags.__tablename__)
         assert inspector.has_table("sessions")

--- a/tests/unit/test_model_serialization.py
+++ b/tests/unit/test_model_serialization.py
@@ -87,17 +87,18 @@ def test_url_serialization_without_tags():
 
     for v_url in valid_urls:
         new_url = Urls(
-            normalized_url=v_url[MODEL_STRS.URL], current_user_id=current_user_id
+            normalized_url=v_url[MODEL_STRS.URL_STRING], current_user_id=current_user_id
         )
 
         new_utub_url = Utub_Urls()
         new_utub_url.standalone_url = new_url
-        new_utub_url.id = v_url[MODEL_STRS.ID]
+        new_utub_url.id = v_url[MODEL_STRS.UTUB_URL_ID]
+        new_utub_url.url_title = ""
 
         # Test a URL without any tags
         valid_url_for_json = json.dumps(v_url)
 
-        assert json.dumps(new_utub_url.serialized_url) == valid_url_for_json
+        assert json.dumps(new_utub_url.serialized(1, 1)) == valid_url_for_json
 
 
 def test_url_serialization_with_tags(
@@ -526,7 +527,7 @@ def test_utub_serialized_creator_and_members_and_urls_and_tags(
                     if url.utub_id == test_utub[MODEL_STRS.ID]
                     and url.standalone_url.url_string == test_url[MODEL_STRS.URL_STRING]
                 ][-1]
-                test_utub[MODEL_STRS.URLS][idx][MODEL_STRS.URL_ID] = real_url.id
+                test_utub[MODEL_STRS.URLS][idx][MODEL_STRS.UTUB_URL_ID] = real_url.id
 
         for test_utub, utub in zip(mock_utub_data, all_utubs):
             test_utub[MODEL_STRS.CREATED_AT] = utub.created_at.strftime(
@@ -540,13 +541,13 @@ def test_utub_serialized_creator_and_members_and_urls_and_tags(
                 key=lambda test_user: test_user[MODEL_STRS.ID],
             )
 
-            # Array of URLs needs to be sorted by URL ID to match
+            # Array of URLs needs to be sorted by UTUB_URL_ID to match
             test_utub[MODEL_STRS.URLS] = sorted(
                 test_utub[MODEL_STRS.URLS],
-                key=lambda utub_url: utub_url[MODEL_STRS.URL_ID],
+                key=lambda utub_url: utub_url[MODEL_STRS.UTUB_URL_ID],
             )
 
-            # Array of Tags needs to be sorted by URL ID to match
+            # Array of Tags needs to be sorted by ID to match
             utub_in_data_serialized[MODEL_STRS.TAGS] = sorted(
                 utub_in_data_serialized[MODEL_STRS.TAGS],
                 key=lambda utub_tag: utub_tag[MODEL_STRS.ID],

--- a/tests/unit/test_model_serialization.py
+++ b/tests/unit/test_model_serialization.py
@@ -6,7 +6,7 @@ import pytest
 from src import db
 from src.models.tags import Tags
 from src.models.urls import Urls
-from src.models.url_tags import Url_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
@@ -145,7 +145,7 @@ def test_url_serialization_with_tags(
 
         for utub, url in zip(all_utubs, all_urls):
             for tag in all_tags:
-                new_url_tag = Url_Tags()
+                new_url_tag = Utub_Url_Tags()
                 new_url_tag.utub_containing_this_tag = utub
                 new_url_tag.utub_id = utub.id
                 new_url_tag.url_id = url.id

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -82,7 +82,6 @@ def test_url_model(app):
 
         assert new_url_object.url_string == find_common_url(new_url["url_string"])
         assert new_url_object.created_by == new_url["creator"]
-        assert len(new_url_object.url_tags) == 0
 
 
 def test_tag_model(app):


### PR DESCRIPTION
Changes table name from `UrlTags` to `UtubUrlTags`

Introduces an `id` field as primary key for `UtubUrls`, and removes previous composite primary key that consisted of `utubID`, `urlID`, and `userID`.

Enforces the usage of the `UtubUrls.id` field as the foreign key for URL reference in the `UtubUrlTags` table. Replaced the `urlID` foreign key that points to an entry in the `Urls` table, with a `utubUrlID` field that points towards the primary key of `UtubUrls` field.

Updates all JSON responses to use `utubUrlID` instead of `urlID` in responses where the `urlID` was provided.