### PR TITLE
Add single or multiple custom urls through CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,21 @@ All tests are included in the _tests_ directory
 From this directory, with the virtual environment enabled, the following commands are enabled:
 
 ```
-`flask addmock users`                   Adds 5 mock users with their emails validated
-`flask addmock utubs`                   Adds 5 UTubs, this can be repeated to create multiple duplicate UTubs with same name. Runs users command first.
-`flask addmock utubs --no-dupes`        Creates 5 UTubs but won't if UTub with name already exists. Runs users command first.
-`flask addmock utubmembers`             Adds all users to all UTubs, even duplicates. Runs utubs commmand first.
-`flask addmock utubmembers --no-dupes`  Adds all users to all UTubs, even duplicates. Does not create duplicate UTubs.
-`flask addmock urls`                    Adds 5 URLs to all UTubs, runs utubmembers command first
-`flask addmock urls --no-dupes`         Adds 5 URLs to all UTubs, without creating duplicate UTubs.
-`flask addmock tags`                    Adds 5 tags to each URL in each UTub, runs urls command first. 
-`flask addmock tags --no-dupes`         Adds 5 tags to each URL in each UTub, without creating duplicate UTubs.
-`flask addmock all`                     Equivalent to `flask addmock tags`
-`flask addmock all --no-dupes`          Equivalent to `flask addmock tags --no-dupes`
-`flask managedb clear [test|dev]`       Clears each table, can specify either test or dev database
-`flask managedb drop [test|dev]`        Drops all tables in the datbase, can specify either test or dev database
+`flask addmock users`                       Adds 5 mock users with their emails validated
+`flask addmock utubs`                       Adds 5 UTubs, this can be repeated to create multiple duplicate UTubs with same name. Runs users command first.
+`flask addmock utubs --no-dupes`            Creates 5 UTubs but won't if UTub with name already exists. Runs users command first.
+`flask addmock utubmembers`                 Adds all users to all UTubs, even duplicates. Runs utubs commmand first.
+`flask addmock utubmembers --no-dupes`      Adds all users to all UTubs, even duplicates. Does not create duplicate UTubs.
+`flask addmock url foo bar baz`             Adds "foo", "bar", and "baz" as URLs to all UTubs, runs utubmembers command first
+`flask addmock url --no-dupes foo bar baz`  Adds "foo", "bar", and "baz" as URLs to all UTubs, runs utubmembers command first. Does not create duplicate UTubs.
+`flask addmock urls`                        Adds 5 URLs to all UTubs, runs utubmembers command first
+`flask addmock urls --no-dupes`             Adds 5 URLs to all UTubs, without creating duplicate UTubs.
+`flask addmock tags`                        Adds 5 tags to each URL in each UTub, runs urls command first. 
+`flask addmock tags --no-dupes`             Adds 5 tags to each URL in each UTub, without creating duplicate UTubs.
+`flask addmock all`                         Equivalent to `flask addmock tags`
+`flask addmock all --no-dupes`              Equivalent to `flask addmock tags --no-dupes`
+`flask managedb clear [test|dev]`           Clears each table, can specify either test or dev database
+`flask managedb drop [test|dev]`            Drops all tables in the datbase, can specify either test or dev database
 ```
 
 Note that some of these commands assume a predefined set of environment variables defining the database URI for either test or development.

--- a/src/mocks/mock_data/urls.py
+++ b/src/mocks/mock_data/urls.py
@@ -53,3 +53,47 @@ def generate_mock_urls(db: SQLAlchemy):
             )
 
     db.session.commit()
+
+
+def generate_custom_mock_url(db: SQLAlchemy, urls_to_add: list[str]):
+    all_utubs: list[Utubs] = Utubs.query.all()
+
+    for utub in all_utubs:
+        utub_members: list[Utub_Members] = utub.members
+        creator = [
+            member for member in utub_members if member.user_id == utub.utub_creator
+        ][0]
+
+        for url in urls_to_add:
+            url_to_add = Urls.query.filter(Urls.url_string == url).first()
+            if url_to_add is not None:
+                print(f"Already added {url} to database")
+            else:
+                url_to_add = Urls(normalized_url=url, current_user_id=utub.utub_creator)
+                db.session.add(url_to_add)
+                print(f"Adding {url} to database")
+
+            if (
+                Utub_Urls.query.filter(
+                    Utub_Urls.utub_id == utub.id,
+                    Utub_Urls.user_id == utub.utub_creator,
+                    Utub_Urls.url_id == url_to_add.id,
+                ).first()
+                is not None
+            ):
+                print(
+                    f"Already added {url} to {utub.name}, ID={utub.id}, by {creator.to_user.username}"
+                )
+                continue
+
+            new_utub_url: Utub_Urls = Utub_Urls()
+            new_utub_url.utub_id = utub.id
+            new_utub_url.user_id = utub.utub_creator
+            new_utub_url.url_id = url_to_add.id
+            new_utub_url.url_title = f"This is {url_to_add.url_string}."
+            db.session.add(new_utub_url)
+            print(
+                f"Adding {url} to {utub.name}, ID={utub.id}, by {creator.to_user.username}"
+            )
+
+    db.session.commit()

--- a/src/mocks/mock_options.py
+++ b/src/mocks/mock_options.py
@@ -6,7 +6,7 @@ from sqlalchemy import MetaData
 
 from src.db import db
 from src.mocks.mock_data.tags import generate_mock_tags
-from src.mocks.mock_data.urls import generate_mock_urls
+from src.mocks.mock_data.urls import generate_mock_urls, generate_custom_mock_url
 from src.mocks.mock_data.users import generate_mock_users
 from src.mocks.mock_data.utubmembers import generate_mock_utubmembers
 from src.mocks.mock_data.utubs import generate_mock_utubs
@@ -56,6 +56,23 @@ def mock_members(no_dupes: bool):
     generate_mock_utubs(db, no_dupes)
     generate_mock_utubmembers(db)
     print("\n--- Finished adding mock UTub members ---\n\n")
+
+
+@mocks_cli.command(
+    "url",
+    help="Adds a URL to each UTub, added by UTub creator. Does all of users/utubs/utubmembers.",
+)
+@click.argument("urls", nargs=-1, required=True)
+@click.option(
+    "--no-dupes", is_flag=True, help="Prevent UTubs being created with the same name"
+)
+def mock_url(urls: list[str], no_dupes: bool):
+    print(f"\n\n--- Adding mock URLs: {urls} to each UTub  ---\n")
+    generate_mock_users(db)
+    generate_mock_utubs(db, no_dupes)
+    generate_mock_utubmembers(db)
+    generate_custom_mock_url(db, urls)
+    print("\n--- Finished adding mock URLs to each UTub ---\n\n")
 
 
 @mocks_cli.command(

--- a/tests/integration/cli/test_cli_add_mock_data.py
+++ b/tests/integration/cli/test_cli_add_mock_data.py
@@ -1,5 +1,7 @@
 import pytest
 from tests.integration.cli.utils import (
+    verify_custom_url_added_to_all_utubs,
+    verify_custom_url_in_database,
     verify_users_added,
     verify_utubs_added_no_duplicates,
     verify_utubs_added_duplicates,
@@ -109,6 +111,112 @@ def test_add_mock_utub_members_no_utub_duplicates(runner):
             verify_users_added()
             verify_utubs_added_no_duplicates()
             verify_utubmembers_added()
+
+
+def test_add_custom_mock_urls_with_utub_duplicates_one_by_one(runner):
+    """
+    GIVEN a developer wanting to add custom mock URLs to UTubs, including duplicate UTubs
+    WHEN the developer provides the following CLI command:
+        `flask addmock url foo bar baz`
+    THEN verify that mock users are added, that UTubs are added to the database with duplicates,
+        that UTub members are added to all created UTubs, and that all URLs are added
+
+    Args:
+        runner (pytest.fixture): Provides a Flask application, and a FlaskCLIRunner
+    """
+    app, cli_runner = runner
+    URLS = ["google.com", "macro macro macro", "facebook.com"]
+
+    for count in range(DUPLICATE_COUNT):
+        cli_runner.invoke(args=["addmock", "url", URLS[0]])
+        with app.app_context():
+            verify_users_added()
+            verify_utubs_added_duplicates(count + 1)
+            verify_custom_url_in_database(URLS[0])
+            verify_custom_url_added_to_all_utubs(URLS[0])
+
+    # Add additional URLs
+    for url in URLS[1:]:
+        cli_runner.invoke(args=["addmock", "url", url])
+        with app.app_context():
+            verify_custom_url_in_database(url)
+            verify_custom_url_added_to_all_utubs(url)
+
+
+def test_add_custom_mock_urls_with_utub_duplicates_all_at_once(runner):
+    """
+    GIVEN a developer wanting to add custom mock URLs to UTubs, including duplicate UTubs
+    WHEN the developer provides the following CLI command:
+        `flask addmock url foo bar baz`
+    THEN verify that mock users are added, that UTubs are added to the database with duplicates,
+        that UTub members are added to all created UTubs, and that all URLs are added
+
+    Args:
+        runner (pytest.fixture): Provides a Flask application, and a FlaskCLIRunner
+    """
+    app, cli_runner = runner
+    URLS = ["google.com", "macro macro macro", "facebook.com"]
+
+    for count in range(DUPLICATE_COUNT):
+        cli_runner.invoke(args=["addmock", "url", URLS[0], URLS[1], URLS[2]])
+        with app.app_context():
+            verify_users_added()
+            verify_utubs_added_duplicates(count + 1)
+            for url in URLS:
+                verify_custom_url_in_database(url)
+                verify_custom_url_added_to_all_utubs(url)
+
+
+def test_add_custom_mock_urls_no_utub_duplicates_one_by_one(runner):
+    """
+    GIVEN a developer wanting to add custom mock URLs to UTubs, including duplicate UTubs
+    WHEN the developer provides the following CLI command:
+        `flask addmock url foo bar baz`
+    THEN verify that mock users are added, that UTubs are added to the database with duplicates,
+        that UTub members are added to all created UTubs, and that all URLs are added
+
+    Args:
+        runner (pytest.fixture): Provides a Flask application, and a FlaskCLIRunner
+    """
+    app, cli_runner = runner
+    URLS = ["google.com", "macro macro macro", "facebook.com"]
+
+    cli_runner.invoke(args=["addmock", "url", "--no-dupes", URLS[0]])
+    with app.app_context():
+        verify_users_added()
+        verify_utubs_added_no_duplicates()
+        verify_custom_url_in_database(URLS[0])
+        verify_custom_url_added_to_all_utubs(URLS[0])
+
+    # Add additional URLs
+    for url in URLS[1:]:
+        cli_runner.invoke(args=["addmock", "url", url])
+        with app.app_context():
+            verify_custom_url_in_database(url)
+            verify_custom_url_added_to_all_utubs(url)
+
+
+def test_add_custom_mock_urls_no_utub_duplicates_all_at_once(runner):
+    """
+    GIVEN a developer wanting to add custom mock URLs to UTubs, including duplicate UTubs
+    WHEN the developer provides the following CLI command:
+        `flask addmock url foo bar baz`
+    THEN verify that mock users are added, that UTubs are added to the database with duplicates,
+        that UTub members are added to all created UTubs, and that all URLs are added
+
+    Args:
+        runner (pytest.fixture): Provides a Flask application, and a FlaskCLIRunner
+    """
+    app, cli_runner = runner
+    URLS = ["google.com", "macro macro macro", "facebook.com"]
+
+    cli_runner.invoke(args=["addmock", "url", "--no-dupes", URLS[0], URLS[1], URLS[2]])
+    with app.app_context():
+        verify_users_added()
+        verify_utubs_added_no_duplicates()
+        for url in URLS:
+            verify_custom_url_in_database(url)
+            verify_custom_url_added_to_all_utubs(url)
 
 
 def test_add_mock_urls_with_utub_duplicates(runner):

--- a/tests/integration/cli/utils.py
+++ b/tests/integration/cli/utils.py
@@ -67,6 +67,11 @@ def verify_urls_in_database():
         assert Urls.query.filter(Urls.url_string == url).count() == 1
 
 
+def verify_custom_url_in_database(url: str):
+    """Verifies custom URL is stored in the database"""
+    assert Urls.query.filter(Urls.url_string == url).count() == 1
+
+
 def verify_urls_added_to_all_utubs():
     """Verifies all mock URLs are added to each UTub"""
     all_utubs: list[Utubs] = Utubs.query.all()
@@ -75,6 +80,14 @@ def verify_urls_added_to_all_utubs():
         assert sorted(
             [url.standalone_url.url_string for url in urls_in_utub]
         ) == sorted(MOCK_URL_STRINGS)
+
+
+def verify_custom_url_added_to_all_utubs(url: str):
+    """Verifies all mock URLs are added to each UTub"""
+    all_utubs: list[Utubs] = Utubs.query.all()
+    for utub in all_utubs:
+        urls_in_utub: list[Utub_Urls] = utub.utub_urls
+        assert url in [url.standalone_url.url_string for url in urls_in_utub]
 
 
 def verify_tags_in_utubs():


### PR DESCRIPTION
Allows developers to add single or multiple URLs to the database through the CLI for development or testing purposes.

Commands as follows:
`flask addmock url --no-dupes foo`  - Will add `foo` as a URL to each UTub, added by UTub creator
`flask addmock url --no-dupes foo bar baz`  - Will add `foo`, `bar`, and `baz` as URLs to each UTub, added by UTub creator