### PR TITLE
Testing/frontend infra/login user via session instead of UI

### DIFF
--- a/DockerfileDev
+++ b/DockerfileDev
@@ -18,10 +18,28 @@ RUN set -ex \
 	&& adduser --system --uid 1001 --gid 1001 --no-create-home u4i-host \
 	&& apt-get update \
 	&& apt-get -y install libpq-dev gcc \
+	&& apt-get install -y wget unzip xvfb libglib2.0-dev libnss3-dev libdbus-1-dev  libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon-dev libxcomposite-dev libxdamage-dev libgbm-dev libpangocairo-1.0-0 libasound2 \
 	&& apt-get upgrade -y \
 	&& apt-get autoremove -y \
 	&& apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Install chrome
+RUN wget https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.116/linux64/chrome-linux64.zip && \
+	unzip chrome-linux64.zip -d /usr/local/bin/ && \
+	chmod +x /usr/local/bin/chrome-linux64
+ENV PATH="/usr/local/bin/chrome-linux64:$PATH"
+
+# Install ChromeDriver
+RUN wget https://storage.googleapis.com/chrome-for-testing-public/130.0.6723.116/linux64/chromedriver-linux64.zip && \
+    unzip chromedriver-linux64.zip -d /usr/local/bin/ && \
+    chmod +x /usr/local/bin/chromedriver-linux64
+ENV PATH="/usr/local/bin/chromedriver-linux64:$PATH"
+
+# Set environment variables for selenium
+ENV SE_CACHE_PATH=/tmp/.cache/selenium
+ENV SE_BROWSER_PATH=/usr/local/bin/chrome64-linux/chrome
+RUN mkdir -p /tmp/.cache/selenium && chmod -R 777 /tmp/.cache/selenium
 
 # Copy files needed
 COPY run.py ./

--- a/src/config.py
+++ b/src/config.py
@@ -103,6 +103,7 @@ class Config:
         ),  # Currently, not testing in local docker containers
     }
     REDIS_URI = environ.get(ENV.REDIS_URI, default="memory://")
+    DOCKER = IS_DOCKER
 
     def __init__(self) -> None:
         if not self.SECRET_KEY:

--- a/src/config.py
+++ b/src/config.py
@@ -71,7 +71,7 @@ class Config:
     FLASK_RUN_HOST = environ.get("FLASK_RUN_HOST", default=None)
     FLASK_DEBUG = environ.get("FLASK_DEBUG")
     SECRET_KEY = environ.get(ENV.SECRET_KEY)
-    SESSION_PERMANENT = "False"
+    SESSION_PERMANENT = False
     if environ.get(ENV.REDIS_URI, default=None) is None:
         SESSION_TYPE = "cachelib"
         SESSION_CACHELIB = FileSystemCache(

--- a/src/mocks/mock_data/users.py
+++ b/src/mocks/mock_data/users.py
@@ -5,7 +5,7 @@ from src.models.email_validations import Email_Validations
 from src.models.users import Users
 
 
-def generate_mock_users(db: SQLAlchemy):
+def generate_mock_users(db: SQLAlchemy, silent: bool = False):
     """
     Generates mock Users, adds them to database if not already added.
 
@@ -19,10 +19,12 @@ def generate_mock_users(db: SQLAlchemy):
         new_user = Users(username=username, email=email, plaintext_password=email)
 
         if Users.query.filter(Users.username == username).first() is not None:
-            print(f"Already added user with username: {username} | email: {email} ")
+            if not silent:
+                print(f"Already added user with username: {username} | email: {email} ")
 
         else:
-            print(f"Adding test user with username: {username} | email: {email} ")
+            if not silent:
+                print(f"Adding test user with username: {username} | email: {email} ")
 
             db.session.add(new_user)
 

--- a/src/mocks/mock_options.py
+++ b/src/mocks/mock_options.py
@@ -6,6 +6,7 @@ from flask_login import login_user
 from sqlalchemy import MetaData
 
 from src.db import db
+from src.mocks.mock_constants import TEST_USER_COUNT
 from src.mocks.mock_data.tags import generate_mock_tags
 from src.mocks.mock_data.urls import generate_mock_urls, generate_custom_mock_url
 from src.mocks.mock_data.users import generate_mock_users
@@ -129,11 +130,14 @@ def _add_all(db: SQLAlchemy, no_dupes: bool):
 @click.argument("user_id", nargs=1, required=True, default=1, type=int)
 @with_appcontext
 def login_mock_user(user_id: int):
-    generate_mock_users(db, silent=True)
+    if not isinstance(user_id, int) or (user_id > TEST_USER_COUNT or user_id <= 0):
+        click.echo("User ID not found to login", err=True)
+        return
+
     user: Users = Users.query.get(user_id)
     if not user:
-        click.echo("User not found to login", err=True)
-        return
+        generate_mock_users(db, silent=True)
+        user: Users = Users.query.get(user_id)
 
     with current_app.test_request_context("/"):
         if login_user(user):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -196,7 +196,7 @@ def create_test_users(runner, debug_strings):
 
 
 @pytest.fixture
-def login_first_user(
+def login_first_user_and_get_browser(
     browser: WebDriver, runner: Tuple[Flask, FlaskCliRunner], debug_strings
 ) -> Generator[WebDriver, None, None]:
     """
@@ -228,7 +228,7 @@ def login_first_user(
 
 
 @pytest.fixture
-def create_test_utubs(runner, debug_strings):
+def create_test_utubs(runner: Tuple[Flask, FlaskCliRunner], debug_strings):
     """
     Assumes users created. Creates sample UTubs, each user owns one.
     """

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,6 +13,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.chrome.options import Options
 
 # Internal libraries
+from src.config import ConfigTest
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS
 from tests.ui_test_utils import clear_db, find_open_port, ping_server, run_app
 
@@ -77,9 +78,13 @@ def build_driver(
     """
     Given the Flask app running in parallel, this function gets the browser ready for manipulation and pings server to ensure Flask app is running in parallel.
     """
+    config = ConfigTest()
     open_port = provide_port
     options = Options()
     options.add_argument("--disable-notifications")
+    if config.DOCKER:
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
 
     if turn_off_headless:
         # Disable Chrome browser pop-up notifications
@@ -188,6 +193,38 @@ def create_test_users(runner, debug_strings):
 
     if debug_strings:
         print("\nusers created")
+
+
+@pytest.fixture
+def login_first_user(
+    browser: WebDriver, runner: Tuple[Flask, FlaskCliRunner], debug_strings
+) -> Generator[WebDriver, None, None]:
+    """
+    Creates users and logs in user with ID = 1
+    Username: u4i_test1
+    """
+    _, cli_runner = runner
+
+    response = cli_runner.invoke(args=["addmock", "login", "1"])
+    if "N/A" == response.output:
+        raise ValueError("Unable to login user")
+
+    user_session = response.output
+
+    if debug_strings:
+        print("\nUser with ID=1 logged in")
+
+    # Login test user and select first test UTub
+    cookie = {
+        "name": "session",
+        "value": user_session.strip(),
+        "path": "/",
+        "httpOnly": True,
+    }
+
+    browser.add_cookie(cookie)
+    yield browser
+    browser.delete_all_cookies()
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -13,6 +13,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.chrome.options import Options
 
 # Internal libraries
+from src import create_app
 from src.config import ConfigTest
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS
 from tests.ui_test_utils import clear_db, find_open_port, ping_server, run_app
@@ -69,6 +70,11 @@ def parallelize_app(provide_port, init_multiprocessing, flask_logs):
     yield process
     process.kill()
     process.join()
+
+
+@pytest.fixture(scope="session")
+def provide_app_for_session_generation() -> Generator[Flask | None, None, None]:
+    yield create_app(ConfigTest())
 
 
 @pytest.fixture(scope="session")
@@ -193,38 +199,6 @@ def create_test_users(runner, debug_strings):
 
     if debug_strings:
         print("\nusers created")
-
-
-@pytest.fixture
-def login_first_user_and_get_browser(
-    browser: WebDriver, runner: Tuple[Flask, FlaskCliRunner], debug_strings
-) -> Generator[WebDriver, None, None]:
-    """
-    Creates users and logs in user with ID = 1
-    Username: u4i_test1
-    """
-    _, cli_runner = runner
-
-    response = cli_runner.invoke(args=["addmock", "login", "1"])
-    if "N/A" == response.output:
-        raise ValueError("Unable to login user")
-
-    user_session = response.output
-
-    if debug_strings:
-        print("\nUser with ID=1 logged in")
-
-    # Login test user and select first test UTub
-    cookie = {
-        "name": "session",
-        "value": user_session.strip(),
-        "path": "/",
-        "httpOnly": True,
-    }
-
-    browser.add_cookie(cookie)
-    yield browser
-    browser.delete_all_cookies()
 
 
 @pytest.fixture

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -78,6 +78,8 @@ class MainPageLocators:
 
     BUTTON_URL_DELETE = ".urlBtnDelete"
 
+    URL_STRING_IN_DATA = "data-url"
+
     # Members Deck
     SUBHEADER_MEMBER_DECK = "#memberDeckSubheader"
     BUTTON_MEMBER_CREATE = "#memberBtnCreate"

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -2,6 +2,7 @@
 from time import sleep
 
 # External libraries
+from flask import Flask
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -14,7 +15,9 @@ from src.mocks.mock_constants import (
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import MainPageLocators as MPL
 from tests.functional.utils_for_test import (
+    create_user_session_and_provide_session_id,
     get_selected_url,
+    login_user_with_cookie_from_session,
     login_utub,
     select_url_by_title,
     select_utub_by_name,
@@ -25,7 +28,9 @@ from tests.functional.urls_ui.utils_for_test_url_ui import create_url
 
 
 # @pytest.mark.skip(reason="Testing another in isolation")
-def test_create_url(login_first_user_and_get_browser: WebDriver, create_test_utubs):
+def test_create_url(
+    browser: WebDriver, create_test_utubs, provide_app_for_session_generation: Flask
+):
     """
     Tests a user's ability to create a new URL in a selected UTub
 
@@ -33,7 +38,9 @@ def test_create_url(login_first_user_and_get_browser: WebDriver, create_test_utu
     WHEN they submit the addUTub form
     THEN ensure the appropriate input field is shown and in focus
     """
-    browser = login_first_user_and_get_browser
+    app = provide_app_for_session_generation
+    session_id = create_user_session_and_provide_session_id(app, 1)
+    browser = login_user_with_cookie_from_session(browser, session_id)
 
     # Refresh to allow the newly added UTubs to show
     browser.refresh()
@@ -90,7 +97,9 @@ def test_create_url_title_length_exceeded(browser: WebDriver, create_test_utubs)
     assert warning_modal_body.text == "Try shortening your UTub name"
 
 
-def test_select_url(login_first_user_and_get_browser: WebDriver, create_test_urls):
+def test_select_url(
+    browser: WebDriver, create_test_urls, provide_app_for_session_generation: Flask
+):
     """
     Tests a user's ability to select a URL and see more details
 
@@ -98,9 +107,10 @@ def test_select_url(login_first_user_and_get_browser: WebDriver, create_test_url
     WHEN they submit the addUTub form
     THEN ensure the appropriate input field is shown and in focus
     """
-
-    # Login test user, select first test UTub, and select first test URL
-    browser = login_first_user_and_get_browser
+    user_id_to_login_as = 1
+    app = provide_app_for_session_generation
+    session_id = create_user_session_and_provide_session_id(app, user_id_to_login_as)
+    browser = login_user_with_cookie_from_session(browser, session_id)
 
     browser.refresh()
     select_utub_by_name(browser, UTS.TEST_UTUB_NAME_1)

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -17,6 +17,7 @@ from tests.functional.utils_for_test import (
     get_selected_url,
     login_utub,
     login_utub_url,
+    select_utub_by_name,
     wait_then_get_element,
     wait_then_get_elements,
 )
@@ -24,7 +25,7 @@ from tests.functional.urls_ui.utils_for_test_url_ui import create_url
 
 
 # @pytest.mark.skip(reason="Testing another in isolation")
-def test_create_url(browser: WebDriver, create_test_utubs):
+def test_create_url(login_first_user: WebDriver, create_test_utubs):
     """
     Tests a user's ability to create a new URL in a selected UTub
 
@@ -32,9 +33,12 @@ def test_create_url(browser: WebDriver, create_test_utubs):
     WHEN they submit the addUTub form
     THEN ensure the appropriate input field is shown and in focus
     """
+    browser = login_first_user
 
-    # Login test user and select first test UTub
-    login_utub(browser)
+    # Refresh to allow the newly added UTubs to show
+    browser.refresh()
+
+    select_utub_by_name(browser, UTS.TEST_UTUB_NAME_1)
 
     url_title = MOCK_URL_TITLES[0]
     url_string = MOCK_URL_STRINGS[0]
@@ -44,7 +48,11 @@ def test_create_url(browser: WebDriver, create_test_utubs):
     sleep(4)
 
     # Extract URL title and string from new row in URL deck
-    url_row = wait_then_get_elements(browser, MPL.ROWS_URLS)[0]
+    url_row = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    if url_row is None:
+        assert False
+    url_row = url_row[0]
+
     url_row_title = url_row.find_elements(By.CLASS_NAME, "urlTitle")[0].get_attribute(
         "innerText"
     )

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -16,7 +16,7 @@ from tests.functional.locators import MainPageLocators as MPL
 from tests.functional.utils_for_test import (
     get_selected_url,
     login_utub,
-    login_utub_url,
+    select_url_by_title,
     select_utub_by_name,
     wait_then_get_element,
     wait_then_get_elements,
@@ -25,7 +25,7 @@ from tests.functional.urls_ui.utils_for_test_url_ui import create_url
 
 
 # @pytest.mark.skip(reason="Testing another in isolation")
-def test_create_url(login_first_user: WebDriver, create_test_utubs):
+def test_create_url(login_first_user_and_get_browser: WebDriver, create_test_utubs):
     """
     Tests a user's ability to create a new URL in a selected UTub
 
@@ -33,7 +33,7 @@ def test_create_url(login_first_user: WebDriver, create_test_utubs):
     WHEN they submit the addUTub form
     THEN ensure the appropriate input field is shown and in focus
     """
-    browser = login_first_user
+    browser = login_first_user_and_get_browser
 
     # Refresh to allow the newly added UTubs to show
     browser.refresh()
@@ -90,8 +90,7 @@ def test_create_url_title_length_exceeded(browser: WebDriver, create_test_utubs)
     assert warning_modal_body.text == "Try shortening your UTub name"
 
 
-# @pytest.mark.skip(reason="Testing another in isolation")
-def test_select_url(browser: WebDriver, create_test_urls):
+def test_select_url(login_first_user_and_get_browser: WebDriver, create_test_urls):
     """
     Tests a user's ability to select a URL and see more details
 
@@ -101,7 +100,11 @@ def test_select_url(browser: WebDriver, create_test_urls):
     """
 
     # Login test user, select first test UTub, and select first test URL
-    login_utub_url(browser)
+    browser = login_first_user_and_get_browser
+
+    browser.refresh()
+    select_utub_by_name(browser, UTS.TEST_UTUB_NAME_1)
+    select_url_by_title(browser, UTS.TEST_URL_TITLE_1)
 
     url_row = get_selected_url(browser)
 
@@ -110,3 +113,5 @@ def test_select_url(browser: WebDriver, create_test_urls):
     assert url_row.find_element(
         By.CSS_SELECTOR, MPL.URL_BUTTONS_OPTIONS_READ
     ).is_displayed
+    url_string = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    assert url_string.get_attribute(MPL.URL_STRING_IN_DATA) in MOCK_URL_STRINGS

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -1,7 +1,9 @@
 # Standard library
+import secrets
 from typing import List
 
 # External libraries
+from flask import Flask, session
 from selenium.common.exceptions import (
     ElementNotInteractableException,
     NoSuchElementException,
@@ -17,6 +19,7 @@ from selenium.webdriver.support import expected_conditions as EC
 
 
 # Internal libraries
+from src.models.users import Users
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.locators import MainPageLocators as MPL
@@ -189,6 +192,56 @@ def dismiss_modal_with_click_out(browser: WebDriver):
 def open_forgot_password_modal(browser: WebDriver):
     wait_then_click_element(browser, SPL.BUTTON_LOGIN)
     wait_then_click_element(browser, SPL.BUTTON_FORGOT_PASSWORD_MODAL)
+
+
+def create_user_session_and_provide_session_id(app: Flask, user_id: int) -> str:
+    """
+    Manually creates a user session to allow user to be logged in
+    without needing UI interaction.
+
+    Args:
+        app (Flask): The Flask application is necessary to generate a request context in order to insert the session into the appropriate session engine
+        user_id (int): The user ID wanting to be logged in as
+
+    Returns:
+        (str): The session ID of the user that can be used to log the user in
+    """
+    random_sid = _create_random_sid()
+    with app.test_request_context("/"):
+        user: Users = Users.query.get(user_id)
+        session["_user_id"] = user.get_id()
+        session["_fresh"] = True
+        session["_id"] = _create_random_identifier()
+        session.sid = random_sid
+        session.modified = True
+
+        app.session_interface.save_session(
+            app, session, response=app.make_response("Testing")
+        )
+    return random_sid
+
+
+def _create_random_identifier() -> str:
+    return secrets.token_hex(64)
+
+
+def _create_random_sid() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def login_user_with_cookie_from_session(
+    browser: WebDriver, session_id: str
+) -> WebDriver:
+    # Login test user and select first test UTub
+    cookie = {
+        "name": "session",
+        "value": session_id,
+        "path": "/",
+        "httpOnly": True,
+    }
+
+    browser.add_cookie(cookie)
+    return browser
 
 
 def login_user(

--- a/tests/integration/cli/test_login_user_via_cli.py
+++ b/tests/integration/cli/test_login_user_via_cli.py
@@ -1,4 +1,8 @@
+from typing import Tuple
+
 from click.testing import Result
+from flask import Flask
+from flask.testing import FlaskCliRunner
 import pytest
 
 from src.mocks.mock_constants import TEST_USER_COUNT
@@ -7,7 +11,7 @@ from src.mocks.mock_options import USER_ID_INVALID_TO_LOGIN_WITH
 pytestmark = pytest.mark.cli
 
 
-def test_login_valid_user_via_cli(runner):
+def test_login_valid_user_via_cli(runner: Tuple[Flask, FlaskCliRunner]):
     app, cli_runner = runner
 
     for user_id in range(1, TEST_USER_COUNT + 1):
@@ -15,11 +19,10 @@ def test_login_valid_user_via_cli(runner):
         user_session_id = result.output.strip()
 
         with app.app_context():
-            assert (
-                b"session:" + user_session_id.encode()
-                in app.session_interface.client.keys("*")
-            )
+            store_id = f"session:{user_session_id}"
+            assert app.session_interface._retrieve_session_data(store_id) is not None
             assert result.exit_code == 0
+            app.session_interface._delete_session(store_id)
 
 
 def test_login_invalid_user_via_cli(runner):

--- a/tests/integration/cli/test_login_user_via_cli.py
+++ b/tests/integration/cli/test_login_user_via_cli.py
@@ -1,0 +1,33 @@
+from click.testing import Result
+import pytest
+
+from src.mocks.mock_constants import TEST_USER_COUNT
+from src.mocks.mock_options import USER_ID_INVALID_TO_LOGIN_WITH
+
+pytestmark = pytest.mark.cli
+
+
+def test_login_valid_user_via_cli(runner):
+    app, cli_runner = runner
+
+    for user_id in range(1, TEST_USER_COUNT + 1):
+        result: Result = cli_runner.invoke(args=["addmock", "login", f"{user_id}"])
+        user_session_id = result.output.strip()
+
+        with app.app_context():
+            assert (
+                b"session:" + user_session_id.encode()
+                in app.session_interface.client.keys("*")
+            )
+            assert result.exit_code == 0
+
+
+def test_login_invalid_user_via_cli(runner):
+    app, cli_runner = runner
+
+    result: Result = cli_runner.invoke(args=["addmock", "login", "0"])
+    user_session_output = result.output.strip()
+
+    with app.app_context():
+        assert USER_ID_INVALID_TO_LOGIN_WITH in user_session_output
+        assert result.exit_code == 1


### PR DESCRIPTION
Allows UI tests to login in via session creation, either through the CLI or programmatically, instead of through the UI. This removes need for the UI and Selenium to have to manually login in before tests requiring the user to be on their home page.