### PR TITLE
Feature/cancel edit url utub

### DIFF
--- a/src/static/scripts/tags.js
+++ b/src/static/scripts/tags.js
@@ -49,8 +49,10 @@ function bindEscapeToExitAddNewTag(inputWrapper) {
   $(document)
     .unbind("keyup.27")
     .bind("keyup.27", function (e) {
-      e.stopPropagation();
-      cancelAddTagHideInput(inputWrapper);
+      if (e.which === 27) {
+        e.stopPropagation();
+        cancelAddTagHideInput(inputWrapper);
+      }
     });
 }
 

--- a/src/static/scripts/tags.js
+++ b/src/static/scripts/tags.js
@@ -44,6 +44,16 @@ function currentTagDeckIDs() {
   return tagIDList;
 }
 
+// Bind escape key to exit adding of a tag
+function bindEscapeToExitAddNewTag(inputWrapper) {
+  $(document)
+    .unbind("keyup.27")
+    .bind("keyup.27", function (e) {
+      e.stopPropagation();
+      cancelAddTagHideInput(inputWrapper);
+    });
+}
+
 // 11/25/23 need to figure out how to map tagids to Array so I can evaluate whether the tag already exists in Deck before adding it
 // Function to evaluate whether newly added tag already exists in Tag Deck
 function isTagInDeck(tagid) {

--- a/src/static/scripts/tags_routes.js
+++ b/src/static/scripts/tags_routes.js
@@ -6,14 +6,33 @@
 function addTagShowInput() {
   // Prevent deselection of URL while modifying its values
   unbindSelectURLBehavior();
+  unbindEscapeKey();
+  unbindURLKeyboardEventListenersWhenEditsOccurring();
 
   let URLCard = getSelectedURLCard();
 
   // Show temporary div element containing input
   let inputEl = URLCard.find(".addTag");
   inputEl.addClass("activeInput");
-  showIfHidden(inputEl.closest(".createDiv"));
+
+  const inputWrapper = inputEl.closest(".createDiv");
+  showIfHidden(inputWrapper);
   highlightInput(inputEl);
+  bindEscapeToExitAddNewTag(inputWrapper);
+
+  // Disable the other buttons in the URL
+  disable(URLCard.find(".accessURLBtn"));
+  disable(URLCard.find(".editURLBtn"));
+  disable(URLCard.find(".delURLBtn"));
+
+  // Modify add tag button
+  const addTagBtn = URLCard.find(".addTagBtn");
+  addTagBtn.removeClass("btn-info").addClass("btn-warning");
+  addTagBtn.text("Return");
+  addTagBtn.off("click").on("click", function (e) {
+    e.stopPropagation();
+    cancelAddTagHideInput(inputWrapper);
+  });
 
   // 02/29/24 Ideally this input would be a dropdown select input that allowed typing. As user types, selection menu filters on each keypress. User can either choose a suggested existing option, or enter a new custom tag
   // Redefine UI interaction with showInputBtn
@@ -28,6 +47,30 @@ function addTagShowInput() {
   //   <option value="opel">Opel</option>
   //   <option value="audi">Audi</option>
   // </select>
+}
+
+function cancelAddTagHideInput(inputWrapper) {
+  let URLCard = getSelectedURLCard();
+  bindEscapeToUnselectURL(getSelectedURLID());
+
+  // Enable the buttons again
+  enable(URLCard.find(".accessURLBtn"));
+  enable(URLCard.find(".editURLBtn"));
+  enable(URLCard.find(".delURLBtn"));
+
+  // Modify add tag button
+  const addTagBtn = URLCard.find(".addTagBtn");
+  addTagBtn.removeClass("btn-warning").addClass("btn-info");
+  addTagBtn.text("Add Tag");
+
+  addTagBtn.off("click").on("click", function (e) {
+    e.stopPropagation();
+    addTagShowInput();
+  });
+
+  hideIfShown(inputWrapper);
+  rebindSelectBehavior();
+  bindURLKeyboardEventListenersWhenEditsNotOccurring();
 }
 
 // Handles addition of new Tag to URL after user submission
@@ -74,7 +117,7 @@ function addTagSetup() {
 // Displays changes related to a successful addition of a new Tag
 function addTagSuccess(response) {
   // Rebind selection behavior of current URL
-  rebindSelectBehavior(getSelectedURLID());
+  rebindSelectBehavior();
 
   let selectedURLCard = getSelectedURLCard();
 

--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -55,17 +55,25 @@ function rebindSelectBehavior(URLID) {
     .on("click", function (e) {
       e.stopPropagation();
       e.preventDefault();
+      console.log("Trying to click on..");
       toggleSelectedURL(URLID);
+      bindEscapeToUnselectURL(URLID);
     });
+}
 
-  $(document).on("keyup", function (e) {
-    let keycode = e.keyCode ? e.keyCode : e.which;
-    if (keycode == 27) {
-      // ESC key, hide all URL cardCols
-      deselectAllURLs();
-      deselectAddURL();
-    }
-  });
+function bindEscapeToUnselectURL(urlID) {
+  $(document)
+    .unbind("keyup.27")
+    .bind("keyup.27", function (e) {
+      if (e.which === 27) {
+        console.log("Trying to access URL: " + urlID);
+        toggleSelectedURL(urlID);
+      }
+    });
+}
+
+function unbindEscapeKey() {
+  $(document).unbind("keyup.27");
 }
 
 // Opens new tab
@@ -185,32 +193,33 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
   const URLInfo = document.createElement("div"); // This element holds the URL title and string
   const URLTitleWrap = document.createElement("div"); // This element wraps the URL title and edit button
   const URLTitle = document.createElement("h5"); // This element displays the user-created title of the URL
-  const editURLTitleBtn = makeEditButton(20);
-  const editURLTitleWrap = document.createElement("div"); // This element wraps the edit field for URL title
-  const editURLTitleLabel = document.createElement("label"); // This element labels the edit field for URL title
-  const editURLTitleInput = document.createElement("input"); // This element is instantiated with the URL title
-  const submitEditURLTitleBtn = makeSubmitButton(20); // Submit changes after 'edit' operations
-  const cancelEditURLTitleBtn = makeCancelButton(20); // Cancel changes after 'edit' operations, populate with pre-edit values
+  const editURLTitleBtn = canModify ? makeEditButton(20) : null;
+  const editURLTitleWrap = canModify ? document.createElement("div") : null; // This element wraps the edit field for URL title
+  const editURLTitleLabel = canModify ? document.createElement("label") : null; // This element labels the edit field for URL title
+  const editURLTitleInput = canModify ? document.createElement("input") : null; // This element is instantiated with the URL title
+  const editURLBtnWrap = canModify ? document.createElement("div") : null;
+  const submitEditURLTitleBtn = canModify ? makeSubmitButton(20) : null; // Submit changes after 'edit' operations
+  const cancelEditURLTitleBtn = canModify ? makeCancelButton(20) : null; // Cancel changes after 'edit' operations, populate with pre-edit values
   const URLWrap = document.createElement("div"); // This element wraps the URL title and edit button
   const URL = document.createElement("p"); // This element displays the user's URL
-  const editURLBtn = makeEditButton(15);
-  const editURLWrap = document.createElement("div"); // This element wraps the edit field for URL string
-  const editURLLabel = document.createElement("label"); // This element labels the edit field for URL string
-  const editURLInput = document.createElement("input"); // This element is instantiated with the URL
-  const submitEditURLBtn = makeSubmitButton(15); // Submit changes after 'edit' operations
-  const cancelEditURLBtn = makeCancelButton(15); // Cancel changes after 'edit' operations, populate with pre-edit values
+  const editURLWrap = canModify ? document.createElement("div") : null; // This element wraps the edit field for URL string
+  const editURLInput = canModify ? document.createElement("input") : null; // This element is instantiated with the URL
+  const submitEditURLBtn = canModify ? makeSubmitButton(25) : null; // Submit changes after 'edit' operations
+  const cancelEditURLBtn = canModify ? makeCancelButton(25) : null; // Cancel changes after 'edit' operations, populate with pre-edit values
   const URLTags = document.createElement("div");
+  const tagsWrap = document.createElement("div");
   const URLOptions = document.createElement("div");
   const accessURLBtn = document.createElement("button");
+  const editURLBtn = canModify ? document.createElement("button") : null;
   const addTagBtn = document.createElement("button");
-  const delURLBtn = document.createElement("button");
+  const delURLBtn = canModify ? document.createElement("button") : null;
 
   $(col)
     .addClass("cardCol mb-3 col-md-12 col-sm-12 col-lg-12 col-xl-12 col-xxl-6")
     .on("click", function (e) {
-      e.stopPropagation();
       e.preventDefault();
       toggleSelectedURL(URLID);
+      bindEscapeToUnselectURL(URLID);
     });
 
   $(card).addClass("card url").attr({
@@ -246,7 +255,7 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
       .attr({ style: "display: none" });
 
     $(editURLTitleWrap)
-      .addClass("createDiv form-group")
+      .addClass("createDiv flex-row form-group")
       .attr({ style: "display: none" });
 
     $(editURLTitleLabel)
@@ -282,25 +291,13 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
         editURLTitleHideInput();
       });
 
-    $(editURLBtn)
-      .addClass("editURLBtn")
-      .on("click", function (e) {
-        e.stopPropagation();
-        e.preventDefault();
-        editURLShowInput();
-      })
-      .attr({ style: "display: none" });
-
     $(editURLWrap)
-      .addClass("createDiv form-group")
+      .addClass("createDiv flex-row form-group")
       .attr({ style: "display: none" });
 
-    $(editURLLabel)
-      .attr({
-        for: "editURL-" + URLID,
-        style: "display:block",
-      })
-      .html("<b> URL </b>");
+    $(editURLBtnWrap)
+      .addClass("editURLBtnWrap createDiv flex-row form-group")
+      .attr({ style: "display: none;" });
 
     $(editURLInput)
       .addClass("card-text userInput editURL")
@@ -332,16 +329,23 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
         e.preventDefault();
         editURLHideInput();
         $(document).bind("keypress", function (e) {
-          if (e.which == 27) {
+          if (e.which === 27) {
             hideInputs();
           }
         });
       });
+
+    $(editURLBtnWrap).append(submitEditURLBtn).append(cancelEditURLBtn);
   }
 
   $(URLInfo).addClass("card-body URLInfo");
 
-  $(URLTags).addClass("card-body URLTags").attr({ style: "display: none" });
+  $(URLTags)
+    .addClass("card-body URLTags flex-column")
+    .attr({ style: "display: none" })
+    .append(tagsWrap);
+
+  $(tagsWrap).addClass("flex-row flex-start");
 
   // Add tag badges
   for (let j in tagArray) {
@@ -354,7 +358,7 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
 
     let tagSpan = createTagBadgeInURL(tag.id, tag.tagString);
 
-    $(URLTags).append(tagSpan);
+    $(tagsWrap).append(tagSpan);
   }
   // New tag create span
   $(URLTags).append(createNewTagInputField());
@@ -394,6 +398,16 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
         e.preventDefault();
         deleteURLShowModal();
       });
+
+    $(editURLBtn)
+      .addClass("card-link btn btn-light editURLBtn")
+      .attr({ type: "button" })
+      .text("Edit Link")
+      .on("click", function (e) {
+        e.stopPropagation();
+        e.preventDefault();
+        editURLShowInput();
+      });
   }
 
   // Assemble url list items
@@ -409,11 +423,9 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
       .append(submitEditURLTitleBtn)
       .append(cancelEditURLTitleBtn);
     $(URLWrap).append(URL).append(editURLBtn);
-    $(editURLWrap)
-      .append(editURLLabel)
-      .append(editURLInput)
-      .append(submitEditURLBtn)
-      .append(cancelEditURLBtn);
+    $(editURLWrap).append(editURLInput).append(editURLBtnWrap);
+    //.append(submitEditURLBtn)
+    //.append(cancelEditURLBtn);
     $(URLInfo)
       .append(URLTitleWrap)
       .append(editURLTitleWrap)
@@ -423,7 +435,11 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
     $(card).append(URLTags);
 
     $(card).append(URLOptions);
-    $(URLOptions).append(accessURLBtn).append(addTagBtn).append(delURLBtn);
+    $(URLOptions)
+      .append(accessURLBtn)
+      .append(editURLBtn)
+      .append(addTagBtn)
+      .append(delURLBtn);
   } else {
     $(URLTitleWrap).append(URLTitle);
     $(URLWrap).append(URL);
@@ -432,7 +448,7 @@ function createURLBlock(URLID, string, title, tagArray, dictTags, canModify) {
     $(card).append(URLTags);
 
     $(card).append(URLOptions);
-    $(URLOptions).append(accessURLBtn);
+    $(URLOptions).append(accessURLBtn).append(addTagBtn);
   }
   // $(URLOptions).append(submitEditBtn);
   // $(URLOptions).append(cancelEditBtn);
@@ -574,6 +590,9 @@ function deselectURL(deselectedCardCol) {
   hideIfShown(deselectedCardCol.find(".URLOptions"));
   hideIfShown(deselectedCardCol.find(".editURLTitleBtn"));
   hideIfShown(deselectedCardCol.find(".editURLBtn"));
+
+  // Unbind escape key from showing URL
+  unbindEscapeKey();
 }
 
 // Deselects all URLs in preparation for creation URL
@@ -749,9 +768,8 @@ function displayState0URLDeck() {
 }
 
 // Display state 1: UTub selected, URL list and subheader prompt
-function displayState1URLDeck() {
+function displayState1URLDeck(UTubName) {
   let numOfURLs = getNumOfURLs();
-  let UTubName = getCurrentUTubName();
   $("#URLDeckHeader").text(UTubName);
   $("#editUTubName").val(UTubName);
 

--- a/src/static/scripts/urls_routes.js
+++ b/src/static/scripts/urls_routes.js
@@ -94,6 +94,7 @@ function addURLFail(response) {
 // Shows edit URL inputs
 function editURLShowInput() {
   // Show edit submission and cancel button, hide edit button
+  unbindURLKeyboardEventListenersWhenEditsOccurring();
   const selectedCardDiv = getSelectedURLCard();
   const editURLInput = selectedCardDiv.find(".editURL");
   const URL = selectedCardDiv.find(".URL");
@@ -101,6 +102,7 @@ function editURLShowInput() {
   // Show input field
   showIfHidden(editURLInput.closest(".createDiv"));
   showIfHidden(editURLInput.next(".editURLBtnWrap"));
+  editURLInput.focus();
 
   // Hide published value
   hideIfShown(URL);
@@ -166,13 +168,14 @@ function editURLHideInput() {
   });
 
   // Rebind click selection behavior to unselect URL
-  rebindSelectBehavior(getSelectedURLID());
+  rebindSelectBehavior();
 
   // Unbind escape key from hiding edit
   $(document).unbind("keyup.27");
 
   // Rebind escape key to hiding selected URL
   bindEscapeToUnselectURL(getSelectedURLID());
+  bindURLKeyboardEventListenersWhenEditsNotOccurring();
 }
 
 // Handles edition of an existing URL
@@ -221,7 +224,7 @@ function editURLSuccess(response) {
   selectedCardDiv.attr("urlid", editedURLID);
 
   // If edit URL action, rebind the ability to select/deselect URL by clicking it
-  rebindSelectBehavior(getSelectedURLID());
+  rebindSelectBehavior();
 
   // Update URL body with latest published data
   selectedCardDiv.find(".card-text").text(editedURLString);
@@ -286,7 +289,7 @@ function editURLTitleHideInput() {
   showIfHidden(URLTitle);
 
   // Rebind select behavior
-  rebindSelectBehavior(getSelectedURLID());
+  rebindSelectBehavior();
 }
 
 // Handles edition of an existing URL
@@ -331,7 +334,7 @@ function editURLTitleSuccess(response) {
   const selectedCardDiv = getSelectedURLCard();
 
   // If edit URL action, rebind the ability to select/deselect URL by clicking it
-  rebindSelectBehavior(getSelectedURLID());
+  rebindSelectBehavior();
 
   // Update URL body with latest published data
   selectedCardDiv.find(".card-title").text(editedURLTitle);

--- a/src/static/scripts/urls_routes.js
+++ b/src/static/scripts/urls_routes.js
@@ -100,12 +100,39 @@ function editURLShowInput() {
 
   // Show input field
   showIfHidden(editURLInput.closest(".createDiv"));
+  showIfHidden(editURLInput.next(".editURLBtnWrap"));
 
   // Hide published value
   hideIfShown(URL);
 
+  // Disable URL Buttons
+  disable(selectedCardDiv.find(".accessURLBtn"));
+  disable(selectedCardDiv.find(".addTagBtn"));
+  disable(selectedCardDiv.find(".delURLBtn"));
+
+  // Edit URL Button text to show a return string
+  const editURLBtn = selectedCardDiv.find(".editURLBtn");
+  editURLBtn.text("Exit Editing");
+  editURLBtn.removeClass("btn-light").addClass("btn-warning");
+
+  // Make the button close editing now if clicked
+  editURLBtn.off("click").on("click", function (e) {
+    e.stopPropagation();
+    editURLHideInput();
+  });
+
   // Inhibit selection toggle behavior until user cancels edit, or successfully submits edit. User can still select and edit other URLs in UTub
   unbindSelectURLBehavior();
+
+  // Allow escape key to close editing
+  $(document)
+    .unbind("keyup.27")
+    .bind("keyup.27", function (e) {
+      if (e.which === 27) {
+        e.stopPropagation();
+        editURLHideInput();
+      }
+    });
 }
 
 // Hides edit URL inputs
@@ -124,8 +151,28 @@ function editURLHideInput() {
   // Show published value
   showIfHidden(URL);
 
-  // Rebind select behavior
+  // Enable URL Buttons
+  enable(selectedCardDiv.find(".accessURLBtn"));
+  enable(selectedCardDiv.find(".addTagBtn"));
+  enable(selectedCardDiv.find(".delURLBtn"));
+
+  // Edit URL Button text to show a return string
+  const editURLBtn = selectedCardDiv.find(".editURLBtn");
+  editURLBtn.text("Edit URL");
+  editURLBtn.removeClass("btn-warning").addClass("btn-light");
+  editURLBtn.off("click").on("click", function (e) {
+    e.stopPropagation();
+    editURLShowInput();
+  });
+
+  // Rebind click selection behavior to unselect URL
   rebindSelectBehavior(getSelectedURLID());
+
+  // Unbind escape key from hiding edit
+  $(document).unbind("keyup.27");
+
+  // Rebind escape key to hiding selected URL
+  bindEscapeToUnselectURL(getSelectedURLID());
 }
 
 // Handles edition of an existing URL

--- a/src/static/scripts/utils.js
+++ b/src/static/scripts/utils.js
@@ -24,33 +24,47 @@ $(document).ready(function () {
     return false;
   });
 
-  // Bind esc key (keycode 27) to hide any visible user input createDivs
-  $(document).bind("keyup", function (e) {
-    if (e.which == 27) {
-      hideInputs();
-    }
-  });
-
   // Keyboard navigation between selected UTubs or URLs
   $(document).on("keyup", function (e) {
-    let keycode = e.keyCode ? e.keyCode : e.which;
-    let prev = keycode == 37 || keycode == 38; // UP and LEFT keys
-    let next = keycode == 39 || keycode == 40; // DOWN and RIGHT keys
+    const keycode = e.keyCode ? e.keyCode : e.which;
+    const prev = keycode === 37 || keycode === 38; // UP and LEFT keys
+    const next = keycode === 39 || keycode === 40; // DOWN and RIGHT keys
 
     if ($("#URLFocusRow").length > 0) {
       // Some URL is selected, switch URLs
 
-      let UPRcards = $("#UPRRow").children(".cardCol").length;
-      let LWRcards = $("#LWRRow").children(".cardCol").length;
+      const UPRCards = $("#UPRRow").children(".cardCol");
+      const LWRCards = $("#LWRRow").children(".cardCol");
 
-      if (prev && UPRcards > 0) {
-        // User wants to highlight previous URL
-        let cardCol = $($("#UPRRow").children(".cardCol")[UPRcards - 1]);
-        toggleSelectedURL($(cardCol[0].children).attr("urlid"));
-      } else if (next && LWRcards > 0) {
-        // User wants to highlight next URL
-        let cardCol = $($("#LWRRow").children(".cardCol")[0]);
-        toggleSelectedURL($(cardCol[0].children).attr("urlid"));
+      const UPRcardsCount = UPRCards.length;
+      const LWRcardsCount = LWRCards.length;
+
+      if (prev) {
+        let urlID;
+        if (UPRcardsCount > 0) {
+          // User wants to highlight previous URL
+          const cardCol = $($(UPRCards)[UPRcardsCount - 1]);
+          urlID = $(cardCol[0].children).attr("urlid");
+        } else {
+          // Highlight last card in lower row
+          const cardCol = $($(LWRCards)[LWRcardsCount - 1]);
+          urlID = $(cardCol[0].children).attr("urlid");
+        }
+        toggleSelectedURL(urlID);
+        bindEscapeToUnselectURL(urlID);
+      } else if (next) {
+        let urlID;
+        if (LWRcardsCount === 0) {
+          // User hit the last URL and should cycle back
+          const cardCol = $($(UPRCards)[0]);
+          urlID = $(cardCol[0].children).attr("urlid");
+        } else {
+          // User has another URL in the LWRRow to select
+          const cardCol = $($(LWRCards)[0]);
+          urlID = $($(cardCol)[0].children).attr("urlid");
+        }
+        toggleSelectedURL(urlID);
+        bindEscapeToUnselectURL(urlID);
       }
     } else {
       // No URL selected, switch UTubs
@@ -198,6 +212,16 @@ function makeCancelButton(wh) {
   $(cancelBtn).addClass("mx-1").html(htmlString);
 
   return cancelBtn;
+}
+
+// Disables buttons
+function disable(jqueryObj) {
+  $(jqueryObj).prop("disabled", true);
+}
+
+// Enables buttons
+function enable(jqueryObj) {
+  $(jqueryObj).prop("disabled", false);
 }
 
 function displayState0() {

--- a/src/static/scripts/utils.js
+++ b/src/static/scripts/utils.js
@@ -23,15 +23,17 @@ $(document).ready(function () {
   $("form").on("submit", function () {
     return false;
   });
+});
 
-  // Keyboard navigation between selected UTubs or URLs
-  $(document).on("keyup", function (e) {
-    const keycode = e.keyCode ? e.keyCode : e.which;
-    const prev = keycode === 37 || keycode === 38; // UP and LEFT keys
-    const next = keycode === 39 || keycode === 40; // DOWN and RIGHT keys
-
-    if ($("#URLFocusRow").length > 0) {
-      // Some URL is selected, switch URLs
+// Keyboard navigation between selected UTubs or URLs
+function bindURLKeyboardEventListenersWhenEditsNotOccurring() {
+  $(document)
+    .off("keyup.switchutubs")
+    .on("keyup.switchutubs", function (e) {
+      e.stopPropagation();
+      const keycode = e.keyCode ? e.keyCode : e.which;
+      const prev = keycode === 37 || keycode === 38; // UP and LEFT keys
+      const next = keycode === 39 || keycode === 40; // DOWN and RIGHT keys
 
       const UPRCards = $("#UPRRow").children(".cardCol");
       const LWRCards = $("#LWRRow").children(".cardCol");
@@ -66,11 +68,18 @@ $(document).ready(function () {
         toggleSelectedURL(urlID);
         bindEscapeToUnselectURL(urlID);
       }
-    } else {
-      // No URL selected, switch UTubs
-    }
-  });
-});
+
+      //REHCH Goal: No URL selected, switch UTubs
+    });
+}
+
+function unbindURLKeyboardEventListenersWhenEditsOccurring() {
+  $(document).off("keyup.switchutubs");
+}
+
+function unbindEscapeKey() {
+  $(document).unbind("keyup.27");
+}
 
 // General Functions
 

--- a/src/static/scripts/utubs.js
+++ b/src/static/scripts/utubs.js
@@ -101,8 +101,6 @@ function resetUTubDeck() {
 
 // Create event listeners to escape from editing UTub name
 function setEventListenersToEscapeEditUTubName() {
-  console.log("Setting up event listeners for edit UTub name!");
-
   // Allow user to still click in the text box
   $("#editUTubName").on("click", function (e) {
     e.stopPropagation();
@@ -111,26 +109,23 @@ function setEventListenersToEscapeEditUTubName() {
   // Bind clicking outside the window
   $(window)
     .off("click")
-    .on("click", function () {
+    .on("click", function (e) {
       // Hide UTub name edit fields
-      console.log("Hiding the inputs");
       editUTubNameHideInput();
     });
 
   // Bind escape key
-  $(document).bind("keyup.27", function (e) {
+  $(document).bind("keyup.escapeKeyUTubName", function (e) {
     if (e.which === 27) {
       hideInputs();
-      console.log("Hiding the inputs");
       editUTubNameHideInput();
     }
   });
 }
 
 function removeEventListenersToEscapeEditUTubName() {
-  console.log("Removing event listeners for edit UTub name!");
   $(window).off("click");
-  $(document).unbind("keyup.27");
+  $(document).unbind("keyup.escapeKeyUTubName");
   $("#editUTubName").off("click");
 }
 
@@ -200,8 +195,8 @@ function buildSelectedUTub(selectedUTub) {
 
   // Only allow owner to edit UTub name
   isCurrentUserOwner
-    ? showIfHidden($("#editUTubNameBtn"))
-    : hideIfShown($("#editUTubNameBtn"));
+    ? $("#editUTubNameBtn").removeClass("hiddenBtn").addClass("visibleBtn")
+    : $("#editUTubNameBtn").addClass("hiddenBtn").removeClass("visibleBtn");
 }
 
 // Handles progagating changes across page related to a UTub selection

--- a/src/static/scripts/utubs.js
+++ b/src/static/scripts/utubs.js
@@ -83,6 +83,7 @@ function getUTubInfo(selectedUTubID) {
   return $.getJSON("/home?UTubID=" + selectedUTubID);
 }
 
+// Utility route to get all UTub summaries
 function getAllUTubs() {
   return $.getJSON("/utubs");
 }
@@ -96,6 +97,41 @@ function resetNewUTubForm() {
 // Clear the UTub Deck
 function resetUTubDeck() {
   $("#listUTubs").empty();
+}
+
+// Create event listeners to escape from editing UTub name
+function setEventListenersToEscapeEditUTubName() {
+  console.log("Setting up event listeners for edit UTub name!");
+
+  // Allow user to still click in the text box
+  $("#editUTubName").on("click", function (e) {
+    e.stopPropagation();
+  });
+
+  // Bind clicking outside the window
+  $(window)
+    .off("click")
+    .on("click", function () {
+      // Hide UTub name edit fields
+      console.log("Hiding the inputs");
+      editUTubNameHideInput();
+    });
+
+  // Bind escape key
+  $(document).bind("keyup.27", function (e) {
+    if (e.which === 27) {
+      hideInputs();
+      console.log("Hiding the inputs");
+      editUTubNameHideInput();
+    }
+  });
+}
+
+function removeEventListenersToEscapeEditUTubName() {
+  console.log("Removing event listeners for edit UTub name!");
+  $(window).off("click");
+  $(document).unbind("keyup.27");
+  $("#editUTubName").off("click");
 }
 
 /** UTub Functions **/
@@ -131,6 +167,7 @@ function buildSelectedUTub(selectedUTub) {
 
   const isUTubHistoryNull = window.history.state === null;
 
+  // Allow user to back and forth in browser based on given UTub selection
   if (
     isUTubHistoryNull ||
     JSON.stringify(window.history.state.UTub) !== JSON.stringify(selectedUTub)
@@ -154,13 +191,17 @@ function buildSelectedUTub(selectedUTub) {
   // URL deck
   buildURLDeck(UTubName, dictURLs, dictTags);
 
-  // RH panels
-  // UTub Description deck
+  // UTub Description
   if (UTubDescription) displayState2UTubDescriptionDeck(UTubDescription);
   else displayState1UTubDescriptionDeck();
 
   // Members deck
   buildMemberDeck(dictMembers, UTubOwnerID, isCurrentUserOwner);
+
+  // Only allow owner to edit UTub name
+  isCurrentUserOwner
+    ? showIfHidden($("#editUTubNameBtn"))
+    : hideIfShown($("#editUTubNameBtn"));
 }
 
 // Handles progagating changes across page related to a UTub selection
@@ -224,7 +265,7 @@ function createNewUTubInputField() {
     .on("click", function (e) {
       e.stopPropagation();
       e.preventDefault();
-      checkSameNameUTub(1, $("#createUTub").val());
+      checkSameNameUTub(true, $("#createUTub").val());
     });
 
   $(cancelBtn)
@@ -288,9 +329,12 @@ function displayState0UTubDeck() {
 // No actions performed within other decks can affect UTub Deck display
 function displayState1UTubDeck(selectedUTubID, UTubOwnerUserID) {
   hideInputs();
+  const numOfUTubs = getNumOfUTubs();
+  const subheaderText =
+    numOfUTubs > 1 ? numOfUTubs + " UTubs" : numOfUTubs + " UTub";
 
   // Subheader to tell user how many UTubs are accessible
-  $("#UTubDeckSubheader").text(getNumOfUTubs() + " UTubs");
+  $("#UTubDeckSubheader").text(subheaderText);
 
   // UTub selected
 
@@ -298,7 +342,6 @@ function displayState1UTubDeck(selectedUTubID, UTubOwnerUserID) {
   bindUTubSelectionBehavior();
   if (selectedUTubID) {
     unbindUTubSelectionBehavior(selectedUTubID);
-    showIfHidden($("#editUTubNameBtn"));
     showIfHidden($("#editUTubDescriptionBtn"));
   }
 
@@ -368,13 +411,16 @@ function displayState3UTubDescriptionDeck(UTubDescription) {
 /** Post data handling **/
 
 // Checks if submitted UTub name exists in db. mode is 0 for editUTub, 1 for addUTub
-function checkSameNameUTub(mode, name) {
+function checkSameNameUTub(isAddingUTub, name) {
   if (getAllAccessibleUTubNames().includes(name)) {
     // UTub with same name exists. Confirm action with user
-    sameNameWarningShowModal(mode, getUTubIDFromName(name));
+    const duplicateUTubIDFromName = getUTubIDFromName(name);
+    isAddingUTub
+      ? sameUTubNameOnNewUTubWarningShowModal(duplicateUTubIDFromName)
+      : sameUTubNameOnEditUtubNameWarningShowModal(duplicateUTubIDFromName);
   } else {
     // UTub name is unique. Proceed with requested action
-    mode ? addUTub() : editUTubName();
+    isAddingUTub ? addUTub() : editUTubName();
   }
 }
 
@@ -383,13 +429,13 @@ function sameNameWarningHideModal() {
   $("#confirmModal").modal("hide");
 }
 
-// Handles a double check if user inputs a new UTub name similar to one already existing. mode 1 'add', mode 0 'edit'
-function sameNameWarningShowModal(mode, UTubID) {
-  let modalTitle = "Are you sure you want to create a new UTub with this name?";
-  let modalBody = "A UTub in your repository has a similar name.";
-  let buttonTextDismiss = "Go back and change name";
-  let buttonTextRedirect = "Go to UTub";
-  let buttonTextSubmit = "Create";
+// Handles a double check if user inputs a new UTub name similar to one already existing. mode true 'add', mode false 'edit'
+function sameUTubNameOnNewUTubWarningShowModal(UTubID) {
+  const modalTitle = "Create a new UTub with this name?";
+  const modalBody = "A UTub in your repository has an identical name.";
+  const buttonTextDismiss = "Go Back to Editing";
+  const buttonTextRedirect = "Go to UTub";
+  const buttonTextSubmit = "Create";
 
   $("#confirmModalTitle").text(modalTitle);
 
@@ -401,8 +447,9 @@ function sameNameWarningShowModal(mode, UTubID) {
     .off("click")
     .on("click", function (e) {
       e.preventDefault();
+      e.stopPropagation();
       sameNameWarningHideModal();
-      highlightInput(mode ? $("#createUTub") : $("#editUTubName"));
+      highlightInput($("#createUTub"));
     });
 
   showIfHidden($("#modalRedirect"));
@@ -413,7 +460,7 @@ function sameNameWarningShowModal(mode, UTubID) {
     .on("click", function (e) {
       e.preventDefault();
       $("#confirmModal").modal("hide");
-      mode ? addUTubHideInput() : editUTubNameHideInput();
+      addUTubHideInput();
       selectUTub(UTubID);
     });
 
@@ -424,10 +471,66 @@ function sameNameWarningShowModal(mode, UTubID) {
     .off("click")
     .on("click", function (e) {
       e.preventDefault();
-      mode ? addUTub() : editUTubName();
+      addUTub();
       hideIfShown($("#modalRedirect"));
       $("#modalRedirect").hide();
     });
 
   $("#confirmModal").modal("show");
+}
+
+function sameUTubNameOnEditUtubNameWarningShowModal(UTubID) {
+  const modalTitle = "Edit this UTub name?";
+  const modalBody = "A UTub in your repository has an identical name.";
+  const buttonTextDismiss = "Go Back to Editing";
+  const buttonTextRedirect = "Go to UTub";
+  const buttonTextSubmit = "Edit Name";
+
+  removeEventListenersToEscapeEditUTubName();
+
+  $("#confirmModalTitle").text(modalTitle);
+
+  $("#confirmModalBody").text(modalBody);
+
+  $("#modalDismiss")
+    .addClass("btn btn-secondary")
+    .text(buttonTextDismiss)
+    .off("click")
+    .on("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      sameNameWarningHideModal();
+      highlightInput($("#editUTubName"));
+      setEventListenersToEscapeEditUTubName();
+    });
+
+  showIfHidden($("#modalRedirect"));
+  $("#modalRedirect")
+    .addClass("btn btn-primary")
+    .text(buttonTextRedirect)
+    .off("click")
+    .on("click", function (e) {
+      e.preventDefault();
+      $("#confirmModal").modal("hide");
+      editUTubNameHideInput();
+      selectUTub(UTubID);
+    });
+
+  $("#modalSubmit")
+    .removeClass()
+    .addClass("btn btn-success")
+    .text(buttonTextSubmit)
+    .off("click")
+    .on("click", function (e) {
+      e.preventDefault();
+      editUTubName();
+      hideIfShown($("#modalRedirect"));
+      $("#modalRedirect").hide();
+    });
+
+  $("#confirmModal").modal("show");
+  $("#confirmModal").on("hidden.bs.modal", function (e) {
+    e.stopPropagation();
+    setEventListenersToEscapeEditUTubName();
+  });
 }

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -16,6 +16,7 @@ $(document).ready(function () {
   });
 
   // Edit UTub name
+  const editUTubNameBtn = $("#editUTubNameBtn");
   $("#editUTubNameBtn").on("click", function (e) {
     hideInputs();
     deselectAllURLs();
@@ -143,8 +144,14 @@ function editUTubNameShowInput() {
   hideIfShown($("#editUTubNameBtn"));
   hideIfShown($("#addURLBtn"));
 
+  // Handle hiding the button on mobile when hover events stay after touch
+  $("#editUTubNameBtn").removeClass("visibleBtn");
+
   // Setup event listeners on window and escape key to escape the input box
   setEventListenersToEscapeEditUTubName();
+
+  // Prevent URL keyboard selection while editing name
+  unbindURLKeyboardEventListenersWhenEditsOccurring();
 }
 
 // Hides input fields for editing an exiting UTub's name
@@ -157,8 +164,14 @@ function editUTubNameHideInput() {
   showIfHidden($("#editUTubNameBtn"));
   showIfHidden($("#addURLBtn"));
   $(window).off("click");
-  $(document).unbind("keyup.27");
+  $(document).unbind("keyup.escapeKeyUTubName");
   $("#editUTubName").off("click");
+
+  // Handle giving mobile devices ability to see button again
+  $("#editUTubNameBtn").addClass("visibleBtn");
+
+  // Allow URL selection with keyboard again
+  bindURLKeyboardEventListenersWhenEditsNotOccurring();
 }
 
 // Handles post request and response for editing an existing UTub's name

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -16,14 +16,18 @@ $(document).ready(function () {
   });
 
   // Edit UTub name
-  $("#editUTubNameBtn").on("click", function () {
+  $("#editUTubNameBtn").on("click", function (e) {
     hideInputs();
     deselectAllURLs();
     editUTubNameShowInput();
+    // Prevent this event from bubbling up to the window to allow event listener creation
+    e.stopPropagation();
   });
 
-  $("#submitEditUTubNameBtn").on("click", function () {
-    checkSameNameUTub(0, $("#editUTubName").val());
+  $("#submitEditUTubNameBtn").on("click", function (e) {
+    // Prevent event from bubbling up to window which would exit the input box
+    e.stopPropagation();
+    checkSameNameUTub(false, $("#editUTubName").val());
   });
 
   // Edit UTub description
@@ -137,8 +141,10 @@ function editUTubNameShowInput() {
   // Hide current name and edit button
   hideIfShown($("#URLDeckHeader"));
   hideIfShown($("#editUTubNameBtn"));
-  hideIfShown($("#editUTubNameBtn"));
   hideIfShown($("#addURLBtn"));
+
+  // Setup event listeners on window and escape key to escape the input box
+  setEventListenersToEscapeEditUTubName();
 }
 
 // Hides input fields for editing an exiting UTub's name
@@ -149,8 +155,10 @@ function editUTubNameHideInput() {
   // Show values and edit button
   showIfHidden($("#URLDeckHeader"));
   showIfHidden($("#editUTubNameBtn"));
-  showIfHidden($("#editUTubNameBtn"));
   showIfHidden($("#addURLBtn"));
+  $(window).off("click");
+  $(document).unbind("keyup.27");
+  $("#editUTubName").off("click");
 }
 
 // Handles post request and response for editing an existing UTub's name

--- a/src/static/styles/app.css
+++ b/src/static/styles/app.css
@@ -29,6 +29,8 @@
     --tagSelectedTextColor: rgba(14, 66, 27, 1.0);
 
     --contentTopBorder: rgba(126, 130, 130, 0.25);
+
+    --cardURLTextColor: rgba(140, 155, 157, 1.0);
 }
 
 /** HTML DOM Elements **/

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -117,6 +117,7 @@ div#pageContent {
     align-items: center;
 }
 
+
 /* UTubs */
 
 .active,
@@ -313,6 +314,19 @@ span.tagBadge:hover .tag-remove {
 .editURLBtnWrap {
     padding-inline:10px;
     gap: 10px;
+}
+
+#UTubNameEditWrap > .visibleBtn {
+    display: none !important;
+
+}
+
+#UTubNameEditWrap:hover > .visibleBtn {
+    display: flex !important;
+}
+
+.hiddenBtn#editUTubNameBtn {
+    display: none !important;
 }
 
 /* Members */

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -204,7 +204,19 @@ span.tagBadge:hover .tag-remove {
     border-color: var(--tagBorderColor);
 }
 
+.URLTags {
+    gap: 2rem;
+}
+
 /* URLs */
+
+.URLOptions {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: no-wrap;
+    justify-content: flex-start;
+    align-items: baseline;
+}
 
 .card {
     background-color: var(--cardBackgroundColor);
@@ -223,7 +235,6 @@ span.tagBadge:hover .tag-remove {
     color: #1abc9c;
     margin-bottom: 2px;
     overflow: hidden;
-    width: 100%;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
@@ -236,7 +247,6 @@ span.tagBadge:hover .tag-remove {
     margin-bottom: 0px;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: 100%;
     overflow: hidden;
 }
 
@@ -257,7 +267,7 @@ span.tagBadge:hover .tag-remove {
     white-space: normal;
     text-overflow: unset;
 }
-/home/giovannigp/Videos/U4I_URLWrapping.webm/home/giovannigp/Videos/U4I_URLWrapping.webm
+
 .URLString {
     width: 200px;
     white-space: nowrap;
@@ -279,6 +289,15 @@ span.tagBadge:hover .tag-remove {
 
 .col-xl-3 {
     flex-shrink: 1;
+}
+
+.editURL {
+    width: 75%;
+}
+
+.editURLBtnWrap {
+    padding-inline:10px;
+    gap: 10px;
 }
 
 /* Members */
@@ -344,6 +363,10 @@ span.member:hover .member-remove {
     color: rgba(255, 255, 255, 0.75);
 }
 
+#editUTubNameBtn {
+    color: rgba(84, 84, 84, 1.0);
+}
+
 
 /* Media size for responsiveness 
  * https://getbootstrap.com/docs/5.2/layout/breakpoints/ 
@@ -372,6 +395,10 @@ span.member:hover .member-remove {
 
     div#pageContent {
         flex-direction: column;
+    }
+
+    #accessAllURLsBtn {
+        width: 100% !important;
     }
 
 }

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -240,7 +240,7 @@ span.tagBadge:hover .tag-remove {
 }
 
 .card-text {
-    color: #8c9b9d;
+    color: var(--cardURLTextColor);
 }
 
 .url-string {
@@ -262,10 +262,23 @@ span.tagBadge:hover .tag-remove {
     cursor: auto;
 }
 
+.URL .url-string {
+    text-decoration: none;
+}
+
+.URL .url-string:hover {
+    color: var(--cardURLTextColor);
+}
+
 .selectedURL .card-title,
 .selectedURL .url-string {
     white-space: normal;
     text-overflow: unset;
+}
+
+.selectedURL .url-string:hover {
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 .URLString {
@@ -274,6 +287,7 @@ span.tagBadge:hover .tag-remove {
     overflow: hidden;
     text-overflow: ellipsis
 }
+
 
 .col-lg-10 {
     flex-grow: 1;
@@ -293,6 +307,7 @@ span.tagBadge:hover .tag-remove {
 
 .editURL {
     width: 75%;
+    color: var(--darkGrayTextColor);
 }
 
 .editURLBtnWrap {

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -146,7 +146,19 @@
 
             <div class="col-9 col-lg-9 flex-row align-center">
                 <!-- Header -->
-                <h2 id="URLDeckHeader">URLs</h2>
+                <div class="flex-row align-center" id="UTubNameEditWrap">
+                    <h2 id="URLDeckHeader">URLs</h2>
+                    <!-- Edit UTub name button -->
+                    <i id="editUTubNameBtn" class="mx-1">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor"
+                            class="bi bi-pencil-square editIcon" viewBox="0 0 16 16">
+                            <path
+                                d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z" />
+                            <path fill-rule="evenodd"
+                                d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z" />
+                        </svg>
+                    </i>
+                </div>
 
                 <!-- Edit UTub name -->
                 <div class="createDiv flex-row" style="display: none">
@@ -162,8 +174,8 @@
                     </i>
                 </div>
 
-                <!-- Edit UTub button -->
-                <i id="editUTubNameBtn" class="mx-1" style="display: none;">
+                <!-- Edit UTub button
+                <i id="editUTubNameBtn" class="mx-1">
                     <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor"
                         class="bi bi-pencil-square editIcon" viewBox="0 0 16 16">
                         <path
@@ -172,6 +184,7 @@
                             d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z" />
                     </svg>
                 </i>
+                -->
             </div>
 
             <!-- Add URL button -->

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -140,7 +140,7 @@
 <!-- Center Panel -->
 
 <div id="centerPanel" class="panel col-sm-9">
-    <div id="URLDeck" class="deck h-100 flex-column">
+    <div id="URLDeck" class="deck h-100 flex-column" style="align-items: stretch;">
         <!-- Header -->
         <div class="titleElement">
 
@@ -163,7 +163,7 @@
                 </div>
 
                 <!-- Edit UTub button -->
-                <i id="editUTubNameBtn" class="mx-1" style="display: none; color: #545454">
+                <i id="editUTubNameBtn" class="mx-1" style="display: none;">
                     <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor"
                         class="bi bi-pencil-square editIcon" viewBox="0 0 16 16">
                         <path
@@ -255,8 +255,8 @@
         </div>
 
         <!-- Access all URLs button -->
-        <div class="titleElement flex-column" style="padding-top: 10px">
-            <button id="accessAllURLsBtn" class="btn btn-primary" style="display: none;">Access All URLs
+        <div class="flex-column align-center" style="padding-top: 10px; width: 100%;">
+            <button id="accessAllURLsBtn" class="btn btn-primary" style="display: none; width: 50%;">Access All URLs
                 in UTub</button>
         </div>
     </div>


### PR DESCRIPTION
Revolving URL keys only works when a URL is selected, and allows a circular selection when the user starts at first/last URL and wants to travel to last/first URL, respectively.

Can cancel edit URL, add tag, edit UTub name

Add esc key events for exiting editing and adding of certain inputs.

URLs now clickable when card is selected. URL Edit moved to button feature.

Closes #141 
Closes #142 