### PR TITLE
Testing/frontend/splash modal swap tests

### DIFF
--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -1,5 +1,5 @@
 class MainPageLocators:
-    """A class for main page locators. All main page locators should come here"""
+    """A collector class for main page locators"""
 
     # Navbar
     BUTTON_LOGOUT = "#logout > .nav-bar-inner-item"
@@ -100,7 +100,7 @@ class MainPageLocators:
 
 
 class SplashPageLocators:
-    """A class for main page locators. All main page locators should come here"""
+    """A collector class for splash page locators"""
 
     # Options
     SPLASH_NAVBAR = "#NavbarDropdownsSplash"
@@ -126,3 +126,10 @@ class SplashPageLocators:
     # Modal
     SPLASH_MODAL = "#SplashModal"
     HEADER_MODAL = "#SplashModalAlertBanner"
+
+
+class ModalLocators:
+    """A collector class for general modal locators"""
+
+    ELEMENT_MODAL = ".modal"
+    BUTTON_MODAL_DISMISS = ".btn-close"

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -126,6 +126,7 @@ class SplashPageLocators:
     # Modal
     SPLASH_MODAL = "#SplashModal"
     HEADER_MODAL = "#SplashModalAlertBanner"
+    BUTTON_X_MODAL_DISMISS = ".close-register-login-modal"
 
 
 class ModalLocators:
@@ -133,3 +134,4 @@ class ModalLocators:
 
     ELEMENT_MODAL = ".modal"
     BUTTON_MODAL_DISMISS = ".btn-close"
+    BUTTON_X_MODAL_DISMISS = ".btn-close"

--- a/tests/functional/splash_ui/test_login_user_ui.py
+++ b/tests/functional/splash_ui/test_login_user_ui.py
@@ -4,7 +4,11 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS
-from tests.functional.utils_for_test import login_user, wait_then_get_element
+from tests.functional.utils_for_test import (
+    login_user,
+    wait_then_click_element,
+    wait_then_get_element,
+)
 from tests.functional.locators import MainPageLocators as MPL
 from tests.functional.locators import SplashPageLocators as SPL
 
@@ -57,6 +61,26 @@ def test_login_modal_RHS_btn(browser: WebDriver):
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
 
     assert modal_element.is_displayed()
+
+    modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
+
+    assert modal_title.text == "Login!"
+
+
+def test_register_to_login_modal_btn(browser: WebDriver):
+    """
+    Tests a user's ability to change view from the Register modal to the Login modal
+
+    GIVEN a fresh load of the U4I Splash page
+    WHEN user opens Register modal and wants to change to Login
+    THEN ensure the modal view changes
+    """
+    # Find and click register button to open modal
+    register_btn = wait_then_get_element(browser, SPL.BUTTON_REGISTER)
+    register_btn.click()
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN_FROM_REGISTER)
+
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
 
     modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
 

--- a/tests/functional/splash_ui/test_login_user_ui.py
+++ b/tests/functional/splash_ui/test_login_user_ui.py
@@ -4,16 +4,16 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS
-from tests.functional.utils_for_test import (
-    login_user,
-    open_splash_page_modal,
-    wait_then_click_element,
-    wait_then_get_element,
-    dismiss_modal_with_btn,
-    dismiss_modal_with_click_out,
-)
 from tests.functional.locators import MainPageLocators as MPL
 from tests.functional.locators import SplashPageLocators as SPL
+from tests.functional.locators import ModalLocators as ML
+from tests.functional.utils_for_test import (
+    login_user,
+    wait_then_click_element,
+    wait_then_get_element,
+    dismiss_modal_with_click_out,
+    wait_until_hidden,
+)
 
 
 def test_example(browser: WebDriver):
@@ -32,9 +32,8 @@ def test_login_modal_center_btn(browser: WebDriver):
     WHEN user clicks the center login button
     THEN ensure the modal opens
     """
-
-    # Find and click login button to open modal
-    modal_element = open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN)
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
 
     assert modal_element.is_displayed()
 
@@ -75,8 +74,7 @@ def test_register_to_login_modal_btn(browser: WebDriver):
     WHEN user opens Register modal and wants to change to Login
     THEN ensure the modal view changes
     """
-    # Find and click register button to open modal
-    open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
+    wait_then_click_element(browser, SPL.BUTTON_REGISTER)
     wait_then_click_element(browser, SPL.BUTTON_LOGIN_FROM_REGISTER)
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
@@ -94,15 +92,11 @@ def test_dismiss_login_modal_btn(browser: WebDriver):
     WHEN user opens the login, then clicks the 'x'
     THEN the modal is closed
     """
-    # Find and click login button to open modal
-    modal_element = open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN)
 
-    print(modal_element.is_displayed())
+    wait_then_click_element(browser, ML.BUTTON_MODAL_DISMISS)
 
-    dismiss_modal_with_btn(browser)
-
-    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL, 5)
-    print(modal_element.is_displayed())
+    modal_element = wait_until_hidden(browser, SPL.SPLASH_MODAL)
 
     assert not modal_element.is_displayed()
 
@@ -115,12 +109,11 @@ def test_dismiss_login_modal_click(browser: WebDriver):
     WHEN user opens the login, then clicks anywhere outside of the modal
     THEN the modal is closed
     """
-    # Find and click login button to open modal
-    open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN)
 
     dismiss_modal_with_click_out(browser)
 
-    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL, 5)
+    modal_element = wait_until_hidden(browser, SPL.SPLASH_MODAL)
 
     assert not modal_element.is_displayed()
 

--- a/tests/functional/splash_ui/test_login_user_ui.py
+++ b/tests/functional/splash_ui/test_login_user_ui.py
@@ -6,8 +6,11 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS
 from tests.functional.utils_for_test import (
     login_user,
+    open_splash_page_modal,
     wait_then_click_element,
     wait_then_get_element,
+    dismiss_modal_with_btn,
+    dismiss_modal_with_click_out,
 )
 from tests.functional.locators import MainPageLocators as MPL
 from tests.functional.locators import SplashPageLocators as SPL
@@ -31,10 +34,7 @@ def test_login_modal_center_btn(browser: WebDriver):
     """
 
     # Find and click login button to open modal
-    login_btn = wait_then_get_element(browser, SPL.BUTTON_LOGIN)
-    login_btn.click()
-
-    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
+    modal_element = open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
 
     assert modal_element.is_displayed()
 
@@ -76,8 +76,7 @@ def test_register_to_login_modal_btn(browser: WebDriver):
     THEN ensure the modal view changes
     """
     # Find and click register button to open modal
-    register_btn = wait_then_get_element(browser, SPL.BUTTON_REGISTER)
-    register_btn.click()
+    open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
     wait_then_click_element(browser, SPL.BUTTON_LOGIN_FROM_REGISTER)
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
@@ -85,6 +84,45 @@ def test_register_to_login_modal_btn(browser: WebDriver):
     modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
 
     assert modal_title.text == "Login!"
+
+
+def test_dismiss_login_modal_btn(browser: WebDriver):
+    """
+    Tests a user's ability to close the splash page login modal by clicking the upper RHS 'x' button
+
+    GIVEN a fresh load of the U4I Splash page
+    WHEN user opens the login, then clicks the 'x'
+    THEN the modal is closed
+    """
+    # Find and click login button to open modal
+    modal_element = open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
+
+    print(modal_element.is_displayed())
+
+    dismiss_modal_with_btn(browser)
+
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL, 5)
+    print(modal_element.is_displayed())
+
+    assert not modal_element.is_displayed()
+
+
+def test_dismiss_login_modal_click(browser: WebDriver):
+    """
+    Tests a user's ability to close the splash page login modal by clicking outside of the modal
+
+    GIVEN a fresh load of the U4I Splash page
+    WHEN user opens the login, then clicks anywhere outside of the modal
+    THEN the modal is closed
+    """
+    # Find and click login button to open modal
+    open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
+
+    dismiss_modal_with_click_out(browser)
+
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL, 5)
+
+    assert not modal_element.is_displayed()
 
 
 def test_login_test_user(browser: WebDriver, create_test_users):

--- a/tests/functional/splash_ui/test_register_user_ui.py
+++ b/tests/functional/splash_ui/test_register_user_ui.py
@@ -15,6 +15,9 @@ from tests.functional.splash_ui.utils_for_test_splash_ui import (
     register_user_unconfirmed_password,
 )
 from tests.functional.utils_for_test import (
+    dismiss_modal_with_btn,
+    dismiss_modal_with_click_out,
+    open_splash_page_modal,
     wait_then_click_element,
     wait_then_get_element,
     wait_then_get_elements,
@@ -31,10 +34,7 @@ def test_register_modal_center_btn(browser: WebDriver):
     """
 
     # Find and click login button to open modal
-    register_btn = wait_then_get_element(browser, SPL.BUTTON_REGISTER)
-    register_btn.click()
-
-    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
+    modal_element = open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
 
     assert modal_element.is_displayed()
 
@@ -69,15 +69,14 @@ def test_register_modal_RHS_btn(browser: WebDriver):
 
 def test_login_to_register_modal_btn(browser: WebDriver):
     """
-    Tests a user's ability to change view from the Register modal to the Login modal
+    Tests a user's ability to change view from the Login modal to the Register modal
 
     GIVEN a fresh load of the U4I Splash page
-    WHEN user opens Register modal and wants to change to Login
+    WHEN user opens Login modal and wants to change to Register
     THEN ensure the modal view changes
     """
     # Find and click login button to open modal
-    login_btn = wait_then_get_element(browser, SPL.BUTTON_LOGIN)
-    login_btn.click()
+    open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
     wait_then_click_element(browser, SPL.BUTTON_REGISTER_FROM_LOGIN)
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
@@ -85,6 +84,38 @@ def test_login_to_register_modal_btn(browser: WebDriver):
     modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
 
     assert modal_title.text == "Register"
+
+
+def test_dismiss_register_modal_btn(browser: WebDriver):
+    """
+    Tests a user's ability to close the splash page register modal by clicking the upper RHS 'x' button
+
+    GIVEN a fresh load of the U4I Splash page
+    WHEN user opens the register, then clicks the 'x'
+    THEN the modal is closed
+    """
+    # Find and click register button to open modal
+    modal_element = open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
+
+    dismiss_modal_with_btn(browser)
+
+    assert not modal_element.is_displayed()
+
+
+def test_dismiss_register_modal_click(browser: WebDriver):
+    """
+    Tests a user's ability to close the splash page register modal by clicking outside of the modal
+
+    GIVEN a fresh load of the U4I Splash page
+    WHEN user opens the register, then clicks anywhere outside of the modal
+    THEN the modal is closed
+    """
+    # Find and click register button to open modal
+    modal_element = open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
+
+    dismiss_modal_with_click_out(browser)
+
+    assert not modal_element.is_displayed()
 
 
 # @pytest.mark.skip(reason="Testing another in isolation")

--- a/tests/functional/splash_ui/test_register_user_ui.py
+++ b/tests/functional/splash_ui/test_register_user_ui.py
@@ -15,6 +15,7 @@ from tests.functional.splash_ui.utils_for_test_splash_ui import (
     register_user_unconfirmed_password,
 )
 from tests.functional.utils_for_test import (
+    wait_then_click_element,
     wait_then_get_element,
     wait_then_get_elements,
 )
@@ -64,6 +65,24 @@ def test_register_modal_RHS_btn(browser: WebDriver):
     modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
 
     assert modal_title.text == "Register"
+
+
+def test_register_to_login_modal_btn(browser: WebDriver):
+    """
+    Tests a user's ability to change view from the Register modal to the Login modal
+
+    GIVEN a fresh load of the U4I Splash page
+    WHEN user opens Register modal and wants to change to Login
+    THEN ensure the modal view changes
+    """
+    # Find and click login button to open modal
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN_FROM_REGISTER)
+
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
+
+    modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
+
+    assert modal_title.text == "Login!"
 
 
 # @pytest.mark.skip(reason="Testing another in isolation")

--- a/tests/functional/splash_ui/test_register_user_ui.py
+++ b/tests/functional/splash_ui/test_register_user_ui.py
@@ -9,18 +9,18 @@ from selenium.webdriver.common.by import By
 # Internal libraries
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import SplashPageLocators as SPL
+from tests.functional.locators import ModalLocators as ML
 from tests.functional.splash_ui.utils_for_test_splash_ui import (
     register_user,
     register_user_unconfirmed_email,
     register_user_unconfirmed_password,
 )
 from tests.functional.utils_for_test import (
-    dismiss_modal_with_btn,
     dismiss_modal_with_click_out,
-    open_splash_page_modal,
     wait_then_click_element,
     wait_then_get_element,
     wait_then_get_elements,
+    wait_until_hidden,
 )
 
 
@@ -32,9 +32,8 @@ def test_register_modal_center_btn(browser: WebDriver):
     WHEN user clicks the center register button
     THEN ensure the modal opens
     """
-
-    # Find and click login button to open modal
-    modal_element = open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
+    wait_then_click_element(browser, SPL.BUTTON_REGISTER)
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
 
     assert modal_element.is_displayed()
 
@@ -75,8 +74,7 @@ def test_login_to_register_modal_btn(browser: WebDriver):
     WHEN user opens Login modal and wants to change to Register
     THEN ensure the modal view changes
     """
-    # Find and click login button to open modal
-    open_splash_page_modal(browser, SPL.BUTTON_LOGIN)
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN)
     wait_then_click_element(browser, SPL.BUTTON_REGISTER_FROM_LOGIN)
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
@@ -94,10 +92,11 @@ def test_dismiss_register_modal_btn(browser: WebDriver):
     WHEN user opens the register, then clicks the 'x'
     THEN the modal is closed
     """
-    # Find and click register button to open modal
-    modal_element = open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN)
 
-    dismiss_modal_with_btn(browser)
+    wait_then_click_element(browser, ML.BUTTON_MODAL_DISMISS)
+
+    modal_element = wait_until_hidden(browser, SPL.SPLASH_MODAL)
 
     assert not modal_element.is_displayed()
 
@@ -110,10 +109,11 @@ def test_dismiss_register_modal_click(browser: WebDriver):
     WHEN user opens the register, then clicks anywhere outside of the modal
     THEN the modal is closed
     """
-    # Find and click register button to open modal
-    modal_element = open_splash_page_modal(browser, SPL.BUTTON_REGISTER)
+    wait_then_click_element(browser, SPL.BUTTON_LOGIN)
 
     dismiss_modal_with_click_out(browser)
+
+    modal_element = wait_until_hidden(browser, SPL.SPLASH_MODAL)
 
     assert not modal_element.is_displayed()
 

--- a/tests/functional/splash_ui/test_register_user_ui.py
+++ b/tests/functional/splash_ui/test_register_user_ui.py
@@ -67,7 +67,7 @@ def test_register_modal_RHS_btn(browser: WebDriver):
     assert modal_title.text == "Register"
 
 
-def test_register_to_login_modal_btn(browser: WebDriver):
+def test_login_to_register_modal_btn(browser: WebDriver):
     """
     Tests a user's ability to change view from the Register modal to the Login modal
 
@@ -76,13 +76,15 @@ def test_register_to_login_modal_btn(browser: WebDriver):
     THEN ensure the modal view changes
     """
     # Find and click login button to open modal
-    wait_then_click_element(browser, SPL.BUTTON_LOGIN_FROM_REGISTER)
+    login_btn = wait_then_get_element(browser, SPL.BUTTON_LOGIN)
+    login_btn.click()
+    wait_then_click_element(browser, SPL.BUTTON_REGISTER_FROM_LOGIN)
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
 
     modal_title = modal_element.find_element(By.CLASS_NAME, "modal-title")
 
-    assert modal_title.text == "Login!"
+    assert modal_title.text == "Register"
 
 
 # @pytest.mark.skip(reason="Testing another in isolation")

--- a/tests/functional/tags_ui/test_filter_tag_ui.py
+++ b/tests/functional/tags_ui/test_filter_tag_ui.py
@@ -32,6 +32,12 @@ def test_filter_tag(browser: WebDriver, create_test_tags):
 
     # Delete first tag badge from first URL row
     first_url_row = get_selected_url(browser)
+    first_url_title = first_url_row.find_element(By.CLASS_NAME, "urlTitle")[
+        0
+    ].get_attribute("innerText")
+    print(first_url_title)
+
+    # Delete first tag badge from first URL row
     first_tag_badge = first_url_row.find_elements(By.CSS_SELECTOR, MPL.TAG_BADGES)[0]
     first_tag_badge_name = first_tag_badge.find_element(
         By.TAG_NAME, "span"

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -17,6 +17,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import ModalLocators as ML
 
 # General
 
@@ -148,6 +149,29 @@ def clear_then_send_keys(element: WebElement, input_text: str):
     input_field = element
     input_field.clear()
     input_field.send_keys(input_text)
+
+
+# Modal
+def open_splash_page_modal(browser: WebDriver, locator: str):
+    # Find and click login button to open modal
+    btn = wait_then_get_element(browser, locator)
+    btn.click()
+
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
+
+    return modal_element
+
+
+def dismiss_modal_with_btn(browser: WebDriver):
+    wait_then_click_element(browser, ML.BUTTON_MODAL_DISMISS)
+
+
+def dismiss_modal_with_click_out(browser: WebDriver):
+    modal = wait_then_get_element(browser, ML.ELEMENT_MODAL)
+    action = WebDriver.common.action_chains.ActionChains(browser)
+    action.move_to_element_with_offset(modal, -5, -5)
+    action.click()
+    action.perform()
 
 
 # Splash Page

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -7,6 +7,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
     TimeoutException,
 )
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
@@ -17,7 +18,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.locators import MainPageLocators as MPL
-from tests.functional.locators import ModalLocators as ML
 
 # General
 
@@ -107,7 +107,9 @@ def wait_then_get_elements(browser: WebDriver, css_selector: str, time: float = 
         return None
 
 
-def wait_then_click_element(browser: WebDriver, css_selector: str, time: float = 2):
+def wait_then_click_element(
+    browser: WebDriver, css_selector: str, time: float = 2
+) -> WebElement:
     """
     Streamlines waiting for load and clicking a single element after user interaction.
 
@@ -117,7 +119,7 @@ def wait_then_click_element(browser: WebDriver, css_selector: str, time: float =
         (Optional) Time to wait, default 2s
 
     Returns:
-        Yields WebDriver
+        Returns clicked WebElement
     """
 
     try:
@@ -131,6 +133,7 @@ def wait_then_click_element(browser: WebDriver, css_selector: str, time: float =
         )
 
         element.click()
+        return element
     except NoSuchElementException:
         return None
 
@@ -151,25 +154,25 @@ def clear_then_send_keys(element: WebElement, input_text: str):
     input_field.send_keys(input_text)
 
 
+def wait_until_hidden(browser: WebDriver, css_selector: str):
+    element = browser.find_element(By.CSS_SELECTOR, css_selector)
+
+    wait = WebDriverWait(browser, timeout=2)
+    wait.until(lambda _: not element.is_displayed())
+
+    return element
+
+
 # Modal
-def open_splash_page_modal(browser: WebDriver, locator: str):
-    # Find and click login button to open modal
-    btn = wait_then_get_element(browser, locator)
-    btn.click()
-
-    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
-
-    return modal_element
-
-
-def dismiss_modal_with_btn(browser: WebDriver):
-    wait_then_click_element(browser, ML.BUTTON_MODAL_DISMISS)
-
-
 def dismiss_modal_with_click_out(browser: WebDriver):
-    modal = wait_then_get_element(browser, ML.ELEMENT_MODAL)
-    action = WebDriver.common.action_chains.ActionChains(browser)
-    action.move_to_element_with_offset(modal, -5, -5)
+    action = ActionChains(browser)
+    modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)
+    width = modal_element.rect["width"]
+    height = modal_element.rect["height"]
+    offset = 15
+    action.move_to_element_with_offset(
+        modal_element, -width / 2 + offset, -height / 2 + offset
+    )
     action.click()
     action.perform()
 


### PR DESCRIPTION
Completed splash page tests of opening modal, swapping register/login views, and dismissing modal in two ways. Third modal dismissal method, and Forgot Password tests to come