### PR TITLE
Fixes multiple UI Bugs

### DIFF
--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -128,6 +128,7 @@ function deselectURL(urlCard) {
   disableTabbingOnURLCardElements(urlCard);
   setURLCardSelectionEventListener(urlCard);
   setFocusEventListenersOnURLCard(urlCard);
+  urlCard.blur(); // Remove focus after deselecting the URL
 }
 
 function deselectAllURLs() {
@@ -241,6 +242,12 @@ function resetURLDeck() {
   resetNewURLForm();
   newURLInputRemoveEventListeners();
   $(".urlRow").remove();
+  hideIfShown($("#urlBtnCreate"));
+}
+
+function resetURLDeckOnDeleteUTub() {
+  hideIfShown($("#urlBtnCreate"));
+  hideIfShown($("#NoURLsSubheader"));
 }
 
 // Prevent editing URL title when needed
@@ -375,7 +382,7 @@ function buildURLDeck(UTubName, dictURLs, dictTags) {
     for (let i = 0; i < dictURLs.length; i++) {
       parent.append(
         createURLBlock(dictURLs[i], dictTags).addClass(
-          i % 2 == 0 ? "even" : "odd",
+          i % 2 === 0 ? "even" : "odd",
         ),
       );
     }
@@ -713,7 +720,8 @@ function createUpdateURLStringInput(urlStringText, urlCard) {
 
   urlStringCancelBtnUpdate
     .find(".cancelButton")
-    .on("click.updateUrlString", function () {
+    .on("click.updateUrlString", function (e) {
+      e.stopPropagation();
       hideAndResetUpdateURLStringForm(urlCard);
     })
     .offAndOn("focus.updateUrlString", function () {
@@ -845,7 +853,8 @@ function createTagInputBlock(urlCard) {
 
   urlTagCancelBtnCreate
     .find(".cancelButton")
-    .on("click.createURLTag", function () {
+    .on("click.createURLTag", function (e) {
+      e.stopPropagation();
       hideAndResetCreateURLTagForm(urlCard);
     })
     .offAndOn("focus.createURLTag", function () {

--- a/src/static/scripts/urls_routes.js
+++ b/src/static/scripts/urls_routes.js
@@ -73,10 +73,11 @@ function createURLSuccess(response) {
   url.canDelete = true;
 
   // DP 09/17 need to implement ability to addTagtoURL interstitially before createURL is completed
+  const currentNumOfURLs = getNumOfVisibleURLs();
   const newUrlCard = createURLBlock(
     url,
     [], // Mimics an empty array of tags to match against
-  );
+  ).addClass(currentNumOfURLs % 2 === 0 ? "even" : "odd");
 
   newUrlCard.insertAfter($("#createURLWrap"));
 }

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -597,6 +597,7 @@ function deleteUTubSuccess() {
   setUIWhenNoUTubSelected();
 
   hideInputsAndSetUTubDeckSubheader();
+  resetURLDeckOnDeleteUTub();
 
   if (getNumOfUTubs() === 0) {
     resetUTubDeckIfNoUTubs();


### PR DESCRIPTION
Fix a bunch of UI bugs, including: URL selection should hide if unselected, X on edit URL should not close URL, X on tag add should not close URL, deleting UTub with no URLs should leave no text in URL deck, do not show add URL button when user has no UTubs on initial page load

Closes #295 
Closes #292 
Closes #291 
Closes #289 
Closes #287 