### PR TITLE
Update docker to copy static files to host

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -89,6 +89,7 @@ jobs:
               ssh -T -q -o StrictHostKeyChecking=no ${{ secrets.DEV_SSH_HOST }} '
               echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin;
               docker compose -f compose-dev.yaml pull;
+              docker cp u4i-dev-flask:/code/src/static ~/static;
               docker compose -f compose-dev.yaml up --force-recreate --build -d;
               docker image prune -f;
               ';

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -3,6 +3,7 @@ name: u4i-dev
 services:
   web:
     image: ghcr.io/4irl/u4i-dev:latest
+    container_name: u4i-dev-flask
     ports: 
       - "127.0.0.1:8659:5000"
     depends_on:
@@ -28,6 +29,7 @@ services:
 
   db:
     image: postgres:16.3-bookworm
+    container_name: u4i-dev-postgres
     env_file:
      - .env
     environment:
@@ -39,6 +41,7 @@ services:
 
   redis:
     image: redis:6.2
+    container_name: u4i-dev-redis
     volumes:
       - redisdata:/data
 


### PR DESCRIPTION
Copies static file directory to host so that nginx can use it to cache properly.

Previously, nginx was setup to cache against a standalone directory containing the static files, from when the app was running using git to update the code when it was updated.