### PR TITLE
Create/delete UTub Tags

### DIFF
--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -1756,6 +1756,284 @@ Indicates invalid form data sent in the request.
 
 ------------------------------------------------------------------------------------------
 
+#### UTub Tags
+
+<details>
+ <summary><code>POST</code> <code><b>/utubs/{UTubID}/tags</b></code> <code>(add a tag to a UTub)</code></summary>
+
+##### Parameters
+
+> | name   |  type      | data type      | description                                          |
+> |--------|------------|----------------|------------------------------------------------------|
+> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub to add tag to |
+
+##### Request Payload
+
+Payload content-type should be `application/x-www-form-urlencoded; charset=utf−8`.
+
+Required form data:
+> ```
+> tagString: %Tag Here%
+> csrf_token: %csrf_token%
+> ```
+
+##### Responses
+
+> | http code     | content-type                      | response  | details |
+> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
+> | `200`         | `application/json`                | `See below.` | Successfully added a tag to UTub. |
+> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
+> | `400`         | `application/json`                | `See below.` | Form errors on creation of new string. |
+> | `403`         | `application/json`                | `See below.` | Requesting user not in the UTub. |
+> | `404`         | `application/json`                | `See below.` | Unable to process the request. |
+> | `404`         | `text/html;charset=utf−8`         | None | Unable to find requested UTub. |
+> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
+
+###### 200 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Success",
+>     "message": "Tag added to this UTub.",
+>     "utubTag": {
+>         "utubTagID": 1,
+>         "tagString": "Hello",
+>     }
+> }
+> ```
+
+###### 400 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "UTub already contains this tag.",
+>     "errorCode": 2,
+> }
+> ```
+
+###### 400 HTTP Code Response Body
+
+Indicates form errors with adding this tag to this UTub.
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Unable to add tag to UTub.",
+>     "errorCode": 3,
+>     "errors": {
+>         "tagString": ["This field is required."],
+>     }
+> }
+> ```
+
+###### 403 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Unable to add tag to UTub.",
+>     "errorCode": 1,
+> }
+> ```
+
+###### 404 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Unable to add tag to UTub.",
+>     "errorCode": 4,
+> }
+> ```
+
+##### Example cURL
+
+> ```bash
+> curl -X POST \
+>  https://urls4irl.app/utubs/1/urls/1/tags \
+>  -H 'Content-Type: application/x-www-form-urlencoded' \
+>  -H 'Cookie: YOUR_COOKIE' \
+>  --data-urlencode 'tagString=Hello'
+>  --data-urlencode 'csrf_token=CSRF_TOKEN'
+> ```
+
+</details>
+<details>
+ <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}/tags/{tagID}</b></code> <code>(remove a tag from a URL in a UTub)</code></summary>
+
+##### Parameters
+
+> | name   |  type      | data type      | description                                          |
+> |--------|------------|----------------|------------------------------------------------------|
+> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL with the tag to remove |
+> | `tagID` |  required  | int ($int64) | The unique ID of the tag to remove |
+
+##### Responses
+
+> | http code     | content-type                      | response  | details |
+> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
+> | `200`         | `application/json`                | `See below.` | Successfully removed the tag from the URL in the UTub. |
+> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
+> | `403`         | `application/json`                | `See below.` | User must be member of UTub to remove a tag from a URL. |
+> | `404`         | `text/html;charset=utf−8`         | None | Unable to find UTub, URL in UTub, or tag on URL in UTub. |
+> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
+
+###### 200 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Success",
+>     "message": "Tag removed from this URL.",
+>     "utubUrlTagIDs": [1, 2, 3],         // Contains tag ID array of tags still on URL
+>     "utubTag": {
+>         "utubTagID": 4,
+>         "tagString": "Hello",
+>     }
+> }
+> ```
+
+###### 403 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Only UTub members can remove tags.",
+> }
+> ```
+
+##### Example cURL
+
+> ```bash
+> curl -X DELETE \
+>  https://urls4irl.app/utubs/1/urls/1/tags/4 \
+>  -H 'Cookie: YOUR_COOKIE' \
+> ```
+
+</details>
+<details>
+ <summary><code>PUT</code> <code><b>/utubs/{UTubID}/urls/1/tags/1</b></code> <code>(modify tag on URL in UTub)</code></summary>
+
+##### Parameters
+
+> | name   |  type      | data type      | description                                          |
+> |--------|------------|----------------|------------------------------------------------------|
+> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL with given tag |
+> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL associated with the tag to modify |
+> | `tagID` |  required  | int ($int64) | The unique ID of the tag to modify |
+
+##### Request Payload
+
+Payload content-type should be `application/x-www-form-urlencoded; charset=utf−8`.
+
+Required form data:
+> ```
+> tagString: %New Tag%
+> csrf_token: %csrf_token%
+> ```
+
+##### Responses
+
+> | http code     | content-type                      | response  | details |
+> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
+> | `200`         | `application/json`                | `See below.` | Successfully modified a tag, or no change. |
+> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
+> | `400`         | `application/json`                | `See below.` | Missing form fields or tag already on URL. |
+> | `403`         | `application/json`                | `See below.` | Only UTub members can modify a tag on a URL. |
+> | `404`         | `application/json`                | `See below.` | Unable to process the form. |
+> | `404`         | `text/html;charset=utf−8`         | None | Unable to find UTub, the URL within the UTub, or the tag on the URL. |
+> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
+
+###### 200 HTTP Code Response Body
+
+Possible messages include: `Tag on this URL modified.`, `Tag was not modified on this URL.`
+
+> ```json
+> {
+>     "status": "Success",
+>     "message": "Tag on this URL modified.", 
+>     "urlTagIDs": [1, 2, 3, 4],      // If modified, contains newly modified tag ID
+>     "tag": {
+>         "tagID": 4,
+>         "tagString": "Hello",
+>     },
+>     "previousTag": {
+>         "tagID": 5,
+>         "tagInUTub": false,
+>     }
+> }
+> ```
+
+###### 200 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "No change",
+>     "message": "Tag was not modified on this URL.",
+> }
+> ```
+
+###### 400 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "URL already has this tag.",
+>     "errorCode": 2,
+> }
+> ```
+
+###### 400 HTTP Code Response Body
+
+`tagString` field must be included in form.
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Unable to add tag to URL.",
+>     "errorCode": 3,
+>     "errors": {
+>         "tagString": ["This field is required."],
+>     }
+> }
+> ```
+
+###### 403 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Only UTub members can modify tags.",
+>     "errorCode": 1
+> }
+> ```
+
+###### 404 HTTP Code Response Body
+
+> ```json
+> {
+>     "status": "Failure",
+>     "message": "Unable to add tag to URL.",
+>     "errorCode": 4,
+> }
+> ```
+
+##### Example cURL
+
+> ```bash
+> curl -X PUT \
+>  https://urls4irl.app/utubs/1/urls/1/tags/1 \
+>  -H 'Content-Type: application/x-www-form-urlencoded' \
+>  -H 'Cookie: YOUR_COOKIE' \
+>  --data-urlencode 'tagString=NewTag'
+>  --data-urlencode 'csrf_token=CSRF_TOKEN'
+> ```
+
+</details>
+
+------------------------------------------------------------------------------------------
+
 #### UTub URL Tags
 
 <details>
@@ -2045,4 +2323,3 @@ Possible messages include: `Tag on this URL modified.`, `Tag was not modified on
 </details>
 
 ------------------------------------------------------------------------------------------
-

--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -1851,7 +1851,7 @@ Indicates form errors with adding this tag to this UTub.
 
 > ```bash
 > curl -X POST \
->  https://urls4irl.app/utubs/1/urls/1/tags \
+>  https://urls4irl.app/utubs/1/tags \
 >  -H 'Content-Type: application/x-www-form-urlencoded' \
 >  -H 'Cookie: YOUR_COOKIE' \
 >  --data-urlencode 'tagString=Hello'
@@ -1860,24 +1860,25 @@ Indicates form errors with adding this tag to this UTub.
 
 </details>
 <details>
- <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/urls/{utubUrlID}/tags/{tagID}</b></code> <code>(remove a tag from a URL in a UTub)</code></summary>
+ <summary><code>DELETE</code> <code><b>/utubs/{UTubID}/tags/{utubTagID}</b></code> <code>(delete a tag from a UTub)</code></summary>
 
 ##### Parameters
 
 > | name   |  type      | data type      | description                                          |
 > |--------|------------|----------------|------------------------------------------------------|
-> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL |
-> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL with the tag to remove |
-> | `tagID` |  required  | int ($int64) | The unique ID of the tag to remove |
+> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub to delete tag from |
+> | `utubTagID` |  required  | int ($int64) | The unique ID of the utubTag to delete tag from |
 
 ##### Responses
 
 > | http code     | content-type                      | response  | details |
 > |---------------|-----------------------------------|-----------|---------------------------------------------------------|
-> | `200`         | `application/json`                | `See below.` | Successfully removed the tag from the URL in the UTub. |
+> | `200`         | `application/json`                | `See below.` | Successfully deleted a tag from UTub, and removed all URL associations with this tag in this UTub. |
 > | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
-> | `403`         | `application/json`                | `See below.` | User must be member of UTub to remove a tag from a URL. |
-> | `404`         | `text/html;charset=utf−8`         | None | Unable to find UTub, URL in UTub, or tag on URL in UTub. |
+> | `403`         | `application/json`                | `See below.` | Requesting user not in the UTub. |
+> | `404`         | `application/json`                | `See below.` | Unable to process the request. |
+> | `404`         | `text/html;charset=utf−8`         | None | Unable to find requested UTub. |
+> | `404`         | `text/html;charset=utf−8`         | None | Unable to find requested utubTag. |
 > | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
 
 ###### 200 HTTP Code Response Body
@@ -1885,12 +1886,12 @@ Indicates form errors with adding this tag to this UTub.
 > ```json
 > {
 >     "status": "Success",
->     "message": "Tag removed from this URL.",
->     "utubUrlTagIDs": [1, 2, 3],         // Contains tag ID array of tags still on URL
+>     "message": "Tag deleted from this UTub.",
 >     "utubTag": {
->         "utubTagID": 4,
+>         "utubTagID": 1,
 >         "tagString": "Hello",
 >     }
+>     "urlIDs": [1, 2, 3]       // IDs of UTubURLs this tag was removed from, can be empty
 > }
 > ```
 
@@ -1899,7 +1900,7 @@ Indicates form errors with adding this tag to this UTub.
 > ```json
 > {
 >     "status": "Failure",
->     "message": "Only UTub members can remove tags.",
+>     "message": "Only UTub members can delete tags.",
 > }
 > ```
 
@@ -1907,127 +1908,9 @@ Indicates form errors with adding this tag to this UTub.
 
 > ```bash
 > curl -X DELETE \
->  https://urls4irl.app/utubs/1/urls/1/tags/4 \
->  -H 'Cookie: YOUR_COOKIE' \
-> ```
-
-</details>
-<details>
- <summary><code>PUT</code> <code><b>/utubs/{UTubID}/urls/1/tags/1</b></code> <code>(modify tag on URL in UTub)</code></summary>
-
-##### Parameters
-
-> | name   |  type      | data type      | description                                          |
-> |--------|------------|----------------|------------------------------------------------------|
-> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL with given tag |
-> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL associated with the tag to modify |
-> | `tagID` |  required  | int ($int64) | The unique ID of the tag to modify |
-
-##### Request Payload
-
-Payload content-type should be `application/x-www-form-urlencoded; charset=utf−8`.
-
-Required form data:
-> ```
-> tagString: %New Tag%
-> csrf_token: %csrf_token%
-> ```
-
-##### Responses
-
-> | http code     | content-type                      | response  | details |
-> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
-> | `200`         | `application/json`                | `See below.` | Successfully modified a tag, or no change. |
-> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
-> | `400`         | `application/json`                | `See below.` | Missing form fields or tag already on URL. |
-> | `403`         | `application/json`                | `See below.` | Only UTub members can modify a tag on a URL. |
-> | `404`         | `application/json`                | `See below.` | Unable to process the form. |
-> | `404`         | `text/html;charset=utf−8`         | None | Unable to find UTub, the URL within the UTub, or the tag on the URL. |
-> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
-
-###### 200 HTTP Code Response Body
-
-Possible messages include: `Tag on this URL modified.`, `Tag was not modified on this URL.`
-
-> ```json
-> {
->     "status": "Success",
->     "message": "Tag on this URL modified.", 
->     "urlTagIDs": [1, 2, 3, 4],      // If modified, contains newly modified tag ID
->     "tag": {
->         "tagID": 4,
->         "tagString": "Hello",
->     },
->     "previousTag": {
->         "tagID": 5,
->         "tagInUTub": false,
->     }
-> }
-> ```
-
-###### 200 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "No change",
->     "message": "Tag was not modified on this URL.",
-> }
-> ```
-
-###### 400 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "URL already has this tag.",
->     "errorCode": 2,
-> }
-> ```
-
-###### 400 HTTP Code Response Body
-
-`tagString` field must be included in form.
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "Unable to add tag to URL.",
->     "errorCode": 3,
->     "errors": {
->         "tagString": ["This field is required."],
->     }
-> }
-> ```
-
-###### 403 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "Only UTub members can modify tags.",
->     "errorCode": 1
-> }
-> ```
-
-###### 404 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "Unable to add tag to URL.",
->     "errorCode": 4,
-> }
-> ```
-
-##### Example cURL
-
-> ```bash
-> curl -X PUT \
->  https://urls4irl.app/utubs/1/urls/1/tags/1 \
+>  https://urls4irl.app/utubs/1/tags/1 \
 >  -H 'Content-Type: application/x-www-form-urlencoded' \
 >  -H 'Cookie: YOUR_COOKIE' \
->  --data-urlencode 'tagString=NewTag'
->  --data-urlencode 'csrf_token=CSRF_TOKEN'
 > ```
 
 </details>

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -65,6 +65,7 @@ def create_app(config_class: Config = Config):
     from src.members.routes import members
     from src.urls.routes import urls
     from src.tags.url_tag_routes import utub_url_tags
+    from src.tags.utub_tag_routes import utub_tags
 
     app.register_blueprint(splash)
     app.register_blueprint(utubs)
@@ -72,6 +73,7 @@ def create_app(config_class: Config = Config):
     app.register_blueprint(members)
     app.register_blueprint(urls)
     app.register_blueprint(utub_url_tags)
+    app.register_blueprint(utub_tags)
     register_mocks_db_cli(app)
 
     app.register_error_handler(404, handle_404_response)

--- a/src/tags/forms.py
+++ b/src/tags/forms.py
@@ -6,7 +6,7 @@ from src.utils.constants import TAG_CONSTANTS
 from src.utils.strings import model_strs as MODEL_STRS
 
 
-class UTubNewUrlTagForm(FlaskForm):
+class NewTagForm(FlaskForm):
     """
     Form to add a tag to a URL in a Utub.
 

--- a/src/tags/url_tag_routes.py
+++ b/src/tags/url_tag_routes.py
@@ -7,7 +7,7 @@ from src.models.utubs import Utubs
 from src.models.utub_members import Utub_Members
 from src.models.utub_urls import Utub_Urls
 from src.models.utub_url_tags import Utub_Url_Tags
-from src.tags.forms import UTubNewUrlTagForm
+from src.tags.forms import NewTagForm
 from src.utils.constants import TAG_CONSTANTS
 from src.utils.strings.json_strs import STD_JSON_RESPONSE
 from src.utils.strings.model_strs import MODELS
@@ -53,7 +53,7 @@ def create_utub_url_tag(utub_id: int, utub_url_id: int):
             403,
         )
 
-    url_tag_form: UTubNewUrlTagForm = UTubNewUrlTagForm()
+    url_tag_form: NewTagForm = NewTagForm()
 
     if url_tag_form.validate_on_submit():
         tag_to_add = url_tag_form.tag_string.data

--- a/src/tags/url_tag_routes.py
+++ b/src/tags/url_tag_routes.py
@@ -169,7 +169,7 @@ def create_utub_url_tag(utub_id: int, utub_url_id: int):
 @email_validation_required
 def delete_utub_url_tag(utub_id: int, utub_url_id: int, utub_url_tag_id: int):
     """
-    User wants to delete a tag from a URL contained in a UTub. Only available to owner of that utub.
+    User wants to delete a tag from a URL contained in a UTub.
 
     Args:
         utub_id (int): The ID of the UTub that contains the URL to be deleted

--- a/src/tags/utub_tag_routes.py
+++ b/src/tags/utub_tag_routes.py
@@ -1,0 +1,167 @@
+from flask import Blueprint, jsonify
+from flask_login import current_user
+
+from src import db
+from src.models.utub_tags import Utub_Tags
+from src.models.utubs import Utubs
+from src.models.utub_members import Utub_Members
+from src.tags.forms import NewTagForm
+from src.utils.strings.json_strs import STD_JSON_RESPONSE
+from src.utils.strings.model_strs import MODELS
+from src.utils.strings.tag_strs import TAGS_FAILURE, TAGS_SUCCESS
+from src.utils.email_validation import email_validation_required
+
+utub_tags = Blueprint("utub_tags", __name__)
+
+# Standard response for JSON messages
+STD_JSON = STD_JSON_RESPONSE
+
+
+@utub_tags.route("/utubs/<int:utub_id>/tags", methods=["POST"])
+@email_validation_required
+def create_utub_tag(utub_id: int):
+    """
+    User wants to add a tag to a UTub.
+
+    Args:
+        utub_id (int): The utub that this user is being added to
+    """
+    utub: Utubs = Utubs.query.get_or_404(utub_id)
+    user_in_utub = Utub_Members.query.get((utub_id, current_user.id)) is not None
+
+    if not user_in_utub:
+        # How did a user not in this utub get access to add a tag to this UTub?
+        return (
+            jsonify(
+                {
+                    STD_JSON.STATUS: STD_JSON.FAILURE,
+                    STD_JSON.MESSAGE: TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+                    STD_JSON.ERROR_CODE: 1,
+                }
+            ),
+            403,
+        )
+
+    utub_tag_form: NewTagForm = NewTagForm()
+
+    if utub_tag_form.validate_on_submit():
+        tag_to_add = utub_tag_form.tag_string.data
+
+        # Check if tag already exists in UTub
+        utub_tag_already_created: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_id, Utub_Tags.tag_string == tag_to_add
+        ).first()
+
+        if utub_tag_already_created:
+            return (
+                jsonify(
+                    {
+                        STD_JSON.STATUS: STD_JSON.FAILURE,
+                        STD_JSON.MESSAGE: TAGS_FAILURE.TAG_ALREADY_IN_UTUB,
+                        STD_JSON.ERROR_CODE: 2,
+                    }
+                ),
+                400,
+            )
+
+        # Create tag, then associate with this UTub
+        new_utub_tag = Utub_Tags(
+            utub_id=utub_id, tag_string=tag_to_add, created_by=current_user.id
+        )
+        db.session.add(new_utub_tag)
+        utub.set_last_updated()
+        db.session.commit()
+
+        # Successfully added tag to UTub
+        return (
+            jsonify(
+                {
+                    STD_JSON.STATUS: STD_JSON.SUCCESS,
+                    STD_JSON.MESSAGE: TAGS_SUCCESS.TAG_ADDED_TO_UTUB,
+                    TAGS_SUCCESS.UTUB_TAG: new_utub_tag.serialized_on_add_delete,
+                }
+            ),
+            200,
+        )
+
+    # Input form errors
+    if utub_tag_form.errors is not None:
+        errors = {MODELS.TAG_STRING: utub_tag_form.tag_string.errors}
+        return (
+            jsonify(
+                {
+                    STD_JSON.STATUS: STD_JSON.FAILURE,
+                    STD_JSON.MESSAGE: TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+                    STD_JSON.ERROR_CODE: 3,
+                    STD_JSON.ERRORS: errors,
+                }
+            ),
+            400,
+        )
+
+    return (
+        jsonify(
+            {
+                STD_JSON.STATUS: STD_JSON.FAILURE,
+                STD_JSON.MESSAGE: TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+                STD_JSON.ERROR_CODE: 4,
+            }
+        ),
+        404,
+    )
+
+
+# @utub_url_tags.route(
+#     "/utubs/<int:utub_id>/urls/<int:utub_url_id>/tags/<int:utub_url_tag_id>",
+#     methods=["DELETE"],
+# )
+# @email_validation_required
+# def delete_utub_url_tag(utub_id: int, utub_url_id: int, utub_url_tag_id: int):
+#     """
+#     User wants to delete a tag from a URL contained in a UTub. Only available to owner of that utub.
+
+#     Args:
+#         utub_id (int): The ID of the UTub that contains the URL to be deleted
+#         url_id (int): The ID of the URL containing tag to be deleted
+#         utub_url_tag_id (int): The ID of the tag to be deleted
+#     """
+#     utub: Utubs = Utubs.query.get_or_404(utub_id)
+#     user_in_utub = Utub_Members.query.get((utub_id, current_user.id)) is not None
+
+#     if not user_in_utub:
+#         return (
+#             jsonify(
+#                 {
+#                     STD_JSON.STATUS: STD_JSON.FAILURE,
+#                     STD_JSON.MESSAGE: TAGS_FAILURE.ONLY_UTUB_MEMBERS_DELETE_TAGS,
+#                 }
+#             ),
+#             403,
+#         )
+
+#     # User is member of this UTub
+#     tag_for_url_in_utub: Utub_Url_Tags = Utub_Url_Tags.query.filter(
+#         Utub_Url_Tags.utub_id == utub_id,
+#         Utub_Url_Tags.utub_url_id == utub_url_id,
+#         Utub_Url_Tags.utub_tag_id == utub_url_tag_id,
+#     ).first_or_404()
+#     url_id_to_remove_tag = tag_for_url_in_utub.utub_url_id
+#     tag_to_remove: Utub_Tags = tag_for_url_in_utub.utub_tag_item
+
+#     db.session.delete(tag_for_url_in_utub)
+#     utub.set_last_updated()
+#     db.session.commit()
+
+#     url_utub_association: Utub_Urls = Utub_Urls.query.get_or_404(url_id_to_remove_tag)
+
+#     return (
+#         jsonify(
+#             {
+#                 STD_JSON.STATUS: STD_JSON.SUCCESS,
+#                 STD_JSON.MESSAGE: TAGS_SUCCESS.TAG_REMOVED_FROM_URL,
+#                 TAGS_SUCCESS.UTUB_URL_TAG_IDS: url_utub_association.associated_tag_ids,
+#                 TAGS_SUCCESS.UTUB_TAG: tag_to_remove.serialized_on_add_delete,
+#             }
+#         ),
+#         200,
+#     )

--- a/src/templates/_routes_constants.html
+++ b/src/templates/_routes_constants.html
@@ -44,6 +44,11 @@
                         .replace("-2", utub_url_id)
                         .replace("-3", utub_url_tag_id);
 
+                // UTub Tag routes
+                this.createUTubTag = (utub_id) =>
+                    "{{url_for('utub_tags.create_utub_tag', utub_id=-1)}}"
+                        .replace("-1", utub_id)
+
                 // Member routes
                 this.createMember = (utub_id) => 
                     "{{url_for('members.create_member', utub_id=-1)}}".replace("-1", utub_id);

--- a/src/utils/all_routes.py
+++ b/src/utils/all_routes.py
@@ -22,10 +22,16 @@ class SPLASH_ROUTES:
     RESET_PASSWORD = _SPLASH + "reset_password"
 
 
-class UTUB_URL_TAG_ROUTES:
-    _UTUB_URL_TAGS = "utub_url_tags."
-    CREATE_TAG = _UTUB_URL_TAGS + "create_utub_url_tag"
-    DELETE_TAG = _UTUB_URL_TAGS + "delete_utub_url_tag"
+class URL_TAG_ROUTES:
+    _URL_TAGS = "utub_url_tags."
+    CREATE_URL_TAG = _URL_TAGS + "create_utub_url_tag"
+    DELETE_URL_TAG = _URL_TAGS + "delete_utub_url_tag"
+
+
+class UTUB_TAG_ROUTES:
+    _UTUB_TAGS = "utub_tags."
+    CREATE_UTUB_TAG = _UTUB_TAGS + "create_utub_tag"
+    DELETE_UTUB_TAG = _UTUB_TAGS + "delete_utub_tag"
 
 
 class URL_ROUTES:
@@ -56,7 +62,8 @@ class UTUB_ROUTES:
 class ROUTES:
     MEMBERS = MEMBER_ROUTES
     SPLASH = SPLASH_ROUTES
-    TAGS = UTUB_URL_TAG_ROUTES
+    URL_TAGS = URL_TAG_ROUTES
+    UTUB_TAGS = UTUB_TAG_ROUTES
     URLS = URL_ROUTES
     USERS = USER_ROUTES
     UTUBS = UTUB_ROUTES

--- a/src/utils/strings/html_identifiers.py
+++ b/src/utils/strings/html_identifiers.py
@@ -1,4 +1,5 @@
 # General Identifiers
 class IDENTIFIERS:
     SPLASH_PAGE = "Welcome to URLS4IRL"
+    CSRF_MISSING = "<p>The CSRF token is missing.</p>"
     HTML_404 = "404 - Invalid Request"

--- a/src/utils/strings/tag_strs.py
+++ b/src/utils/strings/tag_strs.py
@@ -7,19 +7,23 @@ from src.utils.strings.utub_strs import UTUB_GENERAL
 TAG_ADDED_TO_URL = "Tag added to this URL."
 TAG_ADDED_TO_UTUB = "Tag added to this UTub."
 TAG_REMOVED_FROM_URL = "Tag removed from this URL."
+TAG_REMOVED_FROM_UTUB = "Tag removed from UTub and associated URLs."
 TAG_MODIFIED_ON_URL = "Tag on this URL modified."
 TAG_STILL_IN_UTUB = "tagInUTub"
 PREVIOUS_TAG = "previousTag"
+URL_IDS = "urlIDs"
 
 
 class TAGS_SUCCESS(URL_GENERAL, UTUB_GENERAL):
     TAG_ADDED_TO_URL = TAG_ADDED_TO_URL
     TAG_ADDED_TO_UTUB = TAG_ADDED_TO_UTUB
     TAG_REMOVED_FROM_URL = TAG_REMOVED_FROM_URL
+    TAG_REMOVED_FROM_UTUB = TAG_REMOVED_FROM_UTUB
     UTUB_TAG = UTUB_TAG
     TAG_STILL_IN_UTUB = TAG_STILL_IN_UTUB
     TAG_MODIFIED_ON_URL = TAG_MODIFIED_ON_URL
     PREVIOUS_TAG = PREVIOUS_TAG
+    URL_IDS = URL_IDS
 
 
 # Strings for tags failure

--- a/src/utils/strings/tag_strs.py
+++ b/src/utils/strings/tag_strs.py
@@ -5,6 +5,7 @@ from src.utils.strings.utub_strs import UTUB_GENERAL
 
 # Strings for tags success
 TAG_ADDED_TO_URL = "Tag added to this URL."
+TAG_ADDED_TO_UTUB = "Tag added to this UTub."
 TAG_REMOVED_FROM_URL = "Tag removed from this URL."
 TAG_MODIFIED_ON_URL = "Tag on this URL modified."
 TAG_STILL_IN_UTUB = "tagInUTub"
@@ -13,6 +14,7 @@ PREVIOUS_TAG = "previousTag"
 
 class TAGS_SUCCESS(URL_GENERAL, UTUB_GENERAL):
     TAG_ADDED_TO_URL = TAG_ADDED_TO_URL
+    TAG_ADDED_TO_UTUB = TAG_ADDED_TO_UTUB
     TAG_REMOVED_FROM_URL = TAG_REMOVED_FROM_URL
     UTUB_TAG = UTUB_TAG
     TAG_STILL_IN_UTUB = TAG_STILL_IN_UTUB
@@ -22,18 +24,22 @@ class TAGS_SUCCESS(URL_GENERAL, UTUB_GENERAL):
 
 # Strings for tags failure
 UNABLE_TO_ADD_TAG_TO_URL = "Unable to add tag to URL."
+UNABLE_TO_ADD_TAG_TO_UTUB = "Unable to add tag to UTub."
 FIVE_TAGS_MAX = "URLs can only have up to 5 tags."
 TAG_ALREADY_ON_URL = "URL already has this tag."
+TAG_ALREADY_IN_UTUB = "UTub already contains this tag."
 ONLY_UTUB_MEMBERS_DELETE_TAGS = "Only UTub members can delete tags."
 ONLY_UTUB_MEMBERS_UPDATE_TAGS = "Only UTub members can update tags."
 
 
 class TAGS_FAILURE(FAILURE_GENERAL):
     UNABLE_TO_ADD_TAG_TO_URL = UNABLE_TO_ADD_TAG_TO_URL
+    UNABLE_TO_ADD_TAG_TO_UTUB = UNABLE_TO_ADD_TAG_TO_UTUB
     FIVE_TAGS_MAX = FIVE_TAGS_MAX
     TAG_ALREADY_ON_URL = TAG_ALREADY_ON_URL
     ONLY_UTUB_MEMBERS_UPDATE_TAGS = ONLY_UTUB_MEMBERS_UPDATE_TAGS
     ONLY_UTUB_MEMBERS_DELETE_TAGS = ONLY_UTUB_MEMBERS_DELETE_TAGS
+    TAG_ALREADY_IN_UTUB = TAG_ALREADY_IN_UTUB
 
 
 # Strings for tags no change

--- a/tests/integration/utubtags/conftest.py
+++ b/tests/integration/utubtags/conftest.py
@@ -55,6 +55,24 @@ def add_one_tag_to_each_utub_after_one_url_added(
         app (Flask): The Flask client providing an app context
         add_one_url_to_each_utub_no_tags (pytest fixture): Adds one url to each UTub with same ID as creator
     """
+    _add_one_tag_to_each_utub(app)
+
+
+@pytest.fixture
+def add_one_tag_to_each_utub_after_all_users_added(
+    app: Flask, every_user_in_every_utub
+):
+    """
+    Adds one tag to each UTub, generating a single UtubTag entry for each UTub.
+
+    Args:
+        app (Flask): The Flask client providing the app context
+        every_user_in_every_utub (pytest fixture): Adds every user to every UTub
+    """
+    _add_one_tag_to_each_utub(app)
+
+
+def _add_one_tag_to_each_utub(app: Flask):
     with app.app_context():
         all_utubs: list[Utubs] = Utubs.query.all()
 

--- a/tests/integration/utubtags/test_add_tag_to_url_route.py
+++ b/tests/integration/utubtags/test_add_tag_to_url_route.py
@@ -86,7 +86,7 @@ def test_add_fresh_tag_to_valid_url_as_utub_creator(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -185,7 +185,7 @@ def test_add_fresh_tag_to_valid_url_as_utub_member(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_member_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -294,7 +294,7 @@ def test_add_existing_tag_to_valid_url_as_utub_creator(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -398,7 +398,7 @@ def test_add_existing_tag_to_valid_url_as_utub_member(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_member_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -505,7 +505,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_creator(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -620,7 +620,7 @@ def test_add_duplicate_tag_to_valid_url_as_utub_member(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_member_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -707,7 +707,7 @@ def test_add_duplicate_tag_not_in_utub_to_existing_url_in_utub(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_user_is_creator.id,
             utub_url_id=url_id_to_add_to,
         ),
@@ -770,7 +770,7 @@ def test_add_tag_to_nonexistent_url_as_utub_creator(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=NONEXISTENT_URL_IN_UTUB_ID,
         ),
@@ -856,7 +856,7 @@ def test_add_tag_to_nonexistent_url_as_utub_member(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_member_of,
             utub_url_id=NONEXISTENT_URL_IN_UTUB_ID,
         ),
@@ -932,7 +932,7 @@ def test_add_tag_to_url_in_nonexistent_utub(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=NONEXISTENT_UTUB_ID,
             utub_url_id=NONEXISTENT_UTUB_ID,
         ),
@@ -1018,7 +1018,7 @@ def test_add_tag_to_url_in_utub_user_is_not_member_of(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_that_user_not_member_of,
             utub_url_id=url_id_for_url_in_utub,
         ),
@@ -1128,7 +1128,7 @@ def test_add_tag_to_url_not_in_utub(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_for_url_not_in_utub,
         ),
@@ -1257,7 +1257,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_creator(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_in_this_utub,
         ),
@@ -1389,7 +1389,7 @@ def test_add_tag_to_url_with_five_tags_as_utub_member(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_member_of,
             utub_url_id=url_id_in_this_utub,
         ),
@@ -1495,7 +1495,7 @@ def test_add_tag_to_valid_url_valid_utub_missing_tag_field(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -1552,19 +1552,9 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
         - By POST to "/utubs/<int:utub_id>/urls/<int:url_id>/tags where:
             "utub_id" : An integer representing UTub ID,
             "urlID": An integer representing URL ID to add tag to
-    THEN ensure that the server responds with a 404 HTTP status code, that the proper JSON response
+    THEN ensure that the server responds with a 400 HTTP status code, that the proper HTML response
         is sent by the server, and that no new Tag-URL-UTub association exists where it didn't before,
         that no new Tag exists, and that the association between URL and Tag is recorded properly
-
-    Proper JSON response is as follows:
-    {
-        STD_JSON.STATUS : STD_JSON.FAILURE,
-        STD_JSON.MESSAGE : TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_URL,
-        STD_JSON.ERROR_CODE : 4,
-        STD_JSON.ERRORS: {
-            TAG_FORM.TAG_STRING: ["This field is required."]
-        }
-    }
     """
     client, _, _, app = login_first_user_without_register
     tag_to_add = all_tag_strings[0]
@@ -1597,7 +1587,7 @@ def test_add_tag_to_valid_url_valid_utub_missing_csrf_token(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -1673,7 +1663,7 @@ def test_add_fresh_tag_to_url_updates_utub_last_updated(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -1729,7 +1719,7 @@ def test_add_existing_tag_to_url_updates_utub_last_updated(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),
@@ -1789,7 +1779,7 @@ def test_add_duplicate_tag_to_url_does_not_update_utub_last_updated(
 
     add_tag_response = client.post(
         url_for(
-            ROUTES.TAGS.CREATE_TAG,
+            ROUTES.URL_TAGS.CREATE_URL_TAG,
             utub_id=utub_id_user_is_creator_of,
             utub_url_id=url_id_to_add_tag_to,
         ),

--- a/tests/integration/utubtags/test_add_tags_to_utub_route.py
+++ b/tests/integration/utubtags/test_add_tags_to_utub_route.py
@@ -1,0 +1,510 @@
+from flask import url_for
+from flask_login import current_user
+import pytest
+
+from src.models.utub_tags import Utub_Tags
+from src.models.utubs import Utubs
+from src.utils.strings.html_identifiers import IDENTIFIERS
+from src.utils.all_routes import ROUTES
+from src.utils.constants import TAG_CONSTANTS
+from src.utils.strings.form_strs import TAG_FORM
+from src.utils.strings.json_strs import STD_JSON_RESPONSE as STD_JSON
+from src.utils.strings.model_strs import MODELS as MODEL_STRS
+from src.utils.strings.tag_strs import TAGS_FAILURE, TAGS_SUCCESS
+
+pytestmark = pytest.mark.tags
+
+
+def test_add_tag_to_utub(every_user_in_every_utub, login_first_user_without_register):
+    """
+    GIVEN UTubs with members in every UTub, but no tags
+    WHEN a tag is added to a UTub
+    THEN verify that a new UtubTag item exists, the server responds with a 200 HTTP status code,
+        and the proper JSON response is given
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.SUCCESS,
+        STD_JSON.MESSAGE : TAGS_SUCCESS.TAG_ADDED_TO_UTUB,
+        TAGS_SUCCESS.TAG : Serialization representing the new tag object:
+            {
+                MODEL_STRS.UTUB_TAG_ID: Integer representing ID of tag newly added,
+                TAG_FORM.TAG_STRING: String representing the tag just added
+            }
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+    NEW_TAG = "Funny!"
+
+    with app.app_context():
+        utub_to_add_tag_to: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+        num_of_tag_in_utub = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_to_add_tag_to.id, Utub_Tags.tag_string == NEW_TAG
+        ).count()
+        num_of_utub_tags = Utub_Tags.query.count()
+
+    new_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token, TAG_FORM.TAG_STRING: NEW_TAG}
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_to_add_tag_to.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 200
+    add_tag_response_json = add_tag_response.json
+
+    assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
+    assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_ADDED_TO_UTUB
+    assert (
+        add_tag_response_json[TAGS_SUCCESS.UTUB_TAG][MODEL_STRS.TAG_STRING] == NEW_TAG
+    )
+
+    with app.app_context():
+        new_tag: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_to_add_tag_to.id, Utub_Tags.tag_string == NEW_TAG
+        ).first()
+        assert (
+            new_tag.id
+            == add_tag_response_json[TAGS_SUCCESS.UTUB_TAG][MODEL_STRS.UTUB_TAG_ID]
+        )
+
+        assert (
+            Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub_to_add_tag_to.id,
+                Utub_Tags.tag_string == NEW_TAG,
+            ).count()
+            == num_of_tag_in_utub + 1
+        )
+        assert Utub_Tags.query.count() == num_of_utub_tags + 1
+
+
+def test_add_same_tag_to_multiple_utubs(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with members in every UTub, but no tags
+    WHEN the same tag is added to every UTub
+    THEN verify that a new UtubTag item exists, the server responds with a 200 HTTP status code,
+        and the proper JSON response is given
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.SUCCESS,
+        STD_JSON.MESSAGE : TAGS_SUCCESS.TAG_ADDED_TO_UTUB,
+        TAGS_SUCCESS.TAG : Serialization representing the new tag object:
+            {
+                MODEL_STRS.UTUB_TAG_ID: Integer representing ID of tag newly added,
+                TAG_FORM.TAG_STRING: String representing the tag just added
+            }
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+    NEW_TAG = "Funny!"
+
+    with app.app_context():
+        all_utubs: list[Utubs] = Utubs.query.all()
+        utub_tag_count: int = Utub_Tags.query.count()
+
+    for utub in all_utubs:
+        utub_id = utub.id
+        with app.app_context():
+            num_of_tag_in_utub = Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub_id, Utub_Tags.tag_string == NEW_TAG
+            ).count()
+
+        new_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token, TAG_FORM.TAG_STRING: NEW_TAG}
+
+        add_tag_response = client.post(
+            url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_id),
+            data=new_tag_form,
+        )
+
+        assert add_tag_response.status_code == 200
+        add_tag_response_json = add_tag_response.json
+
+        assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
+        assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_ADDED_TO_UTUB
+        assert (
+            add_tag_response_json[TAGS_SUCCESS.UTUB_TAG][MODEL_STRS.TAG_STRING]
+            == NEW_TAG
+        )
+
+        with app.app_context():
+            new_tag: Utub_Tags = Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub_id, Utub_Tags.tag_string == NEW_TAG
+            ).first()
+            assert (
+                new_tag.id
+                == add_tag_response_json[TAGS_SUCCESS.UTUB_TAG][MODEL_STRS.UTUB_TAG_ID]
+            )
+
+            assert (
+                Utub_Tags.query.filter(
+                    Utub_Tags.utub_id == utub_id, Utub_Tags.tag_string == NEW_TAG
+                ).count()
+                == num_of_tag_in_utub + 1
+            )
+            assert Utub_Tags.query.count() == utub_tag_count + 1
+
+        utub_tag_count += 1
+
+
+def test_add_duplicate_tag_to_utub(
+    add_one_tag_to_each_utub_after_all_users_added, login_first_user_without_register
+):
+    """
+    GIVEN UTubs already containing a tag and users
+    WHEN a user wants to add a tag to a UTub that already exists
+    THEN verify that the server responds with a 400 HTTP status code, and responds with the appropriate JSON response
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.FAILURE,
+        STD_JSON.MESSAGE : TAGS_FAILURE.TAG_ALREADY_IN_UTUB,
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        utub_of_user: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+        tag_already_added: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_of_user.id
+        ).first()
+        tag_string_already_added = tag_already_added.tag_string
+
+    new_tag_form = {
+        TAG_FORM.CSRF_TOKEN: csrf_token,
+        TAG_FORM.TAG_STRING: tag_string_already_added,
+    }
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_of_user.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 400
+    add_tag_response_json = add_tag_response.json
+
+    assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.FAILURE
+    assert add_tag_response_json[STD_JSON.MESSAGE] == TAGS_FAILURE.TAG_ALREADY_IN_UTUB
+
+
+def test_add_empty_tag_to_utub(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with every user in them
+    WHEN a user tries to add a tag with an empty tag string
+    THEN verify that the server responds with a 400 HTTP status code, and responds with the appropriate JSON response
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.FAILURE,
+        STD_JSON.MESSAGE : TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        utub_of_user: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+
+    new_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token, TAG_FORM.TAG_STRING: ""}
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_of_user.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 400
+    add_tag_response_json = add_tag_response.json
+
+    assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.FAILURE
+    assert (
+        add_tag_response_json[STD_JSON.MESSAGE]
+        == TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB
+    )
+    assert STD_JSON.ERRORS in add_tag_response_json
+
+    assert (
+        add_tag_response_json[STD_JSON.ERRORS][MODEL_STRS.TAG_STRING]
+        == TAGS_FAILURE.FIELD_REQUIRED
+    )
+
+
+def test_add_long_tag_to_utub(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with every user in them
+    WHEN a user tries to add a tag with an empty tag string
+    THEN verify that the server responds with a 400 HTTP status code, and responds with the appropriate JSON response
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.FAILURE,
+        STD_JSON.MESSAGE : TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        utub_of_user: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+
+    new_tag_form = {
+        TAG_FORM.CSRF_TOKEN: csrf_token,
+        TAG_FORM.TAG_STRING: "a" * (TAG_CONSTANTS.MAX_TAG_LENGTH + 1),
+    }
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_of_user.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 400
+    add_tag_response_json = add_tag_response.json
+
+    assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.FAILURE
+    assert (
+        add_tag_response_json[STD_JSON.MESSAGE]
+        == TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB
+    )
+    assert STD_JSON.ERRORS in add_tag_response_json
+
+    for limit in (
+        TAG_CONSTANTS.MAX_TAG_LENGTH,
+        TAG_CONSTANTS.MIN_TAG_LENGTH,
+    ):
+        assert (
+            str(limit)
+            in add_tag_response_json[STD_JSON.ERRORS][MODEL_STRS.TAG_STRING][0]
+        )
+
+
+def test_add_tag_to_utub_not_member_of(
+    every_user_makes_a_unique_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with only a single member in every UTub, and no tags
+    WHEN a user tries to add a tag to a UTub they aren't a member of
+    THEN verify that no new UtubTag item exists, the server responds with a 403 HTTP status code,
+        and the proper JSON response is given
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.FAILURE,
+        STD_JSON.MESSAGE : TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+        STD_JSON.ERROR_CODE : 1
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+    NEW_TAG = "Funny!"
+
+    with app.app_context():
+        utub_to_add_tag_to: Utubs = Utubs.query.filter(
+            Utubs.utub_creator != current_user.id
+        ).first()
+        num_of_tag_in_utub = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_to_add_tag_to.id
+        ).count()
+        num_of_utub_tags = Utub_Tags.query.count()
+
+    new_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token, TAG_FORM.TAG_STRING: NEW_TAG}
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_to_add_tag_to.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 403
+    add_tag_response_json = add_tag_response.json
+
+    assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.FAILURE
+    assert (
+        add_tag_response_json[STD_JSON.MESSAGE]
+        == TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB
+    )
+    assert add_tag_response_json[STD_JSON.ERROR_CODE] == 1
+
+    with app.app_context():
+        assert num_of_utub_tags == Utub_Tags.query.count()
+        assert (
+            num_of_tag_in_utub
+            == Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub_to_add_tag_to.id
+            ).count()
+        )
+
+
+def test_add_tag_to_nonexistent_utub(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with every member in every UTub, and no tags
+    WHEN a user tries to add a tag to a UTub that does not exist
+    THEN verify that no new UtubTag item exists, the server responds with a 404 HTTP status code,
+        and the proper HTML response is given
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+    NEW_TAG = "Funny!"
+    NONEXISTENT_UTUB_ID = 999
+
+    with app.app_context():
+        num_of_utub_tags = Utub_Tags.query.count()
+
+    new_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token, TAG_FORM.TAG_STRING: NEW_TAG}
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=NONEXISTENT_UTUB_ID),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 404
+    assert IDENTIFIERS.HTML_404.encode() in add_tag_response.data
+
+    with app.app_context():
+        assert num_of_utub_tags == Utub_Tags.query.count()
+
+
+def test_add_tag_to_utub_missing_csrf_token(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with members in every UTub, but no tags
+    WHEN a tag is added to a UTub but the form is missing the CSRF token
+    THEN verify that a new UtubTag item exists, the server responds with a 400 HTTP status code,
+        and the proper HTML response is given
+    """
+    client, _, _, app = login_first_user_without_register
+    NEW_TAG = "Funny!"
+
+    with app.app_context():
+        utub_to_add_tag_to: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+        num_of_tag_in_utub = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_to_add_tag_to.id
+        ).count()
+        num_of_utub_tags = Utub_Tags.query.count()
+
+    new_tag_form = {TAG_FORM.TAG_STRING: NEW_TAG}
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_to_add_tag_to.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 400
+    assert IDENTIFIERS.CSRF_MISSING.encode() in add_tag_response.data
+
+    with app.app_context():
+        assert num_of_utub_tags == Utub_Tags.query.count()
+        assert (
+            num_of_tag_in_utub
+            == Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub_to_add_tag_to.id
+            ).count()
+        )
+
+
+def test_add_tag_to_utub_missing_tag_field(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with members in every UTub, but no tags
+    WHEN a tag is added to a UTub but the form is missing the CSRF token
+    THEN verify that a new UtubTag item exists, the server responds with a 400 HTTP status code,
+        and the proper JSON response is given
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.FAILURE,
+        STD_JSON.MESSAGE : TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB,
+        STD_JSON.ERROR_CODE : 3,
+        STD_JSON.ERRORS: {
+            TAG_FORM.TAG_STRING: ["This field is required."]
+        }
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        utub_to_add_tag_to: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+        num_of_tag_in_utub = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_to_add_tag_to.id
+        ).count()
+        num_of_utub_tags = Utub_Tags.query.count()
+
+    new_tag_form = {
+        TAG_FORM.CSRF_TOKEN: csrf_token,
+    }
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_to_add_tag_to.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 400
+    add_tag_response_json = add_tag_response.json
+
+    assert add_tag_response_json[STD_JSON.STATUS] == STD_JSON.FAILURE
+    assert (
+        add_tag_response_json[STD_JSON.MESSAGE]
+        == TAGS_FAILURE.UNABLE_TO_ADD_TAG_TO_UTUB
+    )
+    assert add_tag_response_json[STD_JSON.ERROR_CODE] == 3
+    assert STD_JSON.ERRORS in add_tag_response_json
+    assert (
+        add_tag_response_json[STD_JSON.ERRORS][TAG_FORM.TAG_STRING]
+        == TAGS_FAILURE.FIELD_REQUIRED
+    )
+
+    with app.app_context():
+        assert num_of_utub_tags == Utub_Tags.query.count()
+        assert (
+            num_of_tag_in_utub
+            == Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub_to_add_tag_to.id
+            ).count()
+        )
+
+
+def test_add_tag_updates_utub_last_updated(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN UTubs with members in every UTub, but no tags
+    WHEN a tag is added to a UTub
+    THEN ensure that the server responds with a 200 HTTP status code, and the UTub's last updated
+        field is updated
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+    NEW_TAG = "Funny!"
+
+    with app.app_context():
+        utub_to_add_tag_to: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == current_user.id
+        ).first()
+        initial_last_updated = utub_to_add_tag_to.last_updated
+
+    new_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token, TAG_FORM.TAG_STRING: NEW_TAG}
+
+    add_tag_response = client.post(
+        url_for(ROUTES.UTUB_TAGS.CREATE_UTUB_TAG, utub_id=utub_to_add_tag_to.id),
+        data=new_tag_form,
+    )
+
+    assert add_tag_response.status_code == 200
+
+    with app.app_context():
+        current_utub: Utubs = Utubs.query.get(utub_to_add_tag_to.id)
+        assert (current_utub.last_updated - initial_last_updated).total_seconds() > 0

--- a/tests/integration/utubtags/test_delete_tag_from_url_route.py
+++ b/tests/integration/utubtags/test_delete_tag_from_url_route.py
@@ -79,7 +79,7 @@ def test_delete_tag_from_url_as_utub_creator(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_creator_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=tag_id_to_delete,
@@ -193,7 +193,7 @@ def test_delete_tag_from_url_as_utub_member(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_member_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=tag_id_to_delete,
@@ -308,7 +308,7 @@ def test_delete_tag_from_url_with_one_tag(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_member_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=tag_id_to_delete,
@@ -426,7 +426,7 @@ def test_delete_last_url_tag_in_utub(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_member_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=tag_id_to_delete,
@@ -584,7 +584,7 @@ def test_delete_tag_from_url_with_five_tags(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_member_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=tag_id_to_delete,
@@ -679,7 +679,7 @@ def test_delete_nonexistent_tag_from_url_as_utub_creator(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_creator_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=NONEXISTENT_TAG_ID,
@@ -756,7 +756,7 @@ def test_delete_nonexistent_tag_from_url_as_utub_member(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_member_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=NONEXISTENT_TAG_ID,
@@ -858,7 +858,7 @@ def test_delete_tag_from_url_but_not_member_of_utub(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_not_member_of,
             utub_url_id=url_id_in_utub,
             utub_url_tag_id=tag_id_to_delete,
@@ -948,7 +948,7 @@ def test_delete_tag_from_url_from_nonexistent_utub(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=NONEXISTENT_UTUB_ID,
             utub_url_id=url_id_to_delete,
             utub_url_tag_id=tag_id_to_delete,
@@ -1027,7 +1027,7 @@ def test_delete_tag_from_nonexistent_url_utub(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=existing_utub_id,
             utub_url_id=NONEXISTENT_URL_ID,
             utub_url_tag_id=tag_id_to_delete,
@@ -1102,7 +1102,7 @@ def test_delete_tag_with_no_csrf_token(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=existing_utub_id,
             utub_url_id=url_id_to_delete,
             utub_url_tag_id=tag_id_to_delete,
@@ -1165,7 +1165,7 @@ def test_delete_tag_from_url_updates_utub_last_updated(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_creator_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=tag_id_to_delete,
@@ -1217,7 +1217,7 @@ def test_delete_nonexistent_tag_from_url_does_not_update_utub_last_updated(
 
     delete_tag_response = client.delete(
         url_for(
-            ROUTES.TAGS.DELETE_TAG,
+            ROUTES.URL_TAGS.DELETE_URL_TAG,
             utub_id=utub_id_this_user_creator_of,
             utub_url_id=url_id_to_delete_tag_from,
             utub_url_tag_id=NONEXISTENT_TAG_ID,

--- a/tests/integration/utubtags/test_delete_tag_from_utub_route.py
+++ b/tests/integration/utubtags/test_delete_tag_from_utub_route.py
@@ -1,0 +1,392 @@
+from flask import url_for
+from flask_login import current_user
+import pytest
+
+from src.models.utub_tags import Utub_Tags
+from src.models.utub_url_tags import Utub_Url_Tags
+from src.models.utubs import Utubs
+from src.utils.strings.html_identifiers import IDENTIFIERS
+from src.utils.all_routes import ROUTES
+from src.utils.strings.form_strs import TAG_FORM
+from src.utils.strings.json_strs import STD_JSON_RESPONSE as STD_JSON
+from src.utils.strings.model_strs import MODELS as MODEL_STRS
+from src.utils.strings.tag_strs import TAGS_FAILURE, TAGS_SUCCESS
+
+pytestmark = pytest.mark.tags
+
+
+def test_delete_tag_from_utub_with_no_url_associations(
+    every_user_in_every_utub,
+    add_one_tag_to_each_utub_after_one_url_added,
+    login_first_user_without_register,
+):
+    """
+    GIVEN utubs with associated utub tags and no tags associated with URLs
+    WHEN a member of those utubs decides to delete a utub tag
+    THEN verify that the tag gets deleted, the server responds with a 200 HTTP status code,
+        and the server responds with the appropriate JSON response
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.SUCCESS,
+        STD_JSON.MESSAGE : TAGS_SUCCESS.TAG_REMOVED_FROM_UTUB,
+        TAGS_SUCCESS.TAG : Serialization representing the deleted tag object:
+            {
+                MODELS.UTUB_TAG_ID: Integer representing ID of deleted tag,
+                TAG_FORM.TAG_STRING: String representing the tag just deleted
+            }
+        TAGS_SUCCESS.URL_IDS : Array of integers representing URLs that has this tag removed
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub: Utubs = Utubs.query.filter(Utubs.utub_creator == current_user.id).first()
+
+        # Find tag in this UTub
+        utub_tag: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub.id
+        ).first()
+        utub_tag_id = utub_tag.id
+        utub_tag_string = utub_tag.tag_string
+
+        num_of_utub_tags: int = Utub_Tags.query.count()
+        num_of_utub_url_tags: int = Utub_Url_Tags.query.count()
+
+    delete_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=utub.id,
+            utub_tag_id=utub_tag_id,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 200
+    delete_tag_response_json = delete_tag_response.json
+
+    assert delete_tag_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
+    assert (
+        delete_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_REMOVED_FROM_UTUB
+    )
+    assert (
+        delete_tag_response_json[TAGS_SUCCESS.UTUB_TAG][TAG_FORM.TAG_STRING]
+        == utub_tag_string
+    )
+    assert (
+        delete_tag_response_json[TAGS_SUCCESS.UTUB_TAG][MODEL_STRS.UTUB_TAG_ID]
+        == utub_tag_id
+    )
+    assert delete_tag_response_json[TAGS_SUCCESS.URL_IDS] == []
+
+    with app.app_context():
+        assert Utub_Tags.query.count() == num_of_utub_tags - 1
+        assert Utub_Tags.query.get(utub_tag_id) is None
+        assert Utub_Url_Tags.query.count() == num_of_utub_url_tags
+
+
+def test_delete_tag_from_utub_with_url_associations(
+    every_user_in_every_utub,
+    add_all_urls_and_users_to_each_utub_with_all_tags,
+    login_first_user_without_register,
+):
+    """
+    GIVEN utubs with associated utub tags and those tags associated with URLs
+    WHEN a member of those utubs decides to delete a utub tag
+    THEN verify that the tag gets deleted, the utub-url-tag associations get deleted,
+        the server responds with a 200 HTTP status code, and the server responds with the appropriate JSON response
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.SUCCESS,
+        STD_JSON.MESSAGE : TAGS_SUCCESS.TAG_REMOVED_FROM_UTUB,
+        TAGS_SUCCESS.TAG : Serialization representing the deleted tag object:
+            {
+                MODELS.UTUB_TAG_ID: Integer representing ID of deleted tag,
+                TAG_FORM.TAG_STRING: String representing the tag just deleted
+            }
+        TAGS_SUCCESS.URL_IDS : Array of integers representing URLs that has this tag removed
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub: Utubs = Utubs.query.filter(Utubs.utub_creator == current_user.id).first()
+
+        # Find tag in this UTub
+        utub_tag: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub.id
+        ).first()
+        utub_tag_id = utub_tag.id
+        utub_tag_string = utub_tag.tag_string
+
+        num_of_utub_tags: int = Utub_Tags.query.count()
+        utub_url_tags: list[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub.id, Utub_Url_Tags.utub_tag_id == utub_tag_id
+        ).all()
+        utub_url_tag_ids: list[int] = [url.utub_url_id for url in utub_url_tags]
+        num_of_utub_url_tags: int = len(utub_url_tags)
+        total_utub_url_tags: int = Utub_Url_Tags.query.count()
+
+    delete_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=utub.id,
+            utub_tag_id=utub_tag_id,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 200
+    delete_tag_response_json = delete_tag_response.json
+
+    assert delete_tag_response_json[STD_JSON.STATUS] == STD_JSON.SUCCESS
+    assert (
+        delete_tag_response_json[STD_JSON.MESSAGE] == TAGS_SUCCESS.TAG_REMOVED_FROM_UTUB
+    )
+    assert (
+        delete_tag_response_json[TAGS_SUCCESS.UTUB_TAG][TAG_FORM.TAG_STRING]
+        == utub_tag_string
+    )
+    assert (
+        delete_tag_response_json[TAGS_SUCCESS.UTUB_TAG][MODEL_STRS.UTUB_TAG_ID]
+        == utub_tag_id
+    )
+    assert sorted(delete_tag_response_json[TAGS_SUCCESS.URL_IDS]) == sorted(
+        utub_url_tag_ids
+    )
+
+    with app.app_context():
+        assert Utub_Tags.query.count() == num_of_utub_tags - 1
+        assert Utub_Tags.query.get(utub_tag_id) is None
+        assert Utub_Url_Tags.query.count() == total_utub_url_tags - num_of_utub_url_tags
+
+
+def test_delete_tag_from_utub_not_member_of(
+    add_one_url_to_each_utub_one_tag_to_each_url_all_tags_in_utub,
+    login_first_user_without_register,
+):
+    """
+    GIVEN utubs with associated utub tags and those tags associated with URLs
+    WHEN a member of those utubs decides to delete a utub tag from a UTub they aren't a member of
+    THEN verify that the tag does not get deleted, the server responds with a 403 HTTP status code,
+        and the server responds with the appropriate JSON response
+
+    Proper JSON response is as follows:
+    {
+        STD_JSON.STATUS : STD_JSON.FAILURE,
+        STD_JSON.MESSAGE : TAGS_FAILURE.ONLY_UTUB_MEMBERS_DELETE_TAGS,
+    }
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub: Utubs = Utubs.query.filter(Utubs.utub_creator != current_user.id).first()
+
+        # Find tag in this UTub
+        utub_tag: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub.id
+        ).first()
+
+        num_of_utub_tags: int = Utub_Tags.query.count()
+        num_of_utub_url_tags: int = Utub_Url_Tags.query.count()
+
+    delete_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=utub.id,
+            utub_tag_id=utub_tag.id,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 403
+    delete_tag_response_json = delete_tag_response.json
+
+    assert delete_tag_response_json[STD_JSON.STATUS] == STD_JSON.FAILURE
+    assert (
+        delete_tag_response_json[STD_JSON.MESSAGE]
+        == TAGS_FAILURE.ONLY_UTUB_MEMBERS_DELETE_TAGS
+    )
+
+    with app.app_context():
+        assert Utub_Tags.query.count() == num_of_utub_tags
+        assert Utub_Url_Tags.query.count() == num_of_utub_url_tags
+
+
+def test_delete_nonexistent_tag_from_utub(
+    every_user_in_every_utub, login_first_user_without_register
+):
+    """
+    GIVEN utubs with associated utub tags and no tags associated with URLs
+    WHEN a member of those utubs decides to delete a nonexistent UTub Tag
+    THEN verify the server responds with a 404 HTTP status code, database content is the same,
+        and the server responds with the appropriate HTML response
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    NONEXISTENT_TAG_ID = 999
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub: Utubs = Utubs.query.filter(Utubs.utub_creator == current_user.id).first()
+
+        num_of_utub_tags: int = Utub_Tags.query.count()
+        num_of_utub_url_tags: int = Utub_Url_Tags.query.count()
+
+    delete_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=utub.id,
+            utub_tag_id=NONEXISTENT_TAG_ID,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 404
+    assert IDENTIFIERS.HTML_404.encode() in delete_tag_response.data
+
+    with app.app_context():
+        assert Utub_Tags.query.count() == num_of_utub_tags
+        assert Utub_Url_Tags.query.count() == num_of_utub_url_tags
+
+
+def test_delete_tag_from_nonexistent_utub(
+    add_all_urls_and_users_to_each_utub_with_all_tags, login_first_user_without_register
+):
+    """
+    GIVEN utubs with associated utub tags and no tags associated with URLs
+    WHEN a member of those utubs decides to delete a tag from a nonexistent UTub
+    THEN verify the server responds with a 404 HTTP status code, database content is the same,
+        and the server responds with the appropriate HTML response
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    NONEXISTENT_UTUB_ID = 999
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub_tag = Utub_Tags.query.first()
+
+        num_of_utub_tags: int = Utub_Tags.query.count()
+        num_of_utub_url_tags: int = Utub_Url_Tags.query.count()
+
+    delete_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=NONEXISTENT_UTUB_ID,
+            utub_tag_id=utub_tag.id,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 404
+    assert IDENTIFIERS.HTML_404.encode() in delete_tag_response.data
+
+    with app.app_context():
+        assert Utub_Tags.query.count() == num_of_utub_tags
+        assert Utub_Url_Tags.query.count() == num_of_utub_url_tags
+
+
+def test_delete_tag_from_utub_no_csrf_token(
+    add_all_urls_and_users_to_each_utub_with_all_tags, login_first_user_without_register
+):
+    """
+    GIVEN utubs with associated utub tags and no tags associated with URLs
+    WHEN a member of those utubs decides to delete a UTub Tag but is missing the CSRF token
+    THEN verify the server responds with a 400 HTTP status code, database content is the same,
+        and the server responds with the appropriate HTML response
+    """
+    client, _, _, app = login_first_user_without_register
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub: Utubs = Utubs.query.filter(Utubs.utub_creator == current_user.id).first()
+
+        # Find tag in this UTub
+        utub_tag: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub.id
+        ).first()
+        utub_tag_id = utub_tag.id
+        utub_tag_string = utub_tag.tag_string
+
+        num_of_utub_tags: int = Utub_Tags.query.count()
+        num_of_utub_url_tags: int = Utub_Url_Tags.query.count()
+
+    delete_tag_form = {}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=utub.id,
+            utub_tag_id=utub_tag_id,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 400
+    assert IDENTIFIERS.CSRF_MISSING.encode() in delete_tag_response.data
+
+    with app.app_context():
+        assert Utub_Tags.query.count() == num_of_utub_tags
+        assert Utub_Url_Tags.query.count() == num_of_utub_url_tags
+        assert (
+            Utub_Tags.query.filter(
+                Utub_Tags.utub_id == utub.id, Utub_Tags.tag_string == utub_tag_string
+            ).first()
+            is not None
+        )
+
+
+def test_delete_utub_tag_updates_utub_last_updated(
+    add_all_urls_and_users_to_each_utub_with_all_tags, login_first_user_without_register
+):
+    """
+    GIVEN utubs with associated utub tags and no tags associated with URLs
+    WHEN a member of those utubs decides to delete a utub tag
+    THEN verify that the tag gets deleted, the server responds with a 200 HTTP status code,
+        and the last_updated field of the UTub is updated appropriately
+    """
+    client, csrf_token, _, app = login_first_user_without_register
+
+    with app.app_context():
+        # Find UTub this user is member of
+        utub: Utubs = Utubs.query.filter(Utubs.utub_creator == current_user.id).first()
+        utub_id: int = utub.id
+        initial_last_updated = utub.last_updated
+
+        # Find tag in this UTub
+        utub_tag: Utub_Tags = Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_id
+        ).first()
+        utub_tag_id = utub_tag.id
+
+    delete_tag_form = {TAG_FORM.CSRF_TOKEN: csrf_token}
+
+    delete_tag_response = client.delete(
+        url_for(
+            ROUTES.UTUB_TAGS.DELETE_UTUB_TAG,
+            utub_id=utub_id,
+            utub_tag_id=utub_tag_id,
+        ),
+        data=delete_tag_form,
+    )
+
+    assert delete_tag_response.status_code == 200
+
+    with app.app_context():
+        utub: Utubs = Utubs.query.get(utub_id)
+        assert (utub.last_updated - initial_last_updated).total_seconds() > 0


### PR DESCRIPTION
Adds endpoints to the backend that allow creating and deleting tags that are just associated with UTubs, called UTubTags.

Updates database to handle relations for strictly UTubTags instead.

Allows UTubTags to be associated with URLs via UTubUrlTags.

Allows the deletion of a UTubTag to delete all associated UTubUrlTags.

Updates the API documentation to account for the new endpoints.

Changes naming across the frontend and backend to match UTubTags over Tags.

TODO: The UI frontend portion of this work.