### PR TITLE
Fix wayback cache attempt, and refactor internet cache into own function

### DIFF
--- a/src/utils/strings/url_validation_strs.py
+++ b/src/utils/strings/url_validation_strs.py
@@ -14,7 +14,7 @@ CF_MITIGATED = "cf-mitigated"
 CLOUDFLARE_SERVER = "cloudflare"
 SERVER = "server"
 GOOGLE_CACHE = "https://webcache.googleusercontent.com/search?q=cache:"
-WAYBACK_ARCHIVE = "https://archive.org/wayback/available?url="
+WAYBACK_ARCHIVE = "https://web.archive.org/web/"
 
 
 class URL_VALIDATION:


### PR DESCRIPTION
Moves the internet archive validation attempts into their own functions.

Makes google cache only use GET requests, and side testing showed HEAD requests to fail.

Make web archive tests look from years 2020 through current year for the given URL.

Fix web archive URL to hit.

Ensure a redirect from these archives means a success, as these archive domains can redirect user towards the valid website. Otherwise they generally 404.