### PR TITLE
Ensure primary key usage for members

### DIFF
--- a/src/members/forms.py
+++ b/src/members/forms.py
@@ -23,7 +23,7 @@ class UTubNewMemberForm(FlaskForm):
 
     def validate_username(self, username):
         """Validates username is unique in the db"""
-        username_exists = Users.query.filter_by(username=username.data).first()
+        username_exists = Users.query.filter(Users.username == username.data).first()
 
         if not username_exists:
             raise ValidationError(USER_FAILURE.USER_NOT_EXIST)

--- a/src/models/utub_members.py
+++ b/src/models/utub_members.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from sqlalchemy import Column, Enum as SQLEnum, ForeignKey, Integer
+from sqlalchemy import Column, Enum as SQLEnum, ForeignKey, Integer, UniqueConstraint
 
 from src import db
 from src.utils.strings.model_strs import MODELS
@@ -29,6 +29,8 @@ class Utub_Members(db.Model):
 
     to_user = db.relationship("Users", back_populates="utubs_is_member_of")
     to_utub = db.relationship("Utubs", back_populates="members")
+
+    UniqueConstraint(utub_id, user_id, name="unique_member")
 
     @property
     def serialized(self) -> dict:

--- a/src/splash/forms.py
+++ b/src/splash/forms.py
@@ -52,14 +52,14 @@ class UserRegistrationForm(FlaskForm):
 
     def validate_username(self, username):
         """Validates username is unique in the db"""
-        user: Users = Users.query.filter_by(username=username.data).first()
+        user: Users = Users.query.filter(Users.username == username.data).first()
 
         if user and user.email_confirm.is_validated:
             raise ValidationError(USER_FAILURE.USERNAME_TAKEN)
 
     def validate_email(self, email):
         """Validates username is unique in the db"""
-        user: Users = Users.query.filter_by(email=email.data.lower()).first()
+        user: Users = Users.query.filter(Users.email == email.data.lower()).first()
 
         if user:
             email_confirm: Email_Validations = user.email_confirm
@@ -88,13 +88,13 @@ class LoginForm(FlaskForm):
     submit = SubmitField(REGISTER_LOGIN_FORM.LOGIN)
 
     def validate_username(self, username):
-        user: Users = Users.query.filter_by(username=username.data).first()
+        user: Users = Users.query.filter(Users.username == username.data).first()
 
         if not user:
             raise ValidationError(USER_FAILURE.USER_NOT_EXIST)
 
     def validate_password(self, password):
-        user: Users = Users.query.filter_by(username=self.username.data).first()
+        user: Users = Users.query.filter(Users.username == self.username.data).first()
         if not user:
             return
 

--- a/src/splash/routes.py
+++ b/src/splash/routes.py
@@ -83,7 +83,7 @@ def register_user():
         new_user.email_confirm = new_email_validation
         db.session.add(new_user)
         db.session.commit()
-        user = Users.query.filter_by(username=username).first()
+        user = Users.query.filter(Users.username == username).first()
         login_user(user)
         validate_email_form = ValidateEmailForm()
         return (
@@ -166,7 +166,7 @@ def login():
 
     if login_form.validate_on_submit():
         username = login_form.username.data
-        user: Users = Users.query.filter_by(username=username).first()
+        user: Users = Users.query.filter(Users.username == username).first()
         email_confirm: Email_Validations = user.email_confirm
         login_user(user)  # Can add Remember Me functionality here
         if not email_confirm.is_validated:

--- a/src/splash/utils.py
+++ b/src/splash/utils.py
@@ -73,8 +73,8 @@ def _handle_mailjet_failure(email_result: requests.Response, error_code: int = 1
 def _handle_after_forgot_password_form_validated(
     forgot_password_form: ForgotPasswordForm,
 ) -> tuple[Response, int]:
-    user_with_email: Users = Users.query.filter_by(
-        email=forgot_password_form.email.data.lower()
+    user_with_email: Users = Users.query.filter(
+        Users.email == forgot_password_form.email.data.lower()
     ).first()
 
     if user_with_email is not None:

--- a/tests/integration/splash/test_login_user.py
+++ b/tests/integration/splash/test_login_user.py
@@ -44,8 +44,8 @@ def test_login_registered_and_logged_in_user(login_first_user_with_register):
 
     # Ensure user id's match with  database
     with app.app_context():
-        registered_db_user = Users.query.filter_by(
-            username=new_user[LOGIN_FORM.USERNAME]
+        registered_db_user = Users.query.filter(
+            Users.username == new_user[LOGIN_FORM.USERNAME]
         ).first()
 
     assert registered_db_user.id == int(current_user.get_id())

--- a/tests/integration/splash/test_register_user.py
+++ b/tests/integration/splash/test_register_user.py
@@ -28,8 +28,8 @@ def test_register_new_user(app, load_register_page):
 
     # Ensure no user with this data exists in database
     with app.app_context():
-        new_db_user: Users = Users.query.filter_by(
-            username=new_user[REGISTER_FORM.USERNAME]
+        new_db_user: Users = Users.query.filter(
+            Users.username == new_user[REGISTER_FORM.USERNAME]
         ).first()
 
     assert new_db_user is None
@@ -52,8 +52,8 @@ def test_register_new_user(app, load_register_page):
 
     # Ensure user exists in database
     with app.app_context():
-        new_db_user: Users = Users.query.filter_by(
-            username=new_user[REGISTER_FORM.USERNAME]
+        new_db_user: Users = Users.query.filter(
+            Users.username == new_user[REGISTER_FORM.USERNAME]
         ).first()
 
     # Ensure user model after loading from database is logged in
@@ -99,8 +99,8 @@ def test_register_duplicate_user(app, load_register_page, register_first_user):
 
     # Ensure user already exists
     with app.app_context():
-        new_db_user = Users.query.filter_by(
-            username=already_registered_user_data[REGISTER_FORM.USERNAME]
+        new_db_user = Users.query.filter(
+            Users.username == already_registered_user_data[REGISTER_FORM.USERNAME]
         ).first()
 
     assert new_db_user is not None
@@ -172,8 +172,8 @@ def test_register_user_cased_email(app, load_register_page, register_first_user)
 
         # Ensure user already exists
         with app.app_context():
-            new_db_user = Users.query.filter_by(
-                username=already_registered_user_data[REGISTER_FORM.USERNAME]
+            new_db_user = Users.query.filter(
+                Users.username == already_registered_user_data[REGISTER_FORM.USERNAME]
             ).first()
 
         assert new_db_user is not None
@@ -294,8 +294,8 @@ def test_register_user_missing_csrf(app, load_register_page):
 
     # Ensure no user with this data exists in database
     with app.app_context():
-        new_db_user = Users.query.filter_by(
-            username=valid_user_1[REGISTER_FORM.USERNAME]
+        new_db_user = Users.query.filter(
+            Users.username == valid_user_1[REGISTER_FORM.USERNAME]
         ).first()
 
     assert new_db_user is None
@@ -324,8 +324,8 @@ def test_register_user_missing_csrf(app, load_register_page):
 
     # Ensure no user with this data exists in database
     with app.app_context():
-        new_db_user = Users.query.filter_by(
-            username=valid_user_1[REGISTER_FORM.USERNAME]
+        new_db_user = Users.query.filter(
+            Users.username == valid_user_1[REGISTER_FORM.USERNAME]
         ).first()
 
     assert new_db_user is None

--- a/tests/integration/utubs/test_add_utub_route.py
+++ b/tests/integration/utubs/test_add_utub_route.py
@@ -131,8 +131,8 @@ def test_add_utub_with_same_name(
 
     # Make sure database is empty of UTubs and associated users
     with app.app_context():
-        current_utub: Utubs = Utubs.query.filter_by(
-            utub_creator=current_user.id
+        current_utub: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
         ).first()
         current_utub_name = current_utub.name
 

--- a/tests/integration/utubs/test_delete_utub_route.py
+++ b/tests/integration/utubs/test_delete_utub_route.py
@@ -515,13 +515,7 @@ def test_delete_utub_as_member_only(
         # Assert current user is in all UTubs
         all_utubs: list[Utubs] = Utubs.query.all()
         for utub in all_utubs:
-            assert (
-                Utub_Members.query.filter(
-                    Utub_Members.user_id == current_user.id,
-                    Utub_Members.utub_id == utub.id,
-                ).count()
-                == 1
-            )
+            assert Utub_Members.query.get((utub.id, current_user.id)) is not None
 
         initial_num_utubs = Utubs.query.count()
 

--- a/tests/integration/utubtags/test_add_tag_to_url_route.py
+++ b/tests/integration/utubtags/test_add_tag_to_url_route.py
@@ -65,20 +65,16 @@ def test_add_fresh_tag_to_valid_url_as_utub_creator(
         associated_tags = url_utub_association.associated_tags
 
         # Ensure this tag does not exist in the database
-        init_num_of_tag_in_db = len(
-            Tags.query.filter(Tags.tag_string == tag_to_add).all()
-        )
+        init_num_of_tag_in_db = Tags.query.filter(Tags.tag_string == tag_to_add).count()
 
         # Ensure no Tag-URL association exists in this UTub
-        init_num_of_tags_on_urls = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Utub_Url_Tags.utub_url_id == url_utub_association.id,
-            ).all()
-        )
+        init_num_of_tags_on_urls = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.utub_url_id == url_utub_association.id,
+        ).count()
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -110,23 +106,21 @@ def test_add_fresh_tag_to_valid_url_as_utub_creator(
     with app.app_context():
         # Ensure a tag exists
         assert (
-            len(Tags.query.filter(Tags.tag_string == tag_to_add).all())
+            Tags.query.filter(Tags.tag_string == tag_to_add).count()
             == init_num_of_tag_in_db + 1
         )
 
         # Ensure a Tag-URL association exists in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+            ).count()
             == init_num_of_tags_on_urls + 1
         )
 
         # Ensure correct total count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations + 1
 
 
 def test_add_fresh_tag_to_valid_url_as_utub_member(
@@ -174,7 +168,7 @@ def test_add_fresh_tag_to_valid_url_as_utub_member(
         associated_tags = url_utub_association.associated_tags
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -209,17 +203,15 @@ def test_add_fresh_tag_to_valid_url_as_utub_member(
 
         # Ensure a Tag-URL association exists in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+            ).count()
             == 1
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations + 1
 
 
 def test_add_existing_tag_to_valid_url_as_utub_creator(
@@ -274,7 +266,7 @@ def test_add_existing_tag_to_valid_url_as_utub_creator(
         tag_id_that_exists = tag_that_exists.id
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -309,18 +301,16 @@ def test_add_existing_tag_to_valid_url_as_utub_creator(
     with app.app_context():
         # Ensure a Tag-URL association exists in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-                    Utub_Url_Tags.tag_id == tag_that_exists.id,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.tag_id == tag_that_exists.id,
+            ).count()
             == 1
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations + 1
 
 
 def test_add_existing_tag_to_valid_url_as_utub_member(
@@ -374,7 +364,7 @@ def test_add_existing_tag_to_valid_url_as_utub_member(
         tag_id_that_exists = tag_that_exists.id
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -409,18 +399,16 @@ def test_add_existing_tag_to_valid_url_as_utub_member(
     with app.app_context():
         # Ensure a Tag-URL association exists in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-                    Utub_Url_Tags.tag_id == tag_that_exists.id,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+                Utub_Url_Tags.tag_id == tag_that_exists.id,
+            ).count()
             == 1
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations + 1
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations + 1
 
 
 def test_add_duplicate_tag_to_valid_url_as_utub_creator(
@@ -447,7 +435,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
 
     with app.app_context():
         # Ensure tags already in database
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Find UTub this current user is creator of
         utub_user_is_creator_of: Utubs = Utubs.query.filter(
@@ -466,12 +454,10 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
             current_user.id, creator_of_utub_id
         )
 
-        num_of_tag_associations_with_url_in_utub = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-            ).all()
-        )
+        num_of_tag_associations_with_url_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+        ).count()
 
         tag_on_url_in_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
             Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
@@ -482,7 +468,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
         tag_to_add = tag_on_url_in_utub.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -509,14 +495,15 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no new tags exist on this URL
-        assert num_of_tag_associations_with_url_in_utub == len(
-            Utub_Url_Tags.query.filter(
+        assert (
+            num_of_tag_associations_with_url_in_utub
+            == Utub_Url_Tags.query.filter(
                 Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
                 Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-            ).all()
+            ).count()
         )
 
         url_utub_tag_association: Utub_Urls = Utub_Urls.query.filter(
@@ -531,7 +518,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_duplicate_tag_to_valid_url_as_utub_member(
@@ -574,12 +561,10 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
             current_user.id, creator_of_utub_id
         )
 
-        num_of_tag_associations_with_url_in_utub = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
-                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-            ).all()
-        )
+        num_of_tag_associations_with_url_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+            Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+        ).count()
 
         tag_on_url_in_utub_association: Utub_Url_Tags = Utub_Url_Tags.query.filter(
             Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
@@ -590,7 +575,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
         tag_to_add = tag_on_url_in_utub.tag_string
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -617,14 +602,15 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no new tags exist on this URL
-        assert num_of_tag_associations_with_url_in_utub == len(
-            Utub_Url_Tags.query.filter(
+        assert (
+            num_of_tag_associations_with_url_in_utub
+            == Utub_Url_Tags.query.filter(
                 Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
                 Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-            ).all()
+            ).count()
         )
 
         # URLs exist in UTub only once
@@ -639,7 +625,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_nonexistent_url_as_utub_creator(
@@ -667,15 +653,13 @@ def test_add_tag_to_nonexistent_url_as_utub_creator(
         ).first()
         utub_id_user_is_creator_of = utub_user_is_creator_of.id
 
-        num_of_tag_associations_with_url_in_utub = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_IN_UTUB_ID,
-            ).all()
-        )
+        num_of_tag_associations_with_url_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+            Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_IN_UTUB_ID,
+        ).count()
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -696,31 +680,30 @@ def test_add_tag_to_nonexistent_url_as_utub_creator(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no URLs were added
-        assert len(Urls.query.all()) == 0
+        assert Urls.query.count() == 0
 
         # Ensure no URL-Tag associations exist for this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of
+            ).count()
             == 0
         )
 
         # Ensure no new tags exist on this URL
-        assert num_of_tag_associations_with_url_in_utub == len(
-            Utub_Url_Tags.query.filter(
+        assert (
+            num_of_tag_associations_with_url_in_utub
+            == Utub_Url_Tags.query.filter(
                 Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
                 Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_IN_UTUB_ID,
-            ).all()
+            ).count()
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_nonexistent_url_as_utub_member(
@@ -748,15 +731,13 @@ def test_add_tag_to_nonexistent_url_as_utub_member(
         ).first()
         utub_id_user_is_member_of = utub_user_is_member_of.id
 
-        num_of_tag_associations_with_url_in_utub = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
-                Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_IN_UTUB_ID,
-            ).all()
-        )
+        num_of_tag_associations_with_url_in_utub = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+            Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_IN_UTUB_ID,
+        ).count()
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -777,31 +758,30 @@ def test_add_tag_to_nonexistent_url_as_utub_member(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no URLs were added
-        assert len(Urls.query.all()) == 0
+        assert Urls.query.count() == 0
 
         # Ensure no URL-Tag associations exist for this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of
+            ).count()
             == 0
         )
 
         # Ensure no new tags exist on this URL
-        assert num_of_tag_associations_with_url_in_utub == len(
-            Utub_Url_Tags.query.filter(
+        assert (
+            num_of_tag_associations_with_url_in_utub
+            == Utub_Url_Tags.query.filter(
                 Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
                 Utub_Url_Tags.utub_url_id == NONEXISTENT_URL_IN_UTUB_ID,
-            ).all()
+            ).count()
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_in_nonexistent_utub(
@@ -823,11 +803,11 @@ def test_add_tag_to_url_in_nonexistent_utub(
     tag_to_add = all_tag_strings[0]
 
     with app.app_context():
-        num_of_utubs_in_db = len(Utubs.query.all())
-        num_of_urls_in_db = len(Urls.query.all())
+        num_of_utubs_in_db = Utubs.query.count()
+        num_of_urls_in_db = Urls.query.count()
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -848,17 +828,17 @@ def test_add_tag_to_url_in_nonexistent_utub(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no URLs were added
-        assert len(Urls.query.all()) == num_of_urls_in_db
+        assert Urls.query.count() == num_of_urls_in_db
 
         # Ensure UTub does not exist
         assert Utubs.query.get(NONEXISTENT_UTUB_ID) is None
-        assert len(Utubs.query.all()) == num_of_utubs_in_db
+        assert Utubs.query.count() == num_of_utubs_in_db
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_in_utub_user_is_not_member_of(
@@ -898,7 +878,7 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
 
         num_of_users_in_utub = len(utub_user_not_member_of.members)
 
-        num_of_urls_in_db = len(Urls.query.all())
+        num_of_urls_in_db = Urls.query.count()
 
         # Find URL in this UTub
         url_association_with_this_utub: Utub_Urls = Utub_Urls.query.filter(
@@ -910,7 +890,7 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -938,10 +918,10 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no URLs were added
-        assert len(Urls.query.all()) == num_of_urls_in_db
+        assert Urls.query.count() == num_of_urls_in_db
 
         # Get UTub again
         utub_that_user_not_member_of: Utubs = Utubs.query.get(
@@ -951,12 +931,10 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
 
         # Ensure no tags on this URL still
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_that_user_not_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_for_url_in_utub,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_that_user_not_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_for_url_in_utub,
+            ).count()
             == 0
         )
 
@@ -971,7 +949,7 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_not_in_utub(
@@ -999,7 +977,7 @@ def test_add_tag_to_url_not_in_utub(
         ).first()
         utub_id_user_is_creator_of = utub_user_is_creator_of.id
 
-        num_of_urls_in_db = len(Urls.query.all())
+        num_of_urls_in_db = Urls.query.count()
 
         # Find URL that isn't in this UTub
         url_association_not_with_this_utub: Utub_Urls = Utub_Urls.query.filter(
@@ -1014,7 +992,7 @@ def test_add_tag_to_url_not_in_utub(
         num_of_urls_in_utub = len(utub_user_is_creator_of.utub_urls)
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -1035,10 +1013,10 @@ def test_add_tag_to_url_not_in_utub(
 
     with app.app_context():
         # Ensure no new tags exist
-        assert len(Tags.query.all()) == len(all_tag_strings)
+        assert Tags.query.count() == len(all_tag_strings)
 
         # Ensure no URLs were added
-        assert len(Urls.query.all()) == num_of_urls_in_db
+        assert Urls.query.count() == num_of_urls_in_db
 
         # Ensure same number of URLs in UTub
         utub_user_is_creator_of_for_check = Utubs.query.get(utub_id_user_is_creator_of)
@@ -1046,28 +1024,24 @@ def test_add_tag_to_url_not_in_utub(
 
         # Ensure no association between this URL and this UTub
         assert (
-            len(
-                Utub_Urls.query.filter(
-                    Utub_Urls.utub_id == utub_id_user_is_creator_of,
-                    Utub_Urls.url_id == url_object_id_for_url_not_in_utub,
-                ).all()
-            )
+            Utub_Urls.query.filter(
+                Utub_Urls.utub_id == utub_id_user_is_creator_of,
+                Utub_Urls.url_id == url_object_id_for_url_not_in_utub,
+            ).count()
             == 0
         )
 
         # Ensure no association with Tags, this URL, and this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_for_url_not_in_utub,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_for_url_not_in_utub,
+            ).count()
             == 0
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_with_five_tags_as_utub_creator(
@@ -1142,7 +1116,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -1168,28 +1142,24 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
 
     with app.app_context():
         # Ensure no new tags exist, accounting for additional
-        assert len(Tags.query.all()) == num_of_tags_in_db
+        assert Tags.query.count() == num_of_tags_in_db
 
         # Ensure this tag isn't on the URL in this UTub already
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
-                    Utub_Url_Tags.tag_id == new_tag_id_to_add,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
+                Utub_Url_Tags.tag_id == new_tag_id_to_add,
+            ).count()
             == 0
         )
 
         # Ensure 5 tags on this URL
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
+            ).count()
             == MAX_NUM_OF_TAGS
         )
 
@@ -1203,7 +1173,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_url_with_five_tags_as_utub_member(
@@ -1278,7 +1248,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -1304,28 +1274,24 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
 
     with app.app_context():
         # Ensure no new tags exist, accounting for additional
-        assert len(Tags.query.all()) == num_of_tags_in_db
+        assert Tags.query.count() == num_of_tags_in_db
 
         # Ensure this tag isn't on the URL in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
-                    Utub_Url_Tags.tag_id == new_tag_id_to_add,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
+                Utub_Url_Tags.tag_id == new_tag_id_to_add,
+            ).count()
             == 0
         )
 
         # Ensure 5 tags on this URL
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_in_this_utub,
+            ).count()
             == MAX_NUM_OF_TAGS
         )
 
@@ -1339,7 +1305,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
@@ -1389,7 +1355,7 @@ def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -1421,7 +1387,7 @@ def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
 
     with app.app_context():
         # Ensure no tags
-        assert len(Tags.query.all()) == 0
+        assert Tags.query.count() == 0
 
         # Ensure same serialization for URL
         assert url_serialization_for_check == Utub_Urls.query.get(
@@ -1429,21 +1395,19 @@ def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
         ).serialized(current_user.id, creator_of_utub_id)
 
         # Ensure this tag does not exist in the database
-        assert len(Tags.query.filter(Tags.tag_string == tag_to_add).all()) == 0
+        assert Tags.query.filter(Tags.tag_string == tag_to_add).count() == 0
 
         # Ensure no Tag-URL association exists in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+            ).count()
             == 0
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
@@ -1493,7 +1457,7 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
         )
 
         # Get initial num of Url-Tag associations
-        initial_num_url_tag_associations = len(Utub_Url_Tags.query.all())
+        initial_num_url_tag_associations = Utub_Url_Tags.query.count()
 
     # Add tag to this URL
     add_tag_form = {
@@ -1515,7 +1479,7 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
 
     with app.app_context():
         # Ensure no tags
-        assert len(Tags.query.all()) == 0
+        assert Tags.query.count() == 0
 
         # Ensure same serialization for URL
         assert url_serialization_for_check == Utub_Urls.query.get(
@@ -1523,21 +1487,19 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
         ).serialized(current_user.id, creator_of_utub_id)
 
         # Ensure this tag does not exist in the database
-        assert len(Tags.query.filter(Tags.tag_string == tag_to_add).all()) == 0
+        assert Tags.query.filter(Tags.tag_string == tag_to_add).count() == 0
 
         # Ensure no Tag-URL association exists in this UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_user_is_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_add_tag_to,
+            ).count()
             == 0
         )
 
         # Ensure correct count of Url-Tag associations
-        assert len(Utub_Url_Tags.query.all()) == initial_num_url_tag_associations
+        assert Utub_Url_Tags.query.count() == initial_num_url_tag_associations
 
 
 def test_add_fresh_tag_to_url_updates_utub_last_updated(

--- a/tests/integration/utubtags/test_remove_tag_from_url_route.py
+++ b/tests/integration/utubtags/test_remove_tag_from_url_route.py
@@ -68,11 +68,12 @@ def test_remove_tag_from_url_as_utub_creator(
         associated_tags = utub_url_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Utub_Url_Tags.query.all())
+        initial_url_tag_count = Utub_Url_Tags.query.count()
 
         # Get tag count for this UTub and tag
-        tag_count = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id_this_user_creator_of, tag_id=tag_id_to_remove
+        tag_count = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+            Utub_Url_Tags.tag_id == tag_id_to_remove,
         ).count()
 
     # Remove tag from this URL
@@ -118,13 +119,11 @@ def test_remove_tag_from_url_as_utub_creator(
 
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_creator_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 0
         )
 
@@ -137,7 +136,7 @@ def test_remove_tag_from_url_as_utub_creator(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert Utub_Url_Tags.query.count() == initial_url_tag_count - 1
 
 
 def test_remove_tag_from_url_as_utub_member(
@@ -192,11 +191,12 @@ def test_remove_tag_from_url_as_utub_member(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Utub_Url_Tags.query.all())
+        initial_url_tag_count = Utub_Url_Tags.query.count()
 
         # Get tag count for this UTub and tag
-        tag_count = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
+        tag_count = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+            Utub_Url_Tags.tag_id == tag_id_to_remove,
         ).count()
 
     # Remove tag from this URL
@@ -242,13 +242,11 @@ def test_remove_tag_from_url_as_utub_member(
 
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 0
         )
 
@@ -261,7 +259,7 @@ def test_remove_tag_from_url_as_utub_member(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert Utub_Url_Tags.query.count() == initial_url_tag_count - 1
 
 
 def test_remove_tag_from_url_with_one_tag(
@@ -317,11 +315,12 @@ def test_remove_tag_from_url_with_one_tag(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Utub_Url_Tags.query.all())
+        initial_url_tag_count = Utub_Url_Tags.query.count()
 
         # Get tag count for this UTub and tag
-        tag_count = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
+        tag_count = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+            Utub_Url_Tags.tag_id == tag_id_to_remove,
         ).count()
 
     # Remove tag from this URL
@@ -367,13 +366,11 @@ def test_remove_tag_from_url_with_one_tag(
 
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 0
         )
 
@@ -387,7 +384,7 @@ def test_remove_tag_from_url_with_one_tag(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert Utub_Url_Tags.query.count() == initial_url_tag_count - 1
 
 
 def test_remove_last_tag_from_utub(
@@ -444,11 +441,12 @@ def test_remove_last_tag_from_utub(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Utub_Url_Tags.query.all())
+        initial_url_tag_count = Utub_Url_Tags.query.count()
 
         # Get tag count for this UTub and tag
-        tag_count = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
+        tag_count = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+            Utub_Url_Tags.tag_id == tag_id_to_remove,
         ).count()
 
     # Remove tag from this URL
@@ -494,23 +492,19 @@ def test_remove_last_tag_from_utub(
 
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 0
         )
 
         # Ensure no tags remain in the UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_member_of
+            ).count()
             == 0
         )
 
@@ -524,7 +518,7 @@ def test_remove_last_tag_from_utub(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert Utub_Url_Tags.query.count() == initial_url_tag_count - 1
 
 
 def test_remove_tag_from_url_with_five_tags(
@@ -603,11 +597,12 @@ def test_remove_tag_from_url_with_five_tags(
         associated_tags = url_utub_association.associated_tags
 
         # Get all Url-Tag associations count
-        initial_url_tag_count = len(Utub_Url_Tags.query.all())
+        initial_url_tag_count = Utub_Url_Tags.query.count()
 
         # Get tag count for this UTub and tag
-        tag_count: int = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id_this_user_member_of, tag_id=tag_id_to_remove
+        tag_count: int = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+            Utub_Url_Tags.tag_id == tag_id_to_remove,
         ).count()
 
     # Remove tag from this URL
@@ -650,18 +645,17 @@ def test_remove_tag_from_url_with_five_tags(
     with app.app_context():
         # Ensure tag still exists
         assert Tags.query.get(tag_id_to_remove) is not None
-        assert len(Tags.query.all()) == num_of_tags_in_db
+        assert Tags.query.count() == num_of_tags_in_db
 
         # Ensure 4 tags on this URL
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+            ).count()
             == MAX_NUM_TAGS - 1
         )
+
         # Grab URL-UTub association
         final_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
             Utub_Urls.id == url_id_to_remove_tag_from,
@@ -671,7 +665,7 @@ def test_remove_tag_from_url_with_five_tags(
         )
 
         # Ensure proper number of Url-Tag associations in db
-        assert len(Utub_Url_Tags.query.all()) == initial_url_tag_count - 1
+        assert Utub_Url_Tags.query.count() == initial_url_tag_count - 1
 
 
 def test_remove_nonexistent_tag_from_url_as_utub_creator(
@@ -784,7 +778,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
         )
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
+        initial_num_tag_url_associations = Utub_Url_Tags.query.count()
 
     # Remove tag from this URL
     add_tag_form = {
@@ -806,13 +800,11 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
     with app.app_context():
         # Ensure the Tag-URL-UTub association does not exist any longer
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
-                    Utub_Url_Tags.tag_id == NONEXISTENT_TAG_ID,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_this_user_member_of,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove_tag_from,
+                Utub_Url_Tags.tag_id == NONEXISTENT_TAG_ID,
+            ).count()
             == 0
         )
 
@@ -826,7 +818,7 @@ def test_remove_nonexistent_tag_from_url_as_utub_member(
             current_user.id, creator_of_utub_id
         )
 
-        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert Utub_Url_Tags.query.count() == initial_num_tag_url_associations
 
 
 def test_remove_tag_from_url_but_not_member_of_utub(
@@ -920,12 +912,10 @@ def test_remove_tag_from_url_but_not_member_of_utub(
 
         # Ensure tag exists on URL in UTub
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == utub_id_not_member_of,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == utub_id_not_member_of,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 1
         )
 
@@ -966,12 +956,10 @@ def test_remove_tag_from_url_from_nonexistent_utub(
             valid_url_tag_association.utub_containing_this_tag.utub_creator
         )
 
-        num_of_url_tag_associations = len(
-            Utub_Url_Tags.query.filter(
-                Utub_Url_Tags.utub_url_id == url_id_to_remove,
-                Utub_Url_Tags.tag_id == tag_id_to_remove,
-            ).all()
-        )
+        num_of_url_tag_associations = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_url_id == url_id_to_remove,
+            Utub_Url_Tags.tag_id == tag_id_to_remove,
+        ).count()
 
         # Grab initial UTub-URL serialization
         initial_utub_url_association: Utub_Urls = Utub_Urls.query.filter(
@@ -982,7 +970,7 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         )
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
+        initial_num_tag_url_associations = Utub_Url_Tags.query.count()
 
     # Remove tag from this URL
     add_tag_form = {
@@ -1004,13 +992,11 @@ def test_remove_tag_from_url_from_nonexistent_utub(
     with app.app_context():
         # Ensure the valid Tag-URL-UTub association still exists
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == existing_utub_id,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 1
         )
 
@@ -1026,14 +1012,15 @@ def test_remove_tag_from_url_from_nonexistent_utub(
         assert initial_utub_url_serialization == final_utub_url_serialization
 
         # Ensure URL tag associations are still same count
-        assert num_of_url_tag_associations == len(
-            Utub_Url_Tags.query.filter(
+        assert (
+            num_of_url_tag_associations
+            == Utub_Url_Tags.query.filter(
                 Utub_Url_Tags.utub_url_id == url_id_to_remove,
                 Utub_Url_Tags.tag_id == tag_id_to_remove,
-            ).all()
+            ).count()
         )
 
-        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert Utub_Url_Tags.query.count() == initial_num_tag_url_associations
 
 
 def test_remove_tag_from_nonexistent_url_utub(
@@ -1062,7 +1049,7 @@ def test_remove_tag_from_nonexistent_url_utub(
         existing_utub_id = valid_url_tag_association.utub_id
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
+        initial_num_tag_url_associations = Utub_Url_Tags.query.count()
 
     # Remove tag from this URL
     add_tag_form = {
@@ -1084,13 +1071,11 @@ def test_remove_tag_from_nonexistent_url_utub(
     with app.app_context():
         # Ensure the valid Tag-URL-UTub association still exists
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == existing_utub_id,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 1
         )
 
@@ -1107,7 +1092,7 @@ def test_remove_tag_from_nonexistent_url_utub(
             is None
         )
 
-        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert Utub_Url_Tags.query.count() == initial_num_tag_url_associations
 
 
 def test_remove_tag_with_no_csrf_token(
@@ -1141,7 +1126,7 @@ def test_remove_tag_with_no_csrf_token(
         existing_utub_id = valid_url_tag_association.utub_id
 
         # Initial number of Url-Tag associations
-        initial_num_tag_url_associations = len(Utub_Url_Tags.query.all())
+        initial_num_tag_url_associations = Utub_Url_Tags.query.count()
 
     # Remove tag from this URL
     add_tag_form = {}
@@ -1163,17 +1148,15 @@ def test_remove_tag_with_no_csrf_token(
     with app.app_context():
         # Ensure the valid Tag-URL-UTub association still exists
         assert (
-            len(
-                Utub_Url_Tags.query.filter(
-                    Utub_Url_Tags.utub_id == existing_utub_id,
-                    Utub_Url_Tags.utub_url_id == url_id_to_remove,
-                    Utub_Url_Tags.tag_id == tag_id_to_remove,
-                ).all()
-            )
+            Utub_Url_Tags.query.filter(
+                Utub_Url_Tags.utub_id == existing_utub_id,
+                Utub_Url_Tags.utub_url_id == url_id_to_remove,
+                Utub_Url_Tags.tag_id == tag_id_to_remove,
+            ).count()
             == 1
         )
 
-        assert len(Utub_Url_Tags.query.all()) == initial_num_tag_url_associations
+        assert Utub_Url_Tags.query.count() == initial_num_tag_url_associations
 
 
 def test_remove_tag_from_url_updates_utub_last_updated(

--- a/tests/integration/utuburls/conftest.py
+++ b/tests/integration/utuburls/conftest.py
@@ -88,7 +88,7 @@ def add_two_url_and_all_users_to_each_utub_no_tags(
                 Utub_Urls.utub_id == utub.id
             ).first()
             current_utub_id = current_utub_url.url_id
-            new_url: Urls = Urls.query.filter_by(id=((current_utub_id % 3) + 1)).first()
+            new_url: Urls = Urls.query.get(((current_utub_id % 3) + 1))
 
             new_utub_url_user_association = Utub_Urls()
 

--- a/tests/integration/utuburls/test_update_url_route.py
+++ b/tests/integration/utuburls/test_update_url_route.py
@@ -53,7 +53,10 @@ def test_update_valid_url_with_another_fresh_valid_url_as_utub_creator(
 
         # Verify URL to modify to is not already in database
         validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
-        assert Urls.query.filter_by(url_string=validated_new_fresh_url).first() is None
+        assert (
+            Urls.query.filter(Urls.url_string == validated_new_fresh_url).first()
+            is None
+        )
 
         # Get the URL in this UTub
         url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
@@ -180,15 +183,16 @@ def test_update_valid_url_with_another_fresh_valid_url_as_url_member(
         validated_new_fresh_url = find_common_url(NEW_FRESH_URL)
 
         # Get the URL in this UTub
-        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter_by(
-            utub_id=utub_member_of.id, user_id=current_user.id
+        url_in_this_utub: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_member_of.id, Utub_Urls.user_id == current_user.id
         ).first()
         current_title = url_in_this_utub.url_title
         current_url_id = url_in_this_utub.url_id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_member_of.id, utub_url_id=url_in_this_utub.id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_member_of.id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
@@ -433,8 +437,9 @@ def test_update_valid_url_with_previously_added_url_as_url_adder(
         url_id_of_url_not_in_utub = url_not_in_utub.url_id
 
         # Find associated tags with this url
-        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter_by(
-            utub_id=utub_id, utub_url_id=url_in_this_utub.id
+        associated_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_this_utub.id,
         ).all()
         associated_tag_ids = [tag.tag_id for tag in associated_tags]
 
@@ -797,8 +802,9 @@ def test_update_valid_url_with_invalid_url_as_utub_creator(
         )
 
         # Check associated tags
-        assert Utub_Url_Tags.query.filter_by(
-            utub_id=utub_creator_of.id, utub_url_id=id_of_url_in_utub
+        assert Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_creator_of.id,
+            Utub_Url_Tags.utub_url_id == id_of_url_in_utub,
         ).count() == len(associated_tags)
 
 


### PR DESCRIPTION
Clean up some tests to use `.count()` instead of `len`, and ensure usage of the composite primary key `(utub_id, user_id)` for `UtubMembers`.