### PR TITLE
Deploy prod and dev only on PR merged, not just closed

### DIFF
--- a/.github/workflows/dev-build-and-deploy.yml
+++ b/.github/workflows/dev-build-and-deploy.yml
@@ -10,12 +10,14 @@ on:
 
 jobs:
     build-dev:
+        if: github.event.pull_request.merged == true
         name: 'CD Dev - Build'
         uses: ./.github/workflows/dev-build.yml
         permissions:
             packages: write
 
     deploy-dev:
+        if: github.event.pull_request.merged == true
         needs: 'build-dev'
         name: 'CD Dev - Deploy'
         uses: ./.github/workflows/dev-deploy.yml

--- a/.github/workflows/prod-build-and-deploy.yml
+++ b/.github/workflows/prod-build-and-deploy.yml
@@ -11,12 +11,14 @@ on:
 
 jobs:
     build-prod:
+        if: github.event.pull_request.merged == true
         name: 'CD Prod - Build'
         uses: ./.github/workflows/prod-build.yml
         permissions:
             packages: write
 
     deploy-prod:
+        if: github.event.pull_request.merged == true
         needs: 'build-prod'
         name: 'CD Prod - Deploy'
         uses: ./.github/workflows/prod-deploy.yml


### PR DESCRIPTION
Ensure that the build and deployments of docker containers only occurs when the PR is fully closed and merged, not when the PR is just closed.