### PR TITLE
Tests/frontend/sad path utub tests

### DIFF
--- a/src/models/utub_members.py
+++ b/src/models/utub_members.py
@@ -20,7 +20,7 @@ class Utub_Members(db.Model):
     user_id: int = Column(
         Integer, ForeignKey("Users.id"), primary_key=True, name="userID"
     )
-    member_role: str = Column(
+    member_role: Member_Role = Column(
         SQLEnum(Member_Role),
         nullable=False,
         default=Member_Role.MEMBER,

--- a/src/static/scripts/tags.js
+++ b/src/static/scripts/tags.js
@@ -220,11 +220,9 @@ function createTagFilterInDeck(tagID, string) {
 
 // Handle tag filtered selected - tags are filtered based on a URL having one tag AND another tag.. etc
 function toggleTagFilterSelected(activeTagFilter) {
-  console.log($(".tagFilter.selected"));
   const currentSelectedTagIDs = $.map($(".tagFilter.selected"), (tagFilter) =>
     parseInt($(tagFilter).attr("data-utub-tag-id")),
   );
-  console.log(currentSelectedTagIDs);
   if (
     currentSelectedTagIDs.length >= CONSTANTS.TAGS_MAX_ON_URLS &&
     activeTagFilter.hasClass("unselected")

--- a/src/static/scripts/tags.js
+++ b/src/static/scripts/tags.js
@@ -4,7 +4,7 @@ $(document).ready(function () {
   /* Bind click functions */
   const utubTagBtnCreate = $("#utubTagBtnCreate");
 
-  // Add member to UTub
+  // Add tag to UTub
   utubTagBtnCreate.on("click.createUTubTag", function () {
     createUTubTagShowInput();
   });
@@ -64,6 +64,16 @@ function resetTagDeck() {
   disableUnselectAllButtonAfterTagFilterRemoved();
   hideIfShown($("#utubTagBtnCreate"));
   createUTubTagHideInput();
+}
+
+function resetTagDeckIfNoUTubSelected() {
+  $("#listTags").empty();
+  $("#createUTubTagWrap").hide();
+  hideIfShown($("#createUTubTagWrap"));
+  hideIfShown($("#utubTagBtnCreate"));
+  removeCreateUTubTagEventListeners();
+  resetCreateUTubTagFailErrors();
+  resetNewUTubTagForm();
 }
 
 // Alphasort tags

--- a/src/static/scripts/tags_routes.js
+++ b/src/static/scripts/tags_routes.js
@@ -14,7 +14,7 @@ function createUTubTagHideInput() {
   hideIfShown($("#createUTubTagWrap"));
   $("#createUTubTagWrap").hide();
   showIfHidden($("#listTags"));
-  showIfHidden($("#utubTagBtnCreate"));
+  if (getNumOfUTubs() !== 0) showIfHidden($("#utubTagBtnCreate"));
   removeCreateUTubTagEventListeners();
   resetCreateUTubTagFailErrors();
   resetNewUTubTagForm();

--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -288,6 +288,7 @@ function resetURLDeck() {
   newURLInputRemoveEventListeners();
   $(".urlRow").remove();
   hideIfShown($("#urlBtnCreate"));
+  updateUTubDescriptionHideInput();
 }
 
 function resetURLDeckOnDeleteUTub() {

--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -212,7 +212,6 @@ function accessLink(urlString) {
 
 function hideAccessAllWarningShowModal() {
   $("#confirmModal").removeClass("accessAllUrlModal");
-  console.log("Testing hide functionality");
 }
 
 // Show confirmation modal for opening all URLs in UTub
@@ -419,7 +418,7 @@ function updateURLAfterFindingStaleData(urlCard, newUrl, updatedUTubTags) {
 }
 
 // Build center panel URL list for selectedUTub
-function buildURLDeck(UTubName, dictURLs, dictTags) {
+function buildURLDeck(utubName, dictURLs, dictTags) {
   resetURLDeck();
   const parent = $("#listURLs");
   const numOfURLs = dictURLs.length ? dictURLs.length : 0;
@@ -443,7 +442,7 @@ function buildURLDeck(UTubName, dictURLs, dictTags) {
     $("#urlBtnDeckCreate").show();
     $("#accessAllURLsBtn").hide();
   }
-  setUTubNameAndDescription(UTubName);
+  setUTubNameAndDescription(utubName);
 }
 
 // Create a URL block to add to current UTub/URLDeck
@@ -1131,7 +1130,6 @@ function createTagDeleteIcon() {
 
 /** URL Display State Functions **/
 
-// Display state 0: Clean slate, no UTub selected
 function setURLDeckWhenNoUTubSelected() {
   $("#URLDeckHeader").text("URLs");
   $(".updateUTubBtn").hide();
@@ -1149,7 +1147,6 @@ function setURLDeckWhenNoUTubSelected() {
   $("#utubNameBtnUpdate").removeClass("visibleBtn");
 }
 
-// Display state 1: UTub selected, URL list and subheader prompt
 function setUTubNameAndDescription(UTubName) {
   $("#URLDeckHeader").text(UTubName);
   $("#utubNameUpdate").val(UTubName);

--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -1140,16 +1140,16 @@ function setURLDeckWhenNoUTubSelected() {
   $("#utubNameBtnUpdate").hide();
   $("#updateUTubDescriptionBtn").removeClass("visibleBtn");
 
-  const URLDeckSubheader = $("#URLDeckSubheader");
-  URLDeckSubheader.text("Select a UTub");
-  URLDeckSubheader.show();
+  const urlDeckSubheader = $("#URLDeckSubheader");
+  urlDeckSubheader.text("Select a UTub");
+  urlDeckSubheader.show();
 
   // Prevent on-hover of URL Deck Header to show update UTub name button in case of back button
   $("#utubNameBtnUpdate").removeClass("visibleBtn");
 }
 
-function setUTubNameAndDescription(UTubName) {
-  $("#URLDeckHeader").text(UTubName);
-  $("#utubNameUpdate").val(UTubName);
+function setUTubNameAndDescription(utubName) {
+  $("#URLDeckHeader").text(utubName);
+  $("#utubNameUpdate").val(utubName);
   updateUTubNameHideInput();
 }

--- a/src/static/scripts/utils.js
+++ b/src/static/scripts/utils.js
@@ -483,7 +483,7 @@ function revertMobileUIToFullScreenUI() {
 function setUIWhenNoUTubSelected() {
   hideInputs();
   setTagDeckSubheaderWhenNoUTubSelected();
-  resetTagDeck();
+  resetTagDeckIfNoUTubSelected();
   setURLDeckWhenNoUTubSelected();
   resetURLDeck();
   setMemberDeckWhenNoUTubSelected();

--- a/src/static/scripts/utubs.js
+++ b/src/static/scripts/utubs.js
@@ -86,8 +86,8 @@ function getUTubSelectorElemFromID(id) {
 
 // Streamline the extraction of a UTub array element from its ID
 function getUTubObjFromID(id) {
-  $(".UTubSelector").forEach(function (UTub) {
-    if (UTub.attr("utubid") === id) return UTub;
+  $(".UTubSelector").forEach(function (utub) {
+    if (utub.attr("utubid") === id) return utub;
   });
 
   return -1;
@@ -95,14 +95,14 @@ function getUTubObjFromID(id) {
 
 // Streamline the jQuery selector extraction of UTub ID. And makes it easier in case the ID is encoded in a new location in the future
 function getUTubIDFromName(name) {
-  const UTubNames = $(".UTubName");
-  let UTub;
+  const utubNames = $(".UTubName");
+  let utub;
 
-  for (i = 0; i < UTubNames.length; i++) {
-    UTub = $(UTubNames[i]);
+  for (i = 0; i < utubNames.length; i++) {
+    utub = $(utubNames[i]);
 
-    if (UTub.text() === name) {
-      return parseInt(UTub.closest(".UTubSelector").attr("utubid"));
+    if (utub.text() === name) {
+      return parseInt(utub.closest(".UTubSelector").attr("utubid"));
     }
   }
 
@@ -116,10 +116,10 @@ function getCurrentUTubName() {
 
 // Quickly extracts all UTub names from #listUTubs and returns an array.
 function getAllAccessibleUTubNames() {
-  let UTubNames = [];
-  const UTubSelectorNames = $(".UTubName");
-  UTubSelectorNames.map((i) => UTubNames.push($(UTubSelectorNames[i]).text()));
-  return UTubNames;
+  let utubNames = [];
+  const utubSelectorNames = $(".UTubName");
+  utubSelectorNames.map((i) => utubNames.push($(utubSelectorNames[i]).text()));
+  return utubNames;
 }
 
 // Streamline the AJAX call to db for updated info
@@ -351,7 +351,9 @@ function buildUTubDeck(utubs, timeoutID) {
 
     hideInputsAndSetUTubDeckSubheader();
     setURLDeckWhenNoUTubSelected();
-  } else resetUTubDeckIfNoUTubs();
+  } else {
+    resetUTubDeckIfNoUTubs();
+  }
 
   if (timeoutID) hideUTubLoadingIconAndClearTimeout(timeoutID);
 }

--- a/src/static/scripts/utubs.js
+++ b/src/static/scripts/utubs.js
@@ -301,6 +301,40 @@ function allowUserToCreateDescriptionIfEmptyOnTitleUpdate() {
   });
 }
 
+function allowHoverOnUTubTitleToCreateDescriptionIfDescEmpty() {
+  const utubTitle = $("#URLDeckHeader");
+  utubTitle.offAndOn("mouseenter.createUTubdescription", function () {
+    const clickToCreateDesc = $("#URLDeckSubheaderCreateDescription");
+    showIfHidden(clickToCreateDesc);
+    clickToCreateDesc.offAndOn("click.createUTubdescription", function (e) {
+      e.stopPropagation();
+      hideIfShown(clickToCreateDesc);
+      updateUTubDescriptionShowInput();
+      clickToCreateDesc.off("click.createUTubdescription");
+    });
+    hideCreateUTubDescriptionButtonOnMouseExit();
+  });
+}
+
+function hideCreateUTubDescriptionButtonOnMouseExit() {
+  const urlHeaderWrap = $("#URLDeckHeaderWrap");
+  const clickToCreateDesc = $("#URLDeckSubheaderCreateDescription");
+  urlHeaderWrap.offAndOn("mouseleave.createUTubdescription", function () {
+    if (!isHidden($(clickToCreateDesc))) {
+      hideIfShown(clickToCreateDesc);
+      clickToCreateDesc.off("click.createUTubdescription");
+      urlHeaderWrap.off("mouseleave.createUTubdescription");
+    }
+  });
+}
+
+function removeEventListenersForShowCreateUTubDescIfEmptyDesc() {
+  const utubTitle = $("#URLDeckHeader");
+  utubTitle.off("mouseenter.createUTubdescription");
+  const urlHeaderWrap = $("#URLDeckHeaderWrap");
+  urlHeaderWrap.off("mouseleave.createUTubdescription");
+}
+
 /** UTub Functions **/
 
 // Assembles components of the UTubDeck (top left panel)
@@ -362,7 +396,11 @@ function buildSelectedUTub(selectedUTub) {
   const utubDescriptionHeader = $("#URLDeckSubheader");
   if (utubDescription) {
     utubDescriptionHeader.text(utubDescription);
+    removeEventListenersForShowCreateUTubDescIfEmptyDesc();
   } else {
+    //const utubTitle = $("#URLDeckHeader");
+    //utubTitle.off("mouseenter.createUTubdescription");
+    allowHoverOnUTubTitleToCreateDescriptionIfDescEmpty();
     utubDescriptionHeader.text(null);
   }
 

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -598,9 +598,9 @@ function deleteUTubSuccess() {
 
   // Update UTub Deck
   const currentUTubID = getActiveUTubID();
-  const UTubSelector = $(".UTubSelector[utubid=" + currentUTubID + "]");
-  UTubSelector.fadeOut();
-  UTubSelector.remove();
+  const utubSelector = $(".UTubSelector[utubid=" + currentUTubID + "]");
+  utubSelector.fadeOut();
+  utubSelector.remove();
 
   // Reset all panels
   setUIWhenNoUTubSelected();
@@ -610,5 +610,6 @@ function deleteUTubSuccess() {
 
   if (getNumOfUTubs() === 0) {
     resetUTubDeckIfNoUTubs();
+    hideIfShown($("#utubTagBtnCreate"));
   }
 }

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -261,7 +261,7 @@ function updateUTubNameShowInput() {
   }
 }
 
-// Hides input fields for updating an exiting UTub's name
+// Hides input fields for updating an existing UTub's name
 function updateUTubNameHideInput() {
   // Hide update fields
   hideInput("#utubNameUpdate");
@@ -408,6 +408,7 @@ function updateUTubDescriptionShowInput() {
 // Hides input fields for updating an exiting UTub's description
 function updateUTubDescriptionHideInput() {
   // Hide update fields
+  const utubDescriptionUpdate = $("#utubDescriptionUpdate");
   hideInput("#utubDescriptionUpdate");
   hideIfShown($("#utubDescriptionSubmitBtnUpdate"));
 
@@ -463,6 +464,14 @@ function updateUTubDescriptionSetup() {
 // Handle updateion of UTub's description
 function updateUTubDescriptionSuccess(response) {
   const utubDescription = response.utubDescription;
+  const utubDescriptionElem = $("#URLDeckSubheader");
+  const originalUTubDescriptionLength = utubDescriptionElem.text().length;
+  console.log(`Length of utubDescription is ${utubDescription.length}`);
+  if (utubDescription.length === 0) {
+    allowHoverOnUTubTitleToCreateDescriptionIfDescEmpty();
+  } else if (originalUTubDescriptionLength === 0) {
+    removeEventListenersForShowCreateUTubDescIfEmptyDesc();
+  }
 
   // Change displayed and updateable value for utub description
   $("#URLDeckSubheader").text(utubDescription);

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -466,7 +466,6 @@ function updateUTubDescriptionSuccess(response) {
   const utubDescription = response.utubDescription;
   const utubDescriptionElem = $("#URLDeckSubheader");
   const originalUTubDescriptionLength = utubDescriptionElem.text().length;
-  console.log(`Length of utubDescription is ${utubDescription.length}`);
   if (utubDescription.length === 0) {
     allowHoverOnUTubTitleToCreateDescriptionIfDescEmpty();
   } else if (originalUTubDescriptionLength === 0) {

--- a/src/templates/home/TagsDeck/TagsDeck.html
+++ b/src/templates/home/TagsDeck/TagsDeck.html
@@ -5,7 +5,7 @@
 		</div>
 		<div class="col-6 col-lg-6 d-flex flex-row icon-holder">
 			<!-- Add tag button -->
-			<i id="utubTagBtnCreate" class="green-clickable ms-1" tabindex="0" style="display: none">
+			<i id="utubTagBtnCreate" style="display: none !important;" class="green-clickable ms-1" tabindex="0" >
 				<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-plus-square-fill"
 					width="30" height="30" viewBox="0 0 16 16">
 					<path

--- a/src/templates/home/URLDeck/URLDeck.html
+++ b/src/templates/home/URLDeck/URLDeck.html
@@ -1,9 +1,11 @@
 <div id="URLDeck" class="deck h-100 flex-column" style="align-items: stretch;">
-	<!-- Header -->
-	{% include 'home/URLDeck/URLDeckHeader.html' %}
+	<div class="flex-column" id="URLDeckHeaderWrap">
+		<!-- Header -->
+		{% include 'home/URLDeck/URLDeckHeader.html' %}
 
-	<!-- Subheader -->
-	{% include 'home/URLDeck/URLDeckSubheader.html' %}
+		<!-- Subheader -->
+		{% include 'home/URLDeck/URLDeckSubheader.html' %}
+	</div>
 
 	<!-- URLs -->
 	<div class="flex-column content">

--- a/src/utils/strings/ui_testing_strs.py
+++ b/src/utils/strings/ui_testing_strs.py
@@ -31,8 +31,6 @@ class UI_TEST_STRINGS:
     )
     BODY_MODAL_UTUB_DELETE = "This action is irreversible!"
 
-    MAX_CHAR_LIM_UTUB_NAME = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Obcaecati necessitatibus suscipit labore sapiente dignissimos hic voluptatem modi vero ipsam cupiditate?"
-
     MESSAGE_NO_UTUBS = "Create a UTub"
 
     # Members

--- a/src/utubs/routes.py
+++ b/src/utubs/routes.py
@@ -47,7 +47,10 @@ def home():
         return render_template("home.html", utubs_for_this_user=utub_details.json)
 
     elif "UTubID" in request.args and len(request.args) == 1:
-        return get_single_utub(request.args.get("UTubID"))
+        utub_id = request.args.get("UTubID")
+        if not utub_id:
+            abort(404)
+        return get_single_utub(utub_id)
 
     abort(404)
 

--- a/tests/functional/home_ui/test_home_ui.py
+++ b/tests/functional/home_ui/test_home_ui.py
@@ -8,7 +8,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support import expected_conditions as EC
 
 # Internal libraries
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.utils_for_test import (
     assert_login,
@@ -36,7 +36,7 @@ def test_logout(browser: WebDriver, create_test_users, provide_app: Flask):
     session_id = create_user_session_and_provide_session_id(app, user_id)
     login_user_with_cookie_from_session(browser, session_id)
 
-    logout_btn = wait_then_get_element(browser, MPL.BUTTON_LOGOUT)
+    logout_btn = wait_then_get_element(browser, HPL.BUTTON_LOGOUT)
     logout_btn.click()
 
     assert EC.staleness_of(logout_btn)
@@ -66,10 +66,10 @@ def test_refresh_logo(browser: WebDriver, create_test_utubs, provide_app: Flask)
     user_id = 1
     login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
 
-    wait_then_click_element(browser, MPL.U4I_LOGO)
+    wait_then_click_element(browser, HPL.U4I_LOGO)
 
     assert_login(browser)
 
-    active_utubs = wait_then_get_element(browser, MPL.SELECTOR_SELECTED_UTUB)
+    active_utubs = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB)
 
     assert EC.staleness_of(active_utubs)

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -1,4 +1,4 @@
-class MainPageLocators:
+class HomePageLocators:
     """A collector class for main page locators"""
 
     # Navbar

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -39,6 +39,7 @@ class HomePageLocators:
     BUTTON_UTUB_NAME_SUBMIT_UPDATE = "#utubNameSubmitBtnUpdate"
     WRAP_URL_CREATE = "#createURLWrap"
     BUTTON_UTUB_NAME_CANCEL_UPDATE = "#utubNameCancelBtnUpdate"
+    BUTTON_ADD_UTUB_DESC_ON_EMPTY = "#URLDeckSubheaderCreateDescription"
 
     WRAP_UTUB_DESCRIPTION_UPDATE = "#UTubDescriptionSubheaderWrap"
     SUBHEADER_URL_DECK = "#URLDeckSubheader"

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -1,6 +1,8 @@
 class HomePageLocators:
     """A collector class for main page locators"""
 
+    INVALID_FIELD_SUFFIX = "-error"
+
     # Navbar
     BUTTON_LOGOUT = "#logout > .nav-bar-inner-item"
     LOGGED_IN_USERNAME_READ = "#userLoggedIn"

--- a/tests/functional/members_ui/test_create_member_ui.py
+++ b/tests/functional/members_ui/test_create_member_ui.py
@@ -10,7 +10,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 # Internal libraries
 from src.cli.mock_constants import MOCK_UTUB_NAME_BASE, USERNAME_BASE
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.members_ui.utils_for_test_members_ui import (
     create_member_active_utub,
     get_all_member_usernames,
@@ -40,9 +40,9 @@ def test_open_input_create_member(
     user_id = 1
     login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
 
-    wait_then_click_element(browser, MPL.BUTTON_MEMBER_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_MEMBER_CREATE)
 
-    create_member_input = wait_then_get_element(browser, MPL.INPUT_MEMBER_CREATE)
+    create_member_input = wait_then_get_element(browser, HPL.INPUT_MEMBER_CREATE)
 
     assert create_member_input.is_displayed()
 
@@ -61,11 +61,11 @@ def test_cancel_input_create_member_x(
     user_id = 1
     login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
 
-    wait_then_click_element(browser, MPL.BUTTON_MEMBER_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_MEMBER_CREATE)
 
-    wait_then_click_element(browser, MPL.BUTTON_MEMBER_CANCEL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_MEMBER_CANCEL_CREATE)
 
-    create_member_input = wait_until_hidden(browser, MPL.INPUT_MEMBER_CREATE)
+    create_member_input = wait_until_hidden(browser, HPL.INPUT_MEMBER_CREATE)
 
     assert not create_member_input.is_displayed()
 
@@ -84,11 +84,11 @@ def test_cancel_input_create_member_key(
     user_id = 1
     login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
 
-    wait_then_click_element(browser, MPL.BUTTON_MEMBER_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_MEMBER_CREATE)
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    create_member_input = wait_until_hidden(browser, MPL.INPUT_MEMBER_CREATE)
+    create_member_input = wait_until_hidden(browser, HPL.INPUT_MEMBER_CREATE)
 
     assert not create_member_input.is_displayed()
 
@@ -110,7 +110,7 @@ def test_create_member_btn(browser: WebDriver, create_test_utubs, provide_app: F
     create_member_active_utub(browser, new_member_username)
 
     # Submits new member form
-    wait_then_click_element(browser, MPL.BUTTON_MEMBER_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_MEMBER_SUBMIT_CREATE)
 
     # Wait for POST request
     sleep(4)
@@ -168,6 +168,6 @@ def test_create_member_denied(
     member_utub = MOCK_UTUB_NAME_BASE + "2"
     select_utub_by_name(browser, member_utub)
 
-    create_member_btn = wait_until_hidden(browser, MPL.BUTTON_MEMBER_CREATE)
+    create_member_btn = wait_until_hidden(browser, HPL.BUTTON_MEMBER_CREATE)
 
     assert not create_member_btn.is_displayed()

--- a/tests/functional/members_ui/test_delete_member_ui.py
+++ b/tests/functional/members_ui/test_delete_member_ui.py
@@ -9,7 +9,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
-from locators import MainPageLocators as MPL
+from locators import HomePageLocators as HPL
 from src.cli.mock_constants import USERNAME_BASE
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.members_ui.utils_for_test_members_ui import (
@@ -47,11 +47,11 @@ def test_open_delete_member_modal(
 
     delete_member_active_utub(browser, member_name)
 
-    warning_modal = wait_then_get_element(browser, MPL.HOME_MODAL)
+    warning_modal = wait_then_get_element(browser, HPL.HOME_MODAL)
 
     assert warning_modal.is_displayed()
 
-    warning_modal_body = warning_modal.find_element(By.CSS_SELECTOR, MPL.BODY_MODAL)
+    warning_modal_body = warning_modal.find_element(By.CSS_SELECTOR, HPL.BODY_MODAL)
     confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
 
     member_delete_check_text = UTS.BODY_MODAL_MEMBER_DELETE
@@ -81,9 +81,9 @@ def test_dismiss_delete_member_modal_btn(
 
     delete_member_active_utub(browser, member_name)
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_DISMISS)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_DISMISS)
 
-    create_member_input = wait_until_hidden(browser, MPL.HOME_MODAL)
+    create_member_input = wait_until_hidden(browser, HPL.HOME_MODAL)
 
     # Assert warning modal appears with appropriate text
     assert not create_member_input.is_displayed()
@@ -110,11 +110,11 @@ def test_dismiss_delete_member_modal_key(
 
     delete_member_active_utub(browser, member_name)
 
-    home_modal = wait_then_get_element(browser, MPL.HOME_MODAL)
+    home_modal = wait_then_get_element(browser, HPL.HOME_MODAL)
 
     home_modal.send_keys(Keys.ESCAPE)
 
-    create_member_input = wait_until_hidden(browser, MPL.HOME_MODAL)
+    create_member_input = wait_until_hidden(browser, HPL.HOME_MODAL)
 
     # Assert warning modal appears with appropriate text
     assert not create_member_input.is_displayed()
@@ -141,7 +141,7 @@ def test_delete_member_btn(
 
     delete_member_active_utub(browser, member_name)
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for DELETE request
     sleep(4)

--- a/tests/functional/members_ui/test_leave_utub.py
+++ b/tests/functional/members_ui/test_leave_utub.py
@@ -7,7 +7,7 @@ import pytest
 from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
-from locators import MainPageLocators as MPL
+from locators import HomePageLocators as HPL
 from src.cli.mock_constants import MOCK_UTUB_NAME_BASE
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.members_ui.utils_for_test_members_ui import (
@@ -47,13 +47,13 @@ def test_leave_utub(
 
     leave_active_utub(browser)
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
 
     # Assert warning modal appears with appropriate text
     assert confirmation_modal_body_text == UTS.BODY_MODAL_LEAVE_UTUB
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for POST request
     sleep(4)

--- a/tests/functional/members_ui/utils_for_test_members_ui.py
+++ b/tests/functional/members_ui/utils_for_test_members_ui.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     clear_then_send_keys,
     user_is_selected_utub_owner,
@@ -28,7 +28,7 @@ def get_all_member_badges(browser: WebDriver):
         WebDriver handoff to member tests
     """
 
-    return wait_then_get_elements(browser, MPL.BADGES_MEMBERS)
+    return wait_then_get_elements(browser, HPL.BADGES_MEMBERS)
 
 
 def get_all_member_usernames(browser: WebDriver):
@@ -65,10 +65,10 @@ def create_member_active_utub(browser: WebDriver, member_name: str):
     if user_is_selected_utub_owner(browser):
 
         # Click createMember button to show input
-        wait_then_click_element(browser, MPL.BUTTON_MEMBER_CREATE)
+        wait_then_click_element(browser, HPL.BUTTON_MEMBER_CREATE)
 
         # Types new member name
-        create_member_input = wait_then_get_element(browser, MPL.INPUT_MEMBER_CREATE)
+        create_member_input = wait_then_get_element(browser, HPL.INPUT_MEMBER_CREATE)
         clear_then_send_keys(create_member_input, member_name)
 
         return True
@@ -105,7 +105,7 @@ def delete_member_active_utub(browser: WebDriver, member_name: str):
                 actions.pause(3).perform()
 
                 member_delete_button = member_badge_to_delete.find_element(
-                    By.CSS_SELECTOR, MPL.BUTTON_MEMBER_DELETE
+                    By.CSS_SELECTOR, HPL.BUTTON_MEMBER_DELETE
                 )
 
                 actions.move_to_element(member_delete_button).pause(2)
@@ -131,6 +131,6 @@ def leave_active_utub(browser: WebDriver):
     """
 
     try:
-        wait_then_click_element(browser, MPL.BUTTON_UTUB_LEAVE)
+        wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE)
     except NoSuchElementException:
         return False

--- a/tests/functional/tags_ui/test_create_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_tag_ui.py
@@ -13,7 +13,7 @@ from src.cli.mock_constants import (
 )
 from src.utils.strings.tag_strs import FIVE_TAGS_MAX
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.tags_ui.utils_for_test_tag_ui import create_tag
 from tests.functional.utils_for_test import (
     get_selected_url,
@@ -56,9 +56,9 @@ def test_cancel_input_create_tag_btn(browser: WebDriver, create_test_urls):
     selected_url_row = get_selected_url(browser)
     create_tag(browser, selected_url_row)
 
-    wait_then_click_element(browser, MPL.BUTTON_TAG_CANCEL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_TAG_CANCEL_CREATE)
 
-    create_tag_input = wait_until_hidden(browser, MPL.INPUT_MEMBER_CREATE)
+    create_tag_input = wait_until_hidden(browser, HPL.INPUT_MEMBER_CREATE)
 
     assert not create_tag_input.is_displayed()
 
@@ -78,7 +78,7 @@ def test_cancel_input_create_tag_key(browser: WebDriver, create_test_urls):
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    create_tag_input = wait_until_hidden(browser, MPL.INPUT_MEMBER_CREATE)
+    create_tag_input = wait_until_hidden(browser, HPL.INPUT_MEMBER_CREATE)
 
     assert not create_tag_input.is_displayed()
 
@@ -101,7 +101,7 @@ def test_create_tag_btn(browser: WebDriver, create_test_urls):
     create_tag(browser, selected_url_row, tag_text)
 
     # Submit
-    wait_then_click_element(browser, MPL.BUTTON_TAG_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_TAG_SUBMIT_CREATE)
 
     # Wait for POST request
     sleep(4)
@@ -169,7 +169,7 @@ def test_create_existing_tag(browser: WebDriver, create_test_tags):
 
     create_url(browser, UTS.MAX_CHAR_LIM_URL_TITLE, MOCK_URL_STRINGS[0])
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
 
     # Assert new UTub is now active and displayed to user
     assert warning_modal_body.text == "Try shortening your UTub name"
@@ -192,12 +192,12 @@ def test_create_sixth_tag(browser: WebDriver, create_test_tags):
     create_tag(browser, selected_url_row, tag_text)
 
     # Submit
-    wait_then_click_element(browser, MPL.BUTTON_TAG_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_TAG_SUBMIT_CREATE)
 
     # Wait for POST request
     sleep(4)
 
-    tag_error = wait_then_get_element(browser, MPL.ERROR_TAG_CREATE)
+    tag_error = wait_then_get_element(browser, HPL.ERROR_TAG_CREATE)
 
     # Assert error text is displayed
     assert "visible" in tag_error.get_attribute("class")

--- a/tests/functional/tags_ui/test_create_utub_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_utub_tag_ui.py
@@ -9,7 +9,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 # Internal libraries
 from src.models.utubs import Utubs
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.tags_ui.utils_for_test_tag_ui import (
     login_user_select_utub_by_name_open_create_utub_tag,
     verify_create_utub_tag_input_form_is_hidden,
@@ -40,10 +40,10 @@ def test_open_input_create_utub_tag(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    elem = wait_then_click_element(browser, MPL.BUTTON_UTUB_TAG_CREATE)
+    elem = wait_then_click_element(browser, HPL.BUTTON_UTUB_TAG_CREATE)
     assert elem is not None
 
-    utub_tag_input = browser.find_element(By.CSS_SELECTOR, MPL.INPUT_UTUB_TAG_CREATE)
+    utub_tag_input = browser.find_element(By.CSS_SELECTOR, HPL.INPUT_UTUB_TAG_CREATE)
 
     wait_until_visible(browser, utub_tag_input)
 
@@ -51,9 +51,9 @@ def test_open_input_create_utub_tag(
     assert browser.switch_to.active_element == utub_tag_input
 
     visible_elems = (
-        MPL.INPUT_UTUB_TAG_CREATE,
-        MPL.BUTTON_UTUB_TAG_SUBMIT_CREATE,
-        MPL.BUTTON_UTUB_TAG_CANCEL_CREATE,
+        HPL.INPUT_UTUB_TAG_CREATE,
+        HPL.BUTTON_UTUB_TAG_SUBMIT_CREATE,
+        HPL.BUTTON_UTUB_TAG_CANCEL_CREATE,
     )
 
     for visible_elem_selector in visible_elems:
@@ -62,9 +62,9 @@ def test_open_input_create_utub_tag(
         assert visible_elem.is_enabled()
 
     non_visible_elems = (
-        MPL.BUTTON_UTUB_TAG_CREATE,
-        MPL.LIST_TAGS,
-        MPL.SELECTOR_UNSELECT_ALL,
+        HPL.BUTTON_UTUB_TAG_CREATE,
+        HPL.LIST_TAGS,
+        HPL.SELECTOR_UNSELECT_ALL,
     )
     for non_visible_elem_selector in non_visible_elems:
         non_visible_elem = browser.find_element(
@@ -90,8 +90,8 @@ def test_open_input_create_utub_tag_click_cancel_btn(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_TAG_CANCEL_CREATE)
-    wait_until_hidden(browser, MPL.BUTTON_UTUB_TAG_CANCEL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_TAG_CANCEL_CREATE)
+    wait_until_hidden(browser, HPL.BUTTON_UTUB_TAG_CANCEL_CREATE)
     verify_create_utub_tag_input_form_is_hidden(browser)
 
 
@@ -114,7 +114,7 @@ def test_open_input_create_utub_tag_press_esc_key(
 
     # Ensure input is focused
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
-    wait_until_hidden(browser, MPL.BUTTON_UTUB_TAG_CANCEL_CREATE)
+    wait_until_hidden(browser, HPL.BUTTON_UTUB_TAG_CANCEL_CREATE)
     verify_create_utub_tag_input_form_is_hidden(browser)
 
 
@@ -142,8 +142,8 @@ def test_open_input_create_utub_tag_click_submit_btn(
 
     # Ensure input is focused
     browser.switch_to.active_element.send_keys(new_tag)
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_TAG_SUBMIT_CREATE)
-    wait_until_hidden(browser, MPL.BUTTON_UTUB_TAG_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_TAG_SUBMIT_CREATE)
+    wait_until_hidden(browser, HPL.BUTTON_UTUB_TAG_SUBMIT_CREATE)
 
     verify_create_utub_tag_input_form_is_hidden(browser)
     verify_new_utub_tag_created(browser, new_tag, init_num_of_utub_tags)
@@ -174,7 +174,7 @@ def test_open_input_create_utub_tag_press_enter_key(
     # Ensure input is focused
     browser.switch_to.active_element.send_keys(new_tag)
     browser.switch_to.active_element.send_keys(Keys.ENTER)
-    wait_until_hidden(browser, MPL.BUTTON_UTUB_TAG_SUBMIT_CREATE)
+    wait_until_hidden(browser, HPL.BUTTON_UTUB_TAG_SUBMIT_CREATE)
 
     verify_create_utub_tag_input_form_is_hidden(browser)
     verify_new_utub_tag_created(browser, new_tag, init_num_of_utub_tags)

--- a/tests/functional/tags_ui/test_delete_tag_ui.py
+++ b/tests/functional/tags_ui/test_delete_tag_ui.py
@@ -33,7 +33,7 @@ from tests.functional.utils_for_test import (
     wait_then_get_element,
     wait_until_visible_css_selector,
 )
-from locators import MainPageLocators as MPL
+from locators import HomePageLocators as HPL
 
 pytestmark = pytest.mark.tags_ui
 
@@ -114,7 +114,7 @@ def test_no_show_delete_tag_button_on_hover_update_url_title(
 
     open_update_url_title(browser, selected_url_row)
 
-    wait_until_visible_css_selector(browser, MPL.INPUT_URL_TITLE_UPDATE)
+    wait_until_visible_css_selector(browser, HPL.INPUT_URL_TITLE_UPDATE)
 
     url_tags = get_selected_url_tags(selected_url_row)
 
@@ -142,9 +142,9 @@ def test_no_show_delete_tag_button_on_hover_update_url_string(
 
     selected_url_row = get_url_by_title(browser, url_title)
 
-    selected_url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_UPDATE).click()
+    selected_url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_UPDATE).click()
 
-    wait_until_visible_css_selector(browser, MPL.INPUT_URL_STRING_UPDATE)
+    wait_until_visible_css_selector(browser, HPL.INPUT_URL_STRING_UPDATE)
 
     url_tags = get_selected_url_tags(selected_url_row)
     first_tag_badge = url_tags[0]
@@ -152,7 +152,7 @@ def test_no_show_delete_tag_button_on_hover_update_url_string(
     hover_tag_badge(browser, first_tag_badge)
 
     delete_tag_button = first_tag_badge.find_element(
-        By.CSS_SELECTOR, MPL.BUTTON_TAG_DELETE
+        By.CSS_SELECTOR, HPL.BUTTON_TAG_DELETE
     )
 
     assert not delete_tag_button.is_displayed()
@@ -177,9 +177,9 @@ def test_no_show_delete_tag_button_on_hover_add_tag(
 
     selected_url_row = get_url_by_title(browser, url_title)
 
-    selected_url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_TAG_CREATE).click()
+    selected_url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_TAG_CREATE).click()
 
-    wait_until_visible_css_selector(browser, MPL.INPUT_TAG_CREATE)
+    wait_until_visible_css_selector(browser, HPL.INPUT_TAG_CREATE)
 
     url_tags = get_selected_url_tags(selected_url_row)
     first_tag_badge = url_tags[0]
@@ -187,7 +187,7 @@ def test_no_show_delete_tag_button_on_hover_add_tag(
     hover_tag_badge(browser, first_tag_badge)
 
     delete_tag_button = first_tag_badge.find_element(
-        By.CSS_SELECTOR, MPL.BUTTON_TAG_DELETE
+        By.CSS_SELECTOR, HPL.BUTTON_TAG_DELETE
     )
 
     assert not delete_tag_button.is_displayed()
@@ -217,7 +217,7 @@ def test_delete_last_tag(browser, create_test_tags):
 
     delete_url(browser, url_row)
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
 
     url_delete_check_text = UTS.BODY_MODAL_URL_DELETE
@@ -225,7 +225,7 @@ def test_delete_last_tag(browser, create_test_tags):
     # Assert warning modal appears with appropriate text
     assert confirmation_modal_body_text == url_delete_check_text
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for DELETE request
     sleep(4)

--- a/tests/functional/tags_ui/test_filter_tag_ui.py
+++ b/tests/functional/tags_ui/test_filter_tag_ui.py
@@ -9,7 +9,7 @@ from selenium.webdriver.remote.webelement import WebElement
 
 # Internal libraries
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.tags_ui.utils_for_test_tag_ui import (
     delete_each_tag_from_one_url_in_utub,
     delete_tag_from_url_in_utub_random,
@@ -67,7 +67,7 @@ def test_filter_tag(browser: WebDriver, create_test_tags, provide_app: Flask):
     tag_name = get_tag_filter_name_by_id(browser, utub_tag_id)
 
     # Assert appropriate initial state of unselectAll button
-    unselect_all_button = wait_then_get_element(browser, MPL.SELECTOR_UNSELECT_ALL)
+    unselect_all_button = wait_then_get_element(browser, HPL.SELECTOR_UNSELECT_ALL)
     unselect_all_button_class_list = unselect_all_button.get_attribute("class")
     assert "disabled" in unselect_all_button_class_list
     assert "unselected" in unselect_all_button_class_list
@@ -157,7 +157,7 @@ def test_unselect_all_filters(browser: WebDriver, create_test_tags, provide_app:
     # Save the number of visible URLs
     num_visible_url_rows = get_num_url_unfiltered_rows(browser)
     unfiltered_url_rows: list[WebElement] = wait_then_get_elements(
-        browser, MPL.ROWS_URLS
+        browser, HPL.ROWS_URLS
     )
 
     tag_filters = get_utub_tag_filters(browser)
@@ -190,7 +190,7 @@ def test_unselect_all_filters(browser: WebDriver, create_test_tags, provide_app:
     # All URLs with tags are filtered
 
     # Unselect all tag filters
-    unselect_all_button = wait_then_get_element(browser, MPL.SELECTOR_UNSELECT_ALL)
+    unselect_all_button = wait_then_get_element(browser, HPL.SELECTOR_UNSELECT_ALL)
     unselect_all_button.click()
 
     # Assert all URLs are unfiltered and are now visible to user

--- a/tests/functional/tags_ui/utils_for_test_tag_ui.py
+++ b/tests/functional/tags_ui/utils_for_test_tag_ui.py
@@ -14,7 +14,7 @@ from src.models.utub_tags import Utub_Tags
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
 from src.models.utub_url_tags import Utub_Url_Tags
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     clear_then_send_keys,
     login_user_and_select_utub_by_name,
@@ -29,17 +29,17 @@ def create_tag(browser: WebDriver, selected_url_row: WebElement, tag_string: str
     """
 
     # Select createTag button
-    selected_url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_TAG_CREATE).click()
+    selected_url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_TAG_CREATE).click()
 
     create_tag_input = selected_url_row.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_TAG_CREATE
+        By.CSS_SELECTOR, HPL.INPUT_TAG_CREATE
     )
 
     assert create_tag_input.is_displayed()
 
     if tag_string:
         # Input new tag
-        tag_input_field = wait_then_get_element(browser, MPL.INPUT_TAG_CREATE)
+        tag_input_field = wait_then_get_element(browser, HPL.INPUT_TAG_CREATE)
         assert tag_input_field is not None
         clear_then_send_keys(tag_input_field, tag_string)
 
@@ -67,7 +67,7 @@ def show_delete_tag_button_on_hover(browser: WebDriver, tag_badge: WebElement):
     """
     actions = hover_tag_badge(browser, tag_badge)
 
-    delete_tag_button = tag_badge.find_element(By.CSS_SELECTOR, MPL.BUTTON_TAG_DELETE)
+    delete_tag_button = tag_badge.find_element(By.CSS_SELECTOR, HPL.BUTTON_TAG_DELETE)
 
     actions.move_to_element(delete_tag_button).pause(2).perform()
 
@@ -131,14 +131,14 @@ def login_user_select_utub_by_name_open_create_utub_tag(
     app: Flask, browser: WebDriver, user_id: int, utub_name: str
 ):
     login_user_and_select_utub_by_name(app, browser, user_id, utub_name)
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_TAG_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_TAG_CREATE)
 
 
 def verify_create_utub_tag_input_form_is_hidden(browser: WebDriver):
     non_visible_elems = (
-        MPL.INPUT_UTUB_TAG_CREATE,
-        MPL.BUTTON_UTUB_TAG_SUBMIT_CREATE,
-        MPL.BUTTON_UTUB_TAG_CANCEL_CREATE,
+        HPL.INPUT_UTUB_TAG_CREATE,
+        HPL.BUTTON_UTUB_TAG_SUBMIT_CREATE,
+        HPL.BUTTON_UTUB_TAG_CANCEL_CREATE,
     )
     for non_visible_elem_selector in non_visible_elems:
         non_visible_elem = browser.find_element(
@@ -147,9 +147,9 @@ def verify_create_utub_tag_input_form_is_hidden(browser: WebDriver):
         assert not non_visible_elem.is_displayed()
 
     visible_elems = (
-        MPL.BUTTON_UTUB_TAG_CREATE,
-        MPL.LIST_TAGS,
-        MPL.SELECTOR_UNSELECT_ALL,
+        HPL.BUTTON_UTUB_TAG_CREATE,
+        HPL.LIST_TAGS,
+        HPL.SELECTOR_UNSELECT_ALL,
     )
     for visible_elem_selector in visible_elems:
         visible_elem = browser.find_element(By.CSS_SELECTOR, visible_elem_selector)
@@ -162,14 +162,14 @@ def verify_new_utub_tag_created(
 ):
     verify_create_utub_tag_input_form_is_hidden(browser)
 
-    utub_tag_container = wait_then_get_element(browser, MPL.LIST_TAGS)
+    utub_tag_container = wait_then_get_element(browser, HPL.LIST_TAGS)
     assert utub_tag_container is not None
 
-    utub_tags = utub_tag_container.find_elements(By.CSS_SELECTOR, MPL.TAG_FILTERS)
+    utub_tags = utub_tag_container.find_elements(By.CSS_SELECTOR, HPL.TAG_FILTERS)
     assert len(utub_tags) == init_utub_tag_count + 1
 
     # Verify the text of the new tag is found in a tag element
     utub_tag_spans = utub_tag_container.find_elements(
-        By.CSS_SELECTOR, MPL.TAG_FILTERS + " span"
+        By.CSS_SELECTOR, HPL.TAG_FILTERS + " span"
     )
     assert new_tag_str in [tag.text for tag in utub_tag_spans]

--- a/tests/functional/urls_ui/test_access_url_ui.py
+++ b/tests/functional/urls_ui/test_access_url_ui.py
@@ -16,7 +16,7 @@ from selenium.webdriver.common.by import By
 from src.cli.mock_constants import MOCK_URL_STRINGS
 from src.utils.constants import URL_CONSTANTS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.urls_ui.utils_for_test_url_ui import (
     get_selected_utub_id,
     get_utub_url_id_for_added_url_in_utub_as_member,
@@ -61,7 +61,7 @@ def test_access_url_by_access_btn_while_selected(
     init_num_of_tabs = len(browser.window_handles)
     init_tab = browser.current_window_handle
 
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_ACCESS).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_ACCESS).click()
 
     curr_tabs = browser.window_handles
 
@@ -94,7 +94,7 @@ def test_access_url_by_goto_btn_while_selected(
     init_num_of_tabs = len(browser.window_handles)
     init_tab = browser.current_window_handle
 
-    url_row.find_element(By.CSS_SELECTOR, MPL.GO_TO_URL_ICON).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.GO_TO_URL_ICON).click()
 
     curr_tabs = browser.window_handles
 
@@ -125,14 +125,14 @@ def test_access_url_by_goto_btn_while_hover(
     init_num_of_tabs = len(browser.window_handles)
     init_tab = browser.current_window_handle
 
-    url_row = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_row = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_row is not None
     url_row = url_row[0]
 
     actions = ActionChains(browser)
     actions.move_to_element(url_row).perform()
 
-    url_row.find_element(By.CSS_SELECTOR, MPL.GO_TO_URL_ICON).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.GO_TO_URL_ICON).click()
     curr_tabs = browser.window_handles
 
     assert init_num_of_tabs + 1 == len(curr_tabs)
@@ -168,7 +168,7 @@ def test_access_url_by_clicking_url_string(
     init_num_of_tabs = len(browser.window_handles)
     init_tab = browser.current_window_handle
 
-    url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).click()
 
     curr_tabs = browser.window_handles
 
@@ -212,11 +212,11 @@ def test_access_all_urls_at_limit(
     init_num_of_tabs = len(browser.window_handles)
     init_tab = browser.current_window_handle
 
-    browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS).click()
+    browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS).click()
 
     # Ensure modal is not shown to user since URLs below value
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.ACCESS_ALL_URL_MODAL)
+        browser.find_element(By.CSS_SELECTOR, HPL.ACCESS_ALL_URL_MODAL)
 
     curr_tabs = browser.window_handles
 
@@ -262,13 +262,13 @@ def test_access_all_urls_above_limit(
     init_num_of_tabs = len(browser.window_handles)
     init_tab = browser.current_window_handle
 
-    browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS).click()
+    browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS).click()
 
     # Modal will now show since number of URLs is equal to max number of URLs
-    access_modal = wait_then_get_element(browser, MPL.ACCESS_ALL_URL_MODAL)
+    access_modal = wait_then_get_element(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert access_modal is not None
     assert access_modal.is_displayed()
-    access_modal.find_element(By.CSS_SELECTOR, MPL.BUTTON_MODAL_SUBMIT).click()
+    access_modal.find_element(By.CSS_SELECTOR, HPL.BUTTON_MODAL_SUBMIT).click()
 
     curr_tabs = browser.window_handles
 
@@ -284,7 +284,7 @@ def test_access_all_urls_above_limit(
     browser.switch_to.window(init_tab)
 
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.ACCESS_ALL_URL_MODAL)
+        browser.find_element(By.CSS_SELECTOR, HPL.ACCESS_ALL_URL_MODAL)
 
 
 def test_access_all_urls_above_limit_cancel_modal_dismiss_btn(
@@ -318,19 +318,19 @@ def test_access_all_urls_above_limit_cancel_modal_dismiss_btn(
 
     init_num_of_tabs = len(browser.window_handles)
 
-    browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS).click()
+    browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS).click()
 
     # Modal will now show since number of URLs is equal to max number of URLs
-    access_modal = wait_then_get_element(browser, MPL.ACCESS_ALL_URL_MODAL)
+    access_modal = wait_then_get_element(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert access_modal is not None
     assert access_modal.is_displayed()
-    access_modal.find_element(By.CSS_SELECTOR, MPL.BUTTON_MODAL_DISMISS).click()
+    access_modal.find_element(By.CSS_SELECTOR, HPL.BUTTON_MODAL_DISMISS).click()
 
     curr_tabs = browser.window_handles
 
     assert init_num_of_tabs == len(curr_tabs)
 
-    wait_until_hidden(browser, MPL.ACCESS_ALL_URL_MODAL)
+    wait_until_hidden(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert not access_modal.is_displayed()
 
 
@@ -365,19 +365,19 @@ def test_access_all_urls_above_limit_cancel_modal_x_btn(
 
     init_num_of_tabs = len(browser.window_handles)
 
-    browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS).click()
+    browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS).click()
 
     # Modal will now show since number of URLs is equal to max number of URLs
-    access_modal = wait_then_get_element(browser, MPL.ACCESS_ALL_URL_MODAL)
+    access_modal = wait_then_get_element(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert access_modal is not None
     assert access_modal.is_displayed()
-    access_modal.find_element(By.CSS_SELECTOR, MPL.BUTTON_X_CLOSE).click()
+    access_modal.find_element(By.CSS_SELECTOR, HPL.BUTTON_X_CLOSE).click()
 
     curr_tabs = browser.window_handles
 
     assert init_num_of_tabs == len(curr_tabs)
 
-    wait_until_hidden(browser, MPL.ACCESS_ALL_URL_MODAL)
+    wait_until_hidden(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert not access_modal.is_displayed()
 
 
@@ -412,10 +412,10 @@ def test_access_all_urls_above_limit_cancel_modal_by_clicking_outside_modal(
 
     init_num_of_tabs = len(browser.window_handles)
 
-    browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS).click()
+    browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS).click()
 
     # Modal will now show since number of URLs is equal to max number of URLs
-    access_modal = wait_then_get_element(browser, MPL.ACCESS_ALL_URL_MODAL)
+    access_modal = wait_then_get_element(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert access_modal is not None
     assert access_modal.is_displayed()
     dismiss_modal_with_click_out(browser)
@@ -424,7 +424,7 @@ def test_access_all_urls_above_limit_cancel_modal_by_clicking_outside_modal(
 
     assert init_num_of_tabs == len(curr_tabs)
 
-    wait_until_hidden(browser, MPL.ACCESS_ALL_URL_MODAL)
+    wait_until_hidden(browser, HPL.ACCESS_ALL_URL_MODAL)
     assert not access_modal.is_displayed()
 
 
@@ -451,7 +451,7 @@ def test_access_to_urls_as_utub_owner(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_rows is not None
 
     for url_row in url_rows:
@@ -491,7 +491,7 @@ def test_access_to_non_added_urls_as_utub_member(
         app, utub_id, user_id
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_rows is not None
 
     for url_row in url_rows:
@@ -533,7 +533,7 @@ def test_access_to_urls_as_url_creator_and_utub_member(
         app, utub_id, user_id
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_rows is not None
 
     for url_row in url_rows:

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -14,7 +14,7 @@ from src.cli.mock_constants import (
     MOCK_URL_STRINGS,
 )
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     assert_not_visible_css_selector,
     clear_then_send_keys,
@@ -47,18 +47,18 @@ def test_create_url_open_input_no_urls_corner_btn(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
-    assert_not_visible_css_selector(browser, MPL.BUTTON_DECK_URL_CREATE)
+    assert_not_visible_css_selector(browser, HPL.BUTTON_DECK_URL_CREATE)
 
     url_title_create_elemnent = browser.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_TITLE_CREATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_TITLE_CREATE
     )
 
     assert browser.switch_to.active_element == url_title_create_elemnent
@@ -81,18 +81,18 @@ def test_create_url_open_input_no_urls_deck_btn(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    wait_then_click_element(browser, MPL.BUTTON_DECK_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_DECK_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
-    assert_not_visible_css_selector(browser, MPL.BUTTON_DECK_URL_CREATE)
+    assert_not_visible_css_selector(browser, HPL.BUTTON_DECK_URL_CREATE)
 
     url_title_create_elemnent = browser.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_TITLE_CREATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_TITLE_CREATE
     )
 
     assert browser.switch_to.active_element == url_title_create_elemnent
@@ -118,16 +118,16 @@ def test_create_url_open_input_with_added_urls(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
     url_title_create_elemnent = browser.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_TITLE_CREATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_TITLE_CREATE
     )
 
     assert browser.switch_to.active_element == url_title_create_elemnent
@@ -150,17 +150,17 @@ def test_create_url_cancel_input_click_button(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
-    wait_then_click_element(browser, MPL.BUTTON_URL_CANCEL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_URL_CANCEL_CREATE)
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
 
@@ -181,17 +181,17 @@ def test_create_url_cancel_input_escape(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
 
@@ -214,37 +214,37 @@ def test_create_url_submit_btn(
     url_title = MOCK_URL_TITLES[0]
     url_string = MOCK_URL_STRINGS[0]
 
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
     # Input new URL Title
-    url_title_input_field = wait_then_get_element(browser, MPL.INPUT_URL_TITLE_CREATE)
+    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
     clear_then_send_keys(url_title_input_field, url_title)
 
     # Input new URL String
-    url_string_input_field = wait_then_get_element(browser, MPL.INPUT_URL_STRING_CREATE)
+    url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
     clear_then_send_keys(url_string_input_field, url_string)
 
-    submit_btn = browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_SUBMIT_CREATE)
+    submit_btn = browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_SUBMIT_CREATE)
     submit_btn.click()
 
     # Wait for HTTP request to complete
     sleep(4)
 
     # Extract URL title and string from new row in URL deck
-    url_row = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_row = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_row is not None
     url_row = url_row[0]
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    url_row_title = url_row.find_elements(By.CSS_SELECTOR, MPL.URL_TITLE_READ)[
+    url_row_title = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_TITLE_READ)[
         0
     ].get_attribute("innerText")
-    url_row_string = url_row.find_elements(By.CSS_SELECTOR, MPL.URL_STRING_READ)[
+    url_row_string = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_STRING_READ)[
         0
     ].get_attribute("innerText")
 
@@ -252,10 +252,10 @@ def test_create_url_submit_btn(
     assert url_string == url_row_string
 
     assert browser.find_element(
-        By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS
+        By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS
     ).is_displayed()
 
-    assert not browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE).is_displayed()
+    assert not browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE).is_displayed()
 
 
 def test_create_url_using_enter_key(
@@ -277,17 +277,17 @@ def test_create_url_using_enter_key(
     url_title = MOCK_URL_TITLES[0]
     url_string = MOCK_URL_STRINGS[0]
 
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    url_creation_row = wait_then_get_element(browser, MPL.WRAP_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
     assert url_creation_row.is_displayed()
 
     # Input new URL Title
-    url_title_input_field = wait_then_get_element(browser, MPL.INPUT_URL_TITLE_CREATE)
+    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
     clear_then_send_keys(url_title_input_field, url_title)
 
     # Input new URL String
-    url_string_input_field = wait_then_get_element(browser, MPL.INPUT_URL_STRING_CREATE)
+    url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
     clear_then_send_keys(url_string_input_field, url_string)
 
     browser.switch_to.active_element.send_keys(Keys.ENTER)
@@ -296,17 +296,17 @@ def test_create_url_using_enter_key(
     sleep(4)
 
     # Extract URL title and string from new row in URL deck
-    url_row = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_row = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_row is not None
     url_row = url_row[0]
 
-    url_creation_row = browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE)
+    url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    url_row_title = url_row.find_elements(By.CSS_SELECTOR, MPL.URL_TITLE_READ)[
+    url_row_title = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_TITLE_READ)[
         0
     ].get_attribute("innerText")
-    url_row_string = url_row.find_elements(By.CSS_SELECTOR, MPL.URL_STRING_READ)[
+    url_row_string = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_STRING_READ)[
         0
     ].get_attribute("innerText")
 
@@ -314,10 +314,10 @@ def test_create_url_using_enter_key(
     assert url_string == url_row_string
 
     assert browser.find_element(
-        By.CSS_SELECTOR, MPL.BUTTON_ACCESS_ALL_URLS
+        By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS
     ).is_displayed()
 
-    assert not browser.find_element(By.CSS_SELECTOR, MPL.WRAP_URL_CREATE).is_displayed()
+    assert not browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE).is_displayed()
 
 
 @pytest.mark.skip(
@@ -342,7 +342,7 @@ def test_create_url_title_length_exceeded(
 
     create_url(browser, UTS.MAX_CHAR_LIM_URL_TITLE, MOCK_URL_STRINGS[0])
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
 
     # Assert new UTub is now active and displayed to user
     assert warning_modal_body.text == "Try shortening your UTub name"
@@ -365,9 +365,9 @@ def test_select_url(browser: WebDriver, create_test_urls, provide_app: Flask):
     url_row = get_selected_url(browser)
 
     assert "true" == url_row.get_attribute("urlselected")
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.URL_TAGS_READ).is_displayed
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TAGS_READ).is_displayed
     assert url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_BUTTONS_OPTIONS_READ
+        By.CSS_SELECTOR, HPL.URL_BUTTONS_OPTIONS_READ
     ).is_displayed
-    url_string = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
-    assert url_string.get_attribute(MPL.URL_STRING_IN_DATA) in MOCK_URL_STRINGS
+    url_string = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
+    assert url_string.get_attribute(HPL.URL_STRING_IN_DATA) in MOCK_URL_STRINGS

--- a/tests/functional/urls_ui/test_delete_url_ui.py
+++ b/tests/functional/urls_ui/test_delete_url_ui.py
@@ -25,7 +25,7 @@ from tests.functional.utils_for_test import (
     wait_then_get_element,
     wait_until_hidden,
 )
-from locators import MainPageLocators as MPL
+from locators import HomePageLocators as HPL
 
 pytestmark = pytest.mark.urls_ui
 
@@ -51,7 +51,7 @@ def test_delete_url_submit(browser: WebDriver, create_test_urls, provide_app: Fl
         )
     )
 
-    css_selector = f'{MPL.URL_STRING_READ}[data-url="{UTS.TEST_URL_STRING_CREATE}"]'
+    css_selector = f'{HPL.URL_STRING_READ}[data-url="{UTS.TEST_URL_STRING_CREATE}"]'
     assert browser.find_element(By.CSS_SELECTOR, css_selector)
 
     init_num_url_rows = get_num_url_rows(browser)
@@ -61,8 +61,8 @@ def test_delete_url_submit(browser: WebDriver, create_test_urls, provide_app: Fl
     # Assert warning modal appears with appropriate text
     assert confirmation_modal_body_text == UTS.BODY_MODAL_URL_DELETE
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
-    wait_until_hidden(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for animation to complete
     assert wait_for_element_to_be_removed(browser, url_elem_to_delete)
@@ -103,8 +103,8 @@ def test_delete_url_cancel_click_cancel_btn(
     # Assert warning modal appears with appropriate text
     assert confirmation_modal_body_text == UTS.BODY_MODAL_URL_DELETE
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_DISMISS)
-    wait_until_hidden(browser, MPL.BUTTON_MODAL_DISMISS)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_DISMISS)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_DISMISS)
 
     # Assert URL no longer exists in UTub
     assert verify_elem_with_url_string_exists(browser, UTS.TEST_URL_STRING_CREATE)
@@ -142,8 +142,8 @@ def test_delete_url_cancel_click_x_btn(
     # Assert warning modal appears with appropriate text
     assert confirmation_modal_body_text == UTS.BODY_MODAL_URL_DELETE
 
-    wait_then_click_element(browser, MPL.BUTTON_X_CLOSE)
-    wait_until_hidden(browser, MPL.BUTTON_X_CLOSE)
+    wait_then_click_element(browser, HPL.BUTTON_X_CLOSE)
+    wait_until_hidden(browser, HPL.BUTTON_X_CLOSE)
 
     # Assert URL no longer exists in UTub
     assert verify_elem_with_url_string_exists(browser, UTS.TEST_URL_STRING_CREATE)
@@ -182,7 +182,7 @@ def test_delete_url_cancel_press_esc_key(
     assert confirmation_modal_body_text == UTS.BODY_MODAL_URL_DELETE
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
-    wait_until_hidden(browser, MPL.BUTTON_X_CLOSE)
+    wait_until_hidden(browser, HPL.BUTTON_X_CLOSE)
 
     # Assert URL no longer exists in UTub
     assert verify_elem_with_url_string_exists(browser, UTS.TEST_URL_STRING_CREATE)
@@ -221,7 +221,7 @@ def test_delete_url_cancel_click_outside_modal(
     assert confirmation_modal_body_text == UTS.BODY_MODAL_URL_DELETE
 
     dismiss_modal_with_click_out(browser)
-    wait_until_hidden(browser, MPL.BUTTON_X_CLOSE)
+    wait_until_hidden(browser, HPL.BUTTON_X_CLOSE)
 
     # Assert URL still exists in UTub
     assert verify_elem_with_url_string_exists(browser, UTS.TEST_URL_STRING_CREATE)
@@ -264,14 +264,14 @@ def test_delete_last_url(
         url_string=random_url_to_add_as_last,
     )
 
-    css_selector = f'{MPL.URL_STRING_READ}[data-url="{random_url_to_add_as_last}"]'
+    css_selector = f'{HPL.URL_STRING_READ}[data-url="{random_url_to_add_as_last}"]'
     assert browser.find_element(By.CSS_SELECTOR, css_selector)
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
-    wait_until_hidden(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT)
     assert wait_for_element_to_be_removed(browser, url_elem_to_delete)
     with pytest.raises(NoSuchElementException):
         browser.find_element(By.CSS_SELECTOR, css_selector)
 
-    no_url_subheader = wait_then_get_element(browser, MPL.SUBHEADER_NO_URLS)
+    no_url_subheader = wait_then_get_element(browser, HPL.SUBHEADER_NO_URLS)
     assert no_url_subheader is not None

--- a/tests/functional/urls_ui/test_select_url_ui.py
+++ b/tests/functional/urls_ui/test_select_url_ui.py
@@ -6,7 +6,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.urls_ui.utils_for_test_url_ui import (
     get_selected_utub_id,
     get_utub_url_id_for_added_url_in_utub_as_member,
@@ -48,7 +48,7 @@ def test_select_urls_as_utub_owner(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_rows is not None
 
     for url_row in url_rows:
@@ -88,7 +88,7 @@ def test_select_non_added_urls_as_utub_member(
         app, utub_id, user_id
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_rows is not None
 
     for url_row in url_rows:
@@ -130,7 +130,7 @@ def test_select_urls_as_url_creator_and_utub_member(
         app, utub_id, user_id
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     assert url_rows is not None
 
     for url_row in url_rows:
@@ -160,7 +160,7 @@ def test_select_urls_using_down_key(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_2
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if not url_rows:
         assert False
     num_of_urls = len(url_rows)
@@ -193,7 +193,7 @@ def test_select_urls_using_up_key(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_2
     )
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if not url_rows:
         assert False
     num_of_urls = len(url_rows)

--- a/tests/functional/urls_ui/test_update_url_ui.py
+++ b/tests/functional/urls_ui/test_update_url_ui.py
@@ -18,7 +18,7 @@ from src.cli.mock_constants import (
     MOCK_URL_STRINGS,
 )
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     add_mock_urls,
     get_selected_url,
@@ -71,12 +71,12 @@ def test_update_url_string_submit_btn(
 
     update_url_string(url_row, random_url_to_change_to)
     verify_update_url_state_is_shown(url_row)
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_SUBMIT_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_SUBMIT_UPDATE).click()
 
-    wait_until_hidden(browser, MPL.UPDATE_URL_STRING_WRAP)
+    wait_until_hidden(browser, HPL.UPDATE_URL_STRING_WRAP)
     verify_update_url_state_is_hidden(url_row)
 
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     # Extract URL string from updated URL row
     url_row_string_display = url_row_string_elem.get_attribute("innerText")
@@ -92,10 +92,10 @@ def test_update_url_string_submit_btn(
     assert host_changed_to in actual_host or actual_host in host_changed_to
 
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
+        browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
 
     assert not browser.find_element(
-        By.CSS_SELECTOR, MPL.UPDATE_URL_STRING_WRAP
+        By.CSS_SELECTOR, HPL.UPDATE_URL_STRING_WRAP
     ).is_displayed()
 
 
@@ -134,10 +134,10 @@ def test_update_url_string_press_enter_key(
     verify_update_url_state_is_shown(url_row)
     browser.switch_to.active_element.send_keys(Keys.ENTER)
 
-    wait_until_hidden(browser, MPL.UPDATE_URL_STRING_WRAP)
+    wait_until_hidden(browser, HPL.UPDATE_URL_STRING_WRAP)
     verify_update_url_state_is_hidden(url_row)
 
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     # Extract URL string from updated URL row
     url_row_string_display = url_row_string_elem.get_attribute("innerText")
@@ -153,10 +153,10 @@ def test_update_url_string_press_enter_key(
     assert host_changed_to in actual_host or actual_host in host_changed_to
 
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
+        browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
 
     assert not browser.find_element(
-        By.CSS_SELECTOR, MPL.UPDATE_URL_STRING_WRAP
+        By.CSS_SELECTOR, HPL.UPDATE_URL_STRING_WRAP
     ).is_displayed()
 
 
@@ -190,23 +190,23 @@ def test_update_url_string_big_cancel_btn(
     )
 
     url_row = get_selected_url(browser)
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     init_url_row_data = url_row_string_elem.get_attribute("data-url")
     init_url_row_string_display = url_row_string_elem.get_attribute("innerText")
 
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_UPDATE).click()
     verify_update_url_state_is_shown(url_row)
 
     cancel_update_btn = wait_then_get_element(
-        browser, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE
+        browser, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE
     )
     assert cancel_update_btn is not None
     cancel_update_btn.click()
-    wait_until_hidden(browser, MPL.UPDATE_URL_STRING_WRAP)
+    wait_until_hidden(browser, HPL.UPDATE_URL_STRING_WRAP)
     verify_update_url_state_is_hidden(url_row)
 
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     # Extract URL string from updated URL row
     url_row_string_display = url_row_string_elem.get_attribute("innerText")
@@ -216,10 +216,10 @@ def test_update_url_string_big_cancel_btn(
     assert url_row_string_display == init_url_row_string_display
 
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
+        browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
 
     assert not browser.find_element(
-        By.CSS_SELECTOR, MPL.UPDATE_URL_STRING_WRAP
+        By.CSS_SELECTOR, HPL.UPDATE_URL_STRING_WRAP
     ).is_displayed()
 
 
@@ -253,22 +253,22 @@ def test_update_url_string_cancel_btn(
     )
 
     url_row = get_selected_url(browser)
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     init_url_row_data = url_row_string_elem.get_attribute("data-url")
     init_url_row_string_display = url_row_string_elem.get_attribute("innerText")
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_UPDATE).click()
     verify_update_url_state_is_shown(url_row)
 
     cancel_update_btn = wait_then_get_element(
-        browser, MPL.BUTTON_URL_STRING_CANCEL_UPDATE
+        browser, HPL.BUTTON_URL_STRING_CANCEL_UPDATE
     )
     assert cancel_update_btn is not None
     cancel_update_btn.click()
-    wait_until_hidden(browser, MPL.UPDATE_URL_STRING_WRAP)
+    wait_until_hidden(browser, HPL.UPDATE_URL_STRING_WRAP)
     verify_update_url_state_is_hidden(url_row)
 
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     # Extract URL string from updated URL row
     url_row_string_display = url_row_string_elem.get_attribute("innerText")
@@ -278,10 +278,10 @@ def test_update_url_string_cancel_btn(
     assert url_row_string_display == init_url_row_string_display
 
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
+        browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
 
     assert not browser.find_element(
-        By.CSS_SELECTOR, MPL.UPDATE_URL_STRING_WRAP
+        By.CSS_SELECTOR, HPL.UPDATE_URL_STRING_WRAP
     ).is_displayed()
 
 
@@ -315,20 +315,20 @@ def test_update_url_string_escape_key(
     )
 
     url_row = get_selected_url(browser)
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     init_url_row_data = url_row_string_elem.get_attribute("data-url")
     init_url_row_string_display = url_row_string_elem.get_attribute("innerText")
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_UPDATE).click()
     verify_update_url_state_is_shown(url_row)
 
     # Sleep required to allow the element to come into focus
     sleep(2)
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
-    wait_until_hidden(browser, MPL.UPDATE_URL_STRING_WRAP)
+    wait_until_hidden(browser, HPL.UPDATE_URL_STRING_WRAP)
     verify_update_url_state_is_hidden(url_row)
 
-    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ)
+    url_row_string_elem = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
 
     # Extract URL string from updated URL row
     url_row_string_display = url_row_string_elem.get_attribute("innerText")
@@ -338,10 +338,10 @@ def test_update_url_string_escape_key(
     assert url_row_string_display == init_url_row_string_display
 
     with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
+        browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
 
     assert not browser.find_element(
-        By.CSS_SELECTOR, MPL.UPDATE_URL_STRING_WRAP
+        By.CSS_SELECTOR, HPL.UPDATE_URL_STRING_WRAP
     ).is_displayed()
 
 
@@ -371,18 +371,18 @@ def test_update_url_title_submit_btn(
     url_row = get_selected_url(browser)
     url_title = UTS.TEST_URL_TITLE_UPDATE
     update_url_title(browser, url_row, url_title)
-    assert not url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    assert not url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     # Submit
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_TITLE_SUBMIT_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_TITLE_SUBMIT_UPDATE).click()
 
     # Wait for POST request
-    wait_until_hidden(browser, MPL.BUTTON_URL_TITLE_SUBMIT_UPDATE)
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    wait_until_hidden(browser, HPL.BUTTON_URL_TITLE_SUBMIT_UPDATE)
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     # Extract URL string from updated URL row
     url_row_title = url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
     assert url_title == url_row_title
@@ -414,18 +414,18 @@ def test_update_url_title_submit_enter_key(
     url_row = get_selected_url(browser)
     url_title = UTS.TEST_URL_TITLE_UPDATE
     update_url_title(browser, url_row, url_title)
-    assert not url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    assert not url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     # Submit
     browser.switch_to.active_element.send_keys(Keys.ENTER)
 
     # Wait for update to hide
-    wait_until_hidden(browser, MPL.BUTTON_URL_TITLE_SUBMIT_UPDATE)
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    wait_until_hidden(browser, HPL.BUTTON_URL_TITLE_SUBMIT_UPDATE)
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     # Extract URL string from updated URL row
     url_row_title = url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
     assert url_title == url_row_title
@@ -458,21 +458,21 @@ def test_update_url_title_cancel_click_btn(
 
     # Extract URL string from updated URL row
     init_url_row_title = url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
     url_title = UTS.TEST_URL_TITLE_UPDATE
     update_url_title(browser, url_row, url_title)
-    assert not url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    assert not url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_TITLE_CANCEL_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_TITLE_CANCEL_UPDATE).click()
 
-    wait_until_hidden(browser, MPL.BUTTON_URL_TITLE_CANCEL_UPDATE)
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    wait_until_hidden(browser, HPL.BUTTON_URL_TITLE_CANCEL_UPDATE)
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     # Extract URL string from updated URL row
     url_row_title = url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
     assert init_url_row_title == url_row_title
@@ -505,21 +505,21 @@ def test_update_url_title_cancel_press_escape(
 
     # Extract URL string from updated URL row
     init_url_row_title = url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
     url_title = UTS.TEST_URL_TITLE_UPDATE
     update_url_title(browser, url_row, url_title)
-    assert not url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    assert not url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    wait_until_hidden(browser, MPL.BUTTON_URL_TITLE_CANCEL_UPDATE)
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ).is_displayed()
+    wait_until_hidden(browser, HPL.BUTTON_URL_TITLE_CANCEL_UPDATE)
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).is_displayed()
 
     # Extract URL string from updated URL row
     url_row_title = url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
     assert init_url_row_title == url_row_title
@@ -539,7 +539,7 @@ def test_update_url_title_length_exceeded(browser: WebDriver, create_test_urls):
 
     update_url_title(browser, UTS.MAX_CHAR_LIM_URL_TITLE, MOCK_URL_STRINGS[0])
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     assert warning_modal_body is not None
 
     # Assert new UTub is now active and displayed to user
@@ -560,7 +560,7 @@ def test_update_url_string_length_exceeded(browser: WebDriver, create_test_urls)
 
     update_url_string(browser, MOCK_URL_STRINGS[0], UTS.MAX_CHAR_LIM_URL_STRING)
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     assert warning_modal_body is not None
 
     # Assert new UTub is now active and displayed to user

--- a/tests/functional/urls_ui/utils_for_test_url_ui.py
+++ b/tests/functional/urls_ui/utils_for_test_url_ui.py
@@ -14,7 +14,7 @@ from selenium.webdriver.remote.webelement import WebElement
 
 # Internal libraries
 from src.models.utub_urls import Utub_Urls
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import ModalLocators as ML
 from tests.functional.utils_for_test import (
     clear_then_send_keys,
@@ -38,20 +38,20 @@ def create_url(browser: WebDriver, url_title: str, url_string: str):
     """
 
     # Select createURL button
-    wait_then_click_element(browser, MPL.BUTTON_CORNER_URL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     # Input new URL Title
-    url_title_input_field = wait_then_get_element(browser, MPL.INPUT_URL_TITLE_CREATE)
+    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
     assert url_title_input_field is not None
     clear_then_send_keys(url_title_input_field, url_title)
 
     # Input new URL String
-    url_string_input_field = wait_then_get_element(browser, MPL.INPUT_URL_STRING_CREATE)
+    url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
     assert url_string_input_field is not None
     clear_then_send_keys(url_string_input_field, url_string)
 
     # Submit
-    wait_then_click_element(browser, MPL.BUTTON_URL_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE)
 
 
 def update_url_string(url_row: WebElement, url_string: str):
@@ -67,11 +67,11 @@ def update_url_string(url_row: WebElement, url_string: str):
     """
 
     # Select editURL button
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_UPDATE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_UPDATE).click()
 
     # Input new URL string
     url_string_input_field = url_row.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_STRING_UPDATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_STRING_UPDATE
     )
     clear_then_send_keys(url_string_input_field, url_string)
 
@@ -89,7 +89,7 @@ def open_update_url_title(browser: WebDriver, selected_url_row: WebElement):
     """
 
     # Select editURL button
-    url_title_text = selected_url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ)
+    url_title_text = selected_url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ)
 
     actions = ActionChains(browser)
 
@@ -100,7 +100,7 @@ def open_update_url_title(browser: WebDriver, selected_url_row: WebElement):
     actions.pause(3).perform()
 
     update_url_title_button = selected_url_row.find_element(
-        By.CSS_SELECTOR, MPL.BUTTON_URL_TITLE_UPDATE
+        By.CSS_SELECTOR, HPL.BUTTON_URL_TITLE_UPDATE
     )
 
     actions.move_to_element(update_url_title_button).pause(2)
@@ -125,7 +125,7 @@ def update_url_title(browser: WebDriver, selected_url_row: WebElement, url_title
 
     # Input new URL Title
     url_title_input_field = selected_url_row.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_TITLE_UPDATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_TITLE_UPDATE
     )
     clear_then_send_keys(url_title_input_field, url_title)
 
@@ -139,7 +139,7 @@ def delete_url(url_row: WebElement):
     """
 
     # Select deleteURL button
-    url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_DELETE).click()
+    url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_DELETE).click()
 
 
 def login_select_utub_select_url_click_delete_get_modal_url(
@@ -154,11 +154,11 @@ def login_select_utub_select_url_click_delete_get_modal_url(
         app, browser, user_id, utub_name, url_string
     )
     url_row = get_selected_url(browser)
-    wait_until_visible_css_selector(browser, MPL.BUTTON_URL_DELETE, timeout)
+    wait_until_visible_css_selector(browser, HPL.BUTTON_URL_DELETE, timeout)
     time.sleep(0.5)
     delete_url(url_row)
     wait_until_visible_css_selector(browser, ML.ELEMENT_MODAL, timeout)
-    modal = wait_then_get_element(browser, MPL.BODY_MODAL)
+    modal = wait_then_get_element(browser, HPL.BODY_MODAL)
     assert modal is not None
 
     return modal, url_row
@@ -178,7 +178,7 @@ def delete_url_confirmed(browser: WebDriver, url_row: WebElement):
     # Select deleteURL button
     delete_url(url_row)
     # Confirm warning modal
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
     # Wait for DELETE request
     sleep(4)
 
@@ -191,7 +191,7 @@ def delete_all_urls(browser: WebDriver):
         WebDriver open to a selected UTub
     """
 
-    url_rows = browser.find_elements(By.CSS_SELECTOR, MPL.ROWS_URLS)
+    url_rows = browser.find_elements(By.CSS_SELECTOR, HPL.ROWS_URLS)
 
     for url_row in url_rows:
         url_row.click()
@@ -209,10 +209,10 @@ def verify_select_url_as_utub_owner_or_url_creator(
     """
 
     visible_elements = (
-        MPL.BUTTON_URL_ACCESS,
-        MPL.BUTTON_TAG_CREATE,
-        MPL.BUTTON_URL_STRING_UPDATE,
-        MPL.BUTTON_URL_DELETE,
+        HPL.BUTTON_URL_ACCESS,
+        HPL.BUTTON_TAG_CREATE,
+        HPL.BUTTON_URL_STRING_UPDATE,
+        HPL.BUTTON_URL_DELETE,
     )
 
     for visible_elem_selector in visible_elements:
@@ -221,7 +221,7 @@ def verify_select_url_as_utub_owner_or_url_creator(
         assert visible_elem.is_displayed()
         assert visible_elem.is_enabled()
 
-    url_title = url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ)
+    url_title = url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ)
     assert url_title.is_displayed()
     assert url_title.is_enabled()
 
@@ -232,7 +232,7 @@ def verify_select_url_as_utub_owner_or_url_creator(
     actions.scroll_to_element(url_title).move_to_element(url_title).perform()
 
     edit_url_title_icon = url_row.find_element(
-        By.CSS_SELECTOR, MPL.BUTTON_URL_TITLE_UPDATE
+        By.CSS_SELECTOR, HPL.BUTTON_URL_TITLE_UPDATE
     )
     wait_until_visible(browser, edit_url_title_icon, 5)
 
@@ -251,12 +251,12 @@ def verify_select_url_as_non_utub_owner_and_non_url_adder(
     """
 
     visible_elements = (
-        MPL.BUTTON_URL_ACCESS,
-        MPL.BUTTON_TAG_CREATE,
+        HPL.BUTTON_URL_ACCESS,
+        HPL.BUTTON_TAG_CREATE,
     )
     non_visible_elements = (
-        MPL.BUTTON_URL_STRING_UPDATE,
-        MPL.BUTTON_URL_DELETE,
+        HPL.BUTTON_URL_STRING_UPDATE,
+        HPL.BUTTON_URL_DELETE,
     )
 
     for visible_elem_selector in visible_elements:
@@ -269,7 +269,7 @@ def verify_select_url_as_non_utub_owner_and_non_url_adder(
         with pytest.raises(NoSuchElementException):
             url_row.find_element(By.CSS_SELECTOR, non_visible_elem_selector)
 
-    url_title = url_row.find_element(By.CSS_SELECTOR, MPL.URL_TITLE_READ)
+    url_title = url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ)
     assert url_title.is_displayed()
     assert url_title.is_enabled()
 
@@ -280,11 +280,11 @@ def verify_select_url_as_non_utub_owner_and_non_url_adder(
     actions.scroll_to_element(url_title).move_to_element(url_title).perform()
 
     with pytest.raises(NoSuchElementException):
-        url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_TITLE_UPDATE)
+        url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_TITLE_UPDATE)
 
 
 def get_selected_utub_id(browser: WebDriver) -> int:
-    utub = browser.find_element(By.CSS_SELECTOR, MPL.SELECTOR_SELECTED_UTUB)
+    utub = browser.find_element(By.CSS_SELECTOR, HPL.SELECTOR_SELECTED_UTUB)
     utub_id = utub.get_attribute("utubid")
     assert utub_id is not None
     return int(utub_id)
@@ -305,7 +305,7 @@ def verify_keyed_url_is_selected(browser: WebDriver, url_row: WebElement):
     Verifies whether a URL that is switched to via key pressed is open by checking
     if the Access URL button is visible
     """
-    access_url_btn = url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_ACCESS)
+    access_url_btn = url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_ACCESS)
     access_url_btn = wait_until_visible(browser, access_url_btn)
     assert access_url_btn.is_enabled()
     assert access_url_btn.is_displayed()

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -25,7 +25,7 @@ from src.models.users import Users
 from src.utils.strings.html_identifiers import IDENTIFIERS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import SplashPageLocators as SPL
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import ModalLocators as MP
 
 
@@ -385,12 +385,12 @@ def assert_login(browser: WebDriver):
 
     # Confirm user logged in
     # Logout button visible
-    btn_logout = wait_then_get_element(browser, MPL.BUTTON_LOGOUT)
+    btn_logout = wait_then_get_element(browser, HPL.BUTTON_LOGOUT)
     assert btn_logout is not None
     assert btn_logout.text == "Logout"
 
     # Correct user logged in
-    user_logged_in = wait_then_get_element(browser, MPL.LOGGED_IN_USERNAME_READ)
+    user_logged_in = wait_then_get_element(browser, HPL.LOGGED_IN_USERNAME_READ)
     assert user_logged_in is not None
     userLoggedInText = "Logged in as " + UTS.TEST_USERNAME_1
 
@@ -411,7 +411,7 @@ def select_utub_by_name(browser: WebDriver, utub_name: str) -> bool:
     """
 
     try:
-        utub_list = wait_then_get_element(browser, MPL.LIST_UTUB)
+        utub_list = wait_then_get_element(browser, HPL.LIST_UTUB)
         assert utub_list is not None
 
         utub_selectors = utub_list.find_elements(By.CSS_SELECTOR, "*")
@@ -466,7 +466,7 @@ def get_num_utubs(browser: WebDriver) -> int:
     Returns:
         Integer length of UTub selectors available to user
     """
-    utub_selectors = wait_then_get_elements(browser, MPL.SELECTORS_UTUB)
+    utub_selectors = wait_then_get_elements(browser, HPL.SELECTORS_UTUB)
     if utub_selectors:
         return len(utub_selectors)
     return 0
@@ -482,7 +482,7 @@ def get_all_utub_selector_names(browser: WebDriver) -> list[str]:
     Returns:
         Array of strings corresponding to UTub selectors available to user
     """
-    utub_selectors = wait_then_get_elements(browser, MPL.SELECTORS_UTUB)
+    utub_selectors = wait_then_get_elements(browser, HPL.SELECTORS_UTUB)
 
     utub_names = []
     if utub_selectors:
@@ -503,7 +503,7 @@ def get_selected_utub_name(browser: WebDriver) -> str:
     """
 
     selected_utub_selector = browser.find_element(
-        By.CSS_SELECTOR, MPL.SELECTOR_SELECTED_UTUB
+        By.CSS_SELECTOR, HPL.SELECTOR_SELECTED_UTUB
     )
 
     utub_name = selected_utub_selector.get_attribute("innerText")
@@ -522,7 +522,7 @@ def get_selected_utub_decsription(browser: WebDriver):
     Returns:
         String containing the selected UTub description.
     """
-    return browser.find_element(By.CSS_SELECTOR, MPL.SUBHEADER_URL_DECK).text
+    return browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK).text
 
 
 # Members Deck
@@ -537,7 +537,7 @@ def get_selected_utub_owner_id(browser: WebDriver):
         Integer user ID
     """
 
-    owner_badge = wait_then_get_element(browser, MPL.BADGE_OWNER)
+    owner_badge = wait_then_get_element(browser, HPL.BADGE_OWNER)
     assert owner_badge is not None
 
     owner_id = owner_badge.get_attribute("memberid")
@@ -557,7 +557,7 @@ def get_current_user_name(browser: WebDriver) -> str:
         String username
     """
 
-    logged_in_user = wait_then_get_element(browser, MPL.LOGGED_IN_USERNAME_READ)
+    logged_in_user = wait_then_get_element(browser, HPL.LOGGED_IN_USERNAME_READ)
     assert logged_in_user is not None
     logged_in_user_string = logged_in_user.get_attribute("innerText")
     assert logged_in_user_string is not None
@@ -577,7 +577,7 @@ def get_current_user_id(browser: WebDriver) -> int:
     Returns:
         Integer user ID
     """
-    logged_in_user = wait_then_get_element(browser, MPL.LOGGED_IN_USERNAME_READ)
+    logged_in_user = wait_then_get_element(browser, HPL.LOGGED_IN_USERNAME_READ)
     assert logged_in_user is not None
 
     parent_element = logged_in_user.find_element(By.XPATH, "..")
@@ -617,14 +617,14 @@ def get_url_by_title(browser: WebDriver, url_title: str) -> WebElement | None:
         URL row with the provided URL title
     """
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if url_rows is None:
         return None
 
     for url_row in url_rows:
 
         url_row_title = url_row.find_element(
-            By.CSS_SELECTOR, MPL.URL_TITLE_READ
+            By.CSS_SELECTOR, HPL.URL_TITLE_READ
         ).get_attribute("innerText")
         if url_row_title == url_title:
             return url_row
@@ -644,14 +644,14 @@ def select_url_by_title(browser: WebDriver, url_title: str):
         Boolean indicating a successful click of the indicated URL row with the provided URL title
     """
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if url_rows is None:
         return False
 
     for url_row in url_rows:
 
         url_row_title = url_row.find_element(
-            By.CSS_SELECTOR, MPL.URL_TITLE_READ
+            By.CSS_SELECTOR, HPL.URL_TITLE_READ
         ).get_attribute("innerText")
         if url_row_title == url_title:
             url_row.click()
@@ -672,14 +672,14 @@ def select_url_by_url_string(browser: WebDriver, url_string: str) -> bool:
         Boolean indicating a successful click of the indicated URL row with the provided URL title
     """
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if url_rows is None:
         return False
 
     for url_row in url_rows:
 
         url_row_string = url_row.find_element(
-            By.CSS_SELECTOR, MPL.URL_STRING_READ
+            By.CSS_SELECTOR, HPL.URL_STRING_READ
         ).get_attribute("data-url")
         if url_row_string == url_string:
             url_row.click()
@@ -700,13 +700,13 @@ def verify_elem_with_url_string_exists(browser: WebDriver, url_string: str) -> b
         (bool): True if element exists, False otherwise
 
     """
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if url_rows is None:
         return False
 
     for url_row in url_rows:
         url_row_string = url_row.find_element(
-            By.CSS_SELECTOR, MPL.URL_STRING_READ
+            By.CSS_SELECTOR, HPL.URL_STRING_READ
         ).get_attribute("data-url")
 
         if url_row_string == url_string:
@@ -751,7 +751,7 @@ def get_num_url_rows(browser: WebDriver):
     Returns:
         Integer length of URL rows in UTub
     """
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
     if url_rows:
         return len(url_rows)
     return 0
@@ -768,7 +768,7 @@ def get_all_url_ids_in_selected_utub(browser: WebDriver) -> list[int]:
         Array of ints corresponding to URL IDs in the UTub
     """
 
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
 
     url_ids = []
     if url_rows:
@@ -783,7 +783,7 @@ def get_all_url_ids_in_selected_utub(browser: WebDriver) -> list[int]:
 
 def get_all_tag_ids_in_url_row(url_row: WebElement) -> list[int] | None:
     tag_badges: list[WebElement] = url_row.find_elements(
-        By.CSS_SELECTOR, MPL.TAG_BADGES
+        By.CSS_SELECTOR, HPL.TAG_BADGES
     )
     if tag_badges:
         tag_ids = [
@@ -819,7 +819,7 @@ def get_num_url_unfiltered_rows(browser: WebDriver):
     Returns:
         Integer length of visible URL rows in UTub available to user
     """
-    url_rows = wait_then_get_elements(browser, MPL.ROWS_URLS)
+    url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
 
     if url_rows:
         visible_url_rows = [
@@ -842,7 +842,7 @@ def get_selected_url(browser: WebDriver) -> WebElement:
     Returns:
         Yields WebDriver to tests
     """
-    return browser.find_element(By.CSS_SELECTOR, MPL.ROW_SELECTED_URL)
+    return browser.find_element(By.CSS_SELECTOR, HPL.ROW_SELECTED_URL)
 
 
 def get_selected_url_title(browser: WebDriver):
@@ -859,18 +859,18 @@ def get_selected_url_title(browser: WebDriver):
     selected_url_row = get_selected_url(browser)
 
     return selected_url_row.find_element(
-        By.CSS_SELECTOR, MPL.URL_TITLE_READ
+        By.CSS_SELECTOR, HPL.URL_TITLE_READ
     ).get_attribute("innerText")
 
 
 def get_url_row_by_id(browser: WebDriver, urlid: int):
-    return browser.find_element(By.CSS_SELECTOR, MPL.ROWS_URLS + f'[urlid="{urlid}"]')
+    return browser.find_element(By.CSS_SELECTOR, HPL.ROWS_URLS + f'[urlid="{urlid}"]')
 
 
 def get_tag_badge_by_id(browser: WebDriver, urlid: int, tagid: int):
     url_row = get_url_row_by_id(browser, urlid)
     return url_row.find_element(
-        By.CSS_SELECTOR, MPL.TAG_BADGES + f'[data-utub-tag-id="{tagid}"]'
+        By.CSS_SELECTOR, HPL.TAG_BADGES + f'[data-utub-tag-id="{tagid}"]'
     )
 
 
@@ -904,62 +904,62 @@ def add_mock_urls(runner: FlaskCliRunner, urls: list[str]):
 
 def verify_update_url_state_is_shown(url_row: WebElement):
     hidden_btns = (
-        MPL.BUTTON_URL_DELETE,
-        MPL.BUTTON_TAG_CREATE,
-        MPL.BUTTON_URL_ACCESS,
+        HPL.BUTTON_URL_DELETE,
+        HPL.BUTTON_TAG_CREATE,
+        HPL.BUTTON_URL_ACCESS,
     )
 
     for btn in hidden_btns:
         assert not url_row.find_element(By.CSS_SELECTOR, btn).is_displayed()
 
     with pytest.raises(NoSuchElementException):
-        url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_URL_STRING_UPDATE)
+        url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_UPDATE)
 
     visible_btns = (
-        MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE,
-        MPL.BUTTON_URL_STRING_SUBMIT_UPDATE,
-        MPL.BUTTON_URL_STRING_CANCEL_UPDATE,
+        HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE,
+        HPL.BUTTON_URL_STRING_SUBMIT_UPDATE,
+        HPL.BUTTON_URL_STRING_CANCEL_UPDATE,
     )
 
     for btn in visible_btns:
         assert url_row.find_element(By.CSS_SELECTOR, btn).is_displayed()
 
     assert url_row.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_STRING_UPDATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_STRING_UPDATE
     ).is_displayed()
 
-    assert not url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ).is_displayed()
-    assert not url_row.find_element(By.CSS_SELECTOR, MPL.GO_TO_URL_ICON).is_displayed()
+    assert not url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).is_displayed()
+    assert not url_row.find_element(By.CSS_SELECTOR, HPL.GO_TO_URL_ICON).is_displayed()
 
 
 def verify_update_url_state_is_hidden(url_row: WebElement):
     visible_btns = (
-        MPL.BUTTON_URL_DELETE,
-        MPL.BUTTON_TAG_CREATE,
-        MPL.BUTTON_URL_ACCESS,
-        MPL.BUTTON_URL_STRING_UPDATE,
+        HPL.BUTTON_URL_DELETE,
+        HPL.BUTTON_TAG_CREATE,
+        HPL.BUTTON_URL_ACCESS,
+        HPL.BUTTON_URL_STRING_UPDATE,
     )
 
     for btn in visible_btns:
         assert url_row.find_element(By.CSS_SELECTOR, btn).is_displayed()
 
     with pytest.raises(NoSuchElementException):
-        url_row.find_element(By.CSS_SELECTOR, MPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
+        url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_BIG_URL_STRING_CANCEL_UPDATE)
 
     hidden_btns = (
-        MPL.BUTTON_URL_STRING_SUBMIT_UPDATE,
-        MPL.BUTTON_URL_STRING_CANCEL_UPDATE,
+        HPL.BUTTON_URL_STRING_SUBMIT_UPDATE,
+        HPL.BUTTON_URL_STRING_CANCEL_UPDATE,
     )
 
     for btn in hidden_btns:
         assert not url_row.find_element(By.CSS_SELECTOR, btn).is_displayed()
 
     assert not url_row.find_element(
-        By.CSS_SELECTOR, MPL.INPUT_URL_STRING_UPDATE
+        By.CSS_SELECTOR, HPL.INPUT_URL_STRING_UPDATE
     ).is_displayed()
 
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.URL_STRING_READ).is_displayed()
-    assert url_row.find_element(By.CSS_SELECTOR, MPL.GO_TO_URL_ICON).is_displayed()
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).is_displayed()
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.GO_TO_URL_ICON).is_displayed()
 
 
 # Tag Deck
@@ -987,7 +987,7 @@ def get_tag_filter_name_by_id(browser: WebDriver, tag_id: int) -> str | None:
 
 def get_tag_filter_by_id(browser: WebDriver, tag_id: int) -> WebElement | None:
     return browser.find_element(
-        By.CSS_SELECTOR, MPL.TAG_FILTERS + '[data-utub-tag-id="' + str(tag_id) + '"]'
+        By.CSS_SELECTOR, HPL.TAG_FILTERS + '[data-utub-tag-id="' + str(tag_id) + '"]'
     )
 
 
@@ -1026,8 +1026,8 @@ def get_tag_filter_by_name(browser: WebDriver, tag_name: str) -> WebElement | No
 
 
 def get_utub_tag_filters(browser: WebDriver) -> list[WebElement]:
-    return wait_then_get_elements(browser, MPL.TAG_FILTERS, 0)
+    return wait_then_get_elements(browser, HPL.TAG_FILTERS, 0)
 
 
 def get_selected_url_tags(url_row: WebElement) -> list[WebElement]:
-    return url_row.find_elements(By.CSS_SELECTOR, MPL.TAG_BADGES)
+    return url_row.find_elements(By.CSS_SELECTOR, HPL.TAG_BADGES)

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -245,7 +245,7 @@ def assert_not_visible_css_selector(
         )
         assert True
     except TimeoutException:
-        print("Element is still visible.")
+        assert False
 
 
 def assert_on_404_page(browser: WebDriver):
@@ -782,7 +782,7 @@ def get_all_url_ids_in_selected_utub(browser: WebDriver) -> list[int]:
         for row in url_rows:
             url_id = row.get_attribute("urlid")
             assert url_id is not None
-            assert isinstance(url_id, str)
+            assert isinstance(url_id, str) and url_id.isdecimal()
             url_ids.append(int(url_id))
 
     return url_ids

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -204,7 +204,9 @@ def clear_then_send_keys(element: WebElement, input_text: str):
     input_field.send_keys(input_text)
 
 
-def wait_until_hidden(browser: WebDriver, css_selector: str, timeout: int = 2):
+def wait_until_hidden(
+    browser: WebDriver, css_selector: str, timeout: int = 2
+) -> WebElement:
     element = browser.find_element(By.CSS_SELECTOR, css_selector)
 
     wait = WebDriverWait(browser, timeout)
@@ -316,6 +318,11 @@ def login_user_with_cookie_from_session(browser: WebDriver, session_id: str):
 
     # Refresh to redirect user to their home page since they're logged in
     browser.refresh()
+
+
+def login_user_to_home_page(app: Flask, browser: WebDriver, user_id: int):
+    session_id = create_user_session_and_provide_session_id(app, user_id)
+    login_user_with_cookie_from_session(browser, session_id)
 
 
 def login_user_and_select_utub_by_name(

--- a/tests/functional/utubs_ui/test_create_utub_ui.py
+++ b/tests/functional/utubs_ui/test_create_utub_ui.py
@@ -1,12 +1,9 @@
-# Standard library
 from time import sleep
 
-# External libraries
 import pytest
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
-# Internal libraries
 from src.cli.mock_constants import MOCK_UTUB_DESCRIPTION
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import SplashPageLocators as SPL
@@ -17,7 +14,7 @@ from tests.functional.utils_for_test import (
     wait_then_get_elements,
     wait_until_hidden,
 )
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from utils_for_test_utub_ui import assert_active_utub, create_utub
 
 pytestmark = pytest.mark.utubs_ui
@@ -37,16 +34,31 @@ def test_open_create_utub_input(browser: WebDriver, create_test_users):
     wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
 
     # Click createUTub button to show input
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
 
-    create_utub_name_input = wait_then_get_element(browser, MPL.INPUT_UTUB_NAME_CREATE)
-
+    create_utub_name_input = wait_then_get_element(browser, HPL.INPUT_UTUB_NAME_CREATE)
+    assert create_utub_name_input is not None
     assert create_utub_name_input.is_displayed()
-    assert wait_then_get_element(
-        browser, MPL.INPUT_UTUB_DESCRIPTION_CREATE
-    ).is_displayed()
+
+    create_utub_desc_input = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_CREATE
+    )
+    assert create_utub_desc_input is not None
+    assert create_utub_desc_input.is_displayed()
 
     assert create_utub_name_input == browser.switch_to.active_element
+
+    create_utub_submit_btn = wait_then_get_element(
+        browser, HPL.BUTTON_UTUB_SUBMIT_CREATE
+    )
+    assert create_utub_submit_btn is not None
+    assert create_utub_submit_btn.is_displayed()
+
+    create_utub_cancel_btn = wait_then_get_element(
+        browser, HPL.BUTTON_UTUB_CANCEL_CREATE
+    )
+    assert create_utub_cancel_btn is not None
+    assert create_utub_submit_btn.is_displayed()
 
 
 def test_close_create_utub_input_btn(browser: WebDriver, create_test_users):
@@ -63,11 +75,11 @@ def test_close_create_utub_input_btn(browser: WebDriver, create_test_users):
     wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
 
     # Click createUTub button to show input
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
 
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_CANCEL_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_CANCEL_CREATE)
 
-    create_utub_name_input = wait_until_hidden(browser, MPL.INPUT_UTUB_NAME_CREATE, 5)
+    create_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_CREATE, 5)
 
     assert not create_utub_name_input.is_displayed()
 
@@ -86,11 +98,11 @@ def test_close_create_utub_input_key(browser: WebDriver, create_test_users):
     wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
 
     # Click createUTub button to show input
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    create_utub_name_input = wait_until_hidden(browser, MPL.INPUT_UTUB_NAME_CREATE, 5)
+    create_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_CREATE, 5)
 
     assert not create_utub_name_input.is_displayed()
 
@@ -115,7 +127,7 @@ def test_create_utub_btn(browser: WebDriver, create_test_users):
     create_utub(browser, utub_name, MOCK_UTUB_DESCRIPTION)
 
     # Submits new UTub
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_SUBMIT_CREATE)
 
     # Wait for POST request
     sleep(4)
@@ -168,7 +180,7 @@ def test_create_utub_name_length_exceeded(browser: WebDriver, create_test_users)
 
     create_utub(browser, UTS.MAX_CHAR_LIM_UTUB_NAME)
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
 
     # Assert new UTub is now active and displayed to user
     assert warning_modal_body.text == "Try shortening your UTub name"
@@ -190,17 +202,17 @@ def test_create_utub_name_similar(browser: WebDriver, create_test_utubs):
     wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
 
     # Extract name of a pre-existing UTub
-    UTub_selectors = wait_then_get_elements(browser, MPL.SELECTORS_UTUB)
+    UTub_selectors = wait_then_get_elements(browser, HPL.SELECTORS_UTUB)
     first_UTub_selector = UTub_selectors[0]
     utub_name = first_UTub_selector.text
 
     # Attempt to add a new UTub with the same name
     create_utub(browser, utub_name, MOCK_UTUB_DESCRIPTION)
     # Submits new UTub
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_SUBMIT_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_SUBMIT_CREATE)
 
     # Extract modal body element
-    confirmation_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    confirmation_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     confirmation_modal_body_text = confirmation_modal_body.get_attribute("innerText")
     utub_same_name_check_text = UTS.BODY_MODAL_UTUB_CREATE_SAME_NAME
 

--- a/tests/functional/utubs_ui/test_create_utub_ui.py
+++ b/tests/functional/utubs_ui/test_create_utub_ui.py
@@ -1,14 +1,14 @@
-from time import sleep
-
+from flask import Flask
 import pytest
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from src.cli.mock_constants import MOCK_UTUB_DESCRIPTION
+from src.utils.constants import CONSTANTS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.locators import SplashPageLocators as SPL
+from src.utils.strings.utub_strs import UTUB_FAILURE
 from tests.functional.utils_for_test import (
-    login_user,
+    login_user_to_home_page,
     wait_then_click_element,
     wait_then_get_element,
     wait_then_get_elements,
@@ -20,7 +20,9 @@ from utils_for_test_utub_ui import assert_active_utub, create_utub
 pytestmark = pytest.mark.utubs_ui
 
 
-def test_open_create_utub_input(browser: WebDriver, create_test_users):
+def test_open_create_utub_input(
+    browser: WebDriver, create_test_users, provide_app: Flask
+):
     """
     Tests a user's ability to open the createUTub input using the plus button.
 
@@ -28,10 +30,9 @@ def test_open_create_utub_input(browser: WebDriver, create_test_users):
     WHEN user clicks the UTub module plus button
     THEN ensure the createUTub input opens
     """
-    login_user(browser)
-
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
     # Click createUTub button to show input
     wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
@@ -61,7 +62,9 @@ def test_open_create_utub_input(browser: WebDriver, create_test_users):
     assert create_utub_submit_btn.is_displayed()
 
 
-def test_close_create_utub_input_btn(browser: WebDriver, create_test_users):
+def test_close_create_utub_input_btn(
+    browser: WebDriver, create_test_users, provide_app: Flask
+):
     """
     Tests a user's ability to close the createUTub input by clicking the 'x' button
 
@@ -69,22 +72,25 @@ def test_close_create_utub_input_btn(browser: WebDriver, create_test_users):
     WHEN user opens the createUTub input, then clicks the 'x'
     THEN ensure the createUTub input is closed
     """
-    login_user(browser)
-
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
     # Click createUTub button to show input
     wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
 
     wait_then_click_element(browser, HPL.BUTTON_UTUB_CANCEL_CREATE)
 
-    create_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_CREATE, 5)
+    create_utub_name_input = wait_until_hidden(
+        browser, HPL.INPUT_UTUB_NAME_CREATE, timeout=3
+    )
 
     assert not create_utub_name_input.is_displayed()
 
 
-def test_close_create_utub_input_key(browser: WebDriver, create_test_users):
+def test_close_create_utub_input_key(
+    browser: WebDriver, create_test_users, provide_app: Flask
+):
     """
     Tests a user's ability to close the createUTub input by pressing the Escape key
 
@@ -92,35 +98,33 @@ def test_close_create_utub_input_key(browser: WebDriver, create_test_users):
     WHEN user opens the createUTub input, then presses 'Esc'
     THEN ensure the createUTub input is closed
     """
-    login_user(browser)
-
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
     # Click createUTub button to show input
     wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    create_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_CREATE, 5)
+    create_utub_name_input = wait_until_hidden(
+        browser, HPL.INPUT_UTUB_NAME_CREATE, timeout=3
+    )
 
     assert not create_utub_name_input.is_displayed()
 
 
-# @pytest.mark.skip(reason="Testing another in isolation")
-def test_create_utub_btn(browser: WebDriver, create_test_users):
+def test_create_utub_btn(browser: WebDriver, create_test_users, provide_app: Flask):
     """
     Tests a user's ability to create a UTub
 
-    GIVEN a user
+    GIVEN a user attempting to make a UTub
     WHEN the createUTub form is populated and submitted by the 'check' button
     THEN ensure the new UTub is successfully added to the user's UTub Deck and is selected.
     """
-
-    login_user(browser)
-
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
     utub_name = UTS.TEST_UTUB_NAME_1
 
@@ -130,24 +134,25 @@ def test_create_utub_btn(browser: WebDriver, create_test_users):
     wait_then_click_element(browser, HPL.BUTTON_UTUB_SUBMIT_CREATE)
 
     # Wait for POST request
-    sleep(4)
+    create_utub_name_input = wait_until_hidden(
+        browser, HPL.INPUT_UTUB_NAME_CREATE, timeout=3
+    )
 
+    assert not create_utub_name_input.is_displayed()
     assert_active_utub(browser, utub_name)
 
 
-def test_create_utub_key(browser: WebDriver, create_test_users):
+def test_create_utub_key(browser: WebDriver, create_test_users, provide_app: Flask):
     """
     Tests a user's ability to create a UTub
 
-    GIVEN a user
+    GIVEN a user attempting to make a UTub
     WHEN the createUTub form is populated and submitted by pressing the 'Enter' key
     THEN ensure the new UTub is successfully added to the user's UTub Deck and is selected.
     """
-
-    login_user(browser)
-
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
     utub_name = UTS.TEST_UTUB_NAME_1
 
@@ -156,38 +161,46 @@ def test_create_utub_key(browser: WebDriver, create_test_users):
     browser.switch_to.active_element.send_keys(Keys.ENTER)
 
     # Wait for POST request
-    sleep(4)
+    create_utub_name_input = wait_until_hidden(
+        browser, HPL.INPUT_UTUB_NAME_CREATE, timeout=3
+    )
 
+    assert not create_utub_name_input.is_displayed()
     assert_active_utub(browser, utub_name)
 
 
-@pytest.mark.skip(
-    reason="Not on happy path. This test tests functionality that is not yet captured on the frontend"
-)
-def test_create_utub_name_length_exceeded(browser: WebDriver, create_test_users):
+def test_create_utub_name_length_exceeded(
+    browser: WebDriver, create_test_users, provide_app: Flask
+):
     """
     Tests the site error response to a user's attempt to create a new UTub with a name that exceeds the maximum character length limit.
 
-    GIVEN a user
+    GIVEN a user attempting to make a UTub
     WHEN the createUTub form is populated and submitted with a name that exceeds character limits
     THEN ensure the appropriate error and prompt is shown to user.
     """
 
-    login_user(browser)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    oversized_utub_name = "a" * CONSTANTS.UTUBS.MAX_NAME_LENGTH
+    create_utub(
+        browser, utub_name=oversized_utub_name, utub_description=oversized_utub_name
+    )
 
-    create_utub(browser, UTS.MAX_CHAR_LIM_UTUB_NAME)
+    create_utub_name_input = wait_then_get_element(browser, HPL.INPUT_UTUB_NAME_CREATE)
+    assert create_utub_name_input is not None
+    current_input = create_utub_name_input.get_attribute("value")
+    assert current_input is not None
 
-    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
-
-    # Assert new UTub is now active and displayed to user
-    assert warning_modal_body.text == "Try shortening your UTub name"
+    # HTML element has a maxlength on it, so check that the input is still the max length
+    assert len(current_input) == CONSTANTS.UTUBS.MAX_NAME_LENGTH
 
 
-# @pytest.mark.skip(reason="Testing another in isolation")
-def test_create_utub_name_similar(browser: WebDriver, create_test_utubs):
+def test_create_utub_name_similar(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
     """
     Tests the site warning response to a user's attempt to create a new UTub with a name that is similar to one already in their UTub Deck.
 
@@ -195,16 +208,14 @@ def test_create_utub_name_similar(browser: WebDriver, create_test_utubs):
     WHEN the createUTub form is populated and submitted with a name that is similar to one already in their UTub Deck
     THEN ensure the appropriate warning and prompt for confirmation is shown to user.
     """
-
-    login_user(browser)
-
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
 
     # Extract name of a pre-existing UTub
-    UTub_selectors = wait_then_get_elements(browser, HPL.SELECTORS_UTUB)
-    first_UTub_selector = UTub_selectors[0]
-    utub_name = first_UTub_selector.text
+    utub_selectors = wait_then_get_elements(browser, HPL.SELECTORS_UTUB)
+    first_utub_selector = utub_selectors[0]
+    utub_name = first_utub_selector.text
 
     # Attempt to add a new UTub with the same name
     create_utub(browser, utub_name, MOCK_UTUB_DESCRIPTION)
@@ -213,8 +224,36 @@ def test_create_utub_name_similar(browser: WebDriver, create_test_utubs):
 
     # Extract modal body element
     confirmation_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
+    assert confirmation_modal_body is not None
     confirmation_modal_body_text = confirmation_modal_body.get_attribute("innerText")
     utub_same_name_check_text = UTS.BODY_MODAL_UTUB_CREATE_SAME_NAME
 
     # Assert modal prompts user to consider duplicate UTub naming
     assert confirmation_modal_body_text == utub_same_name_check_text
+
+
+def test_create_utub_empty_utub_name(
+    browser: WebDriver, create_test_users, provide_app: Flask
+):
+    """
+    Tests a user's ability to create a UTub
+
+    GIVEN a user attempting to make a UTub
+    WHEN the createUTub form is sent with the UTub Name field being empty
+    THEN ensure U4I responds with a proper error message
+    """
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
+
+    create_utub(browser, utub_name="", utub_description="")
+
+    # Submits new UTub
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_SUBMIT_CREATE)
+
+    # Wait for POST request to fail
+    invalid_utub_name_error = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_NAME_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_utub_name_error is not None
+    assert invalid_utub_name_error.text == UTUB_FAILURE.FIELD_REQUIRED_STR

--- a/tests/functional/utubs_ui/test_delete_utub_ui.py
+++ b/tests/functional/utubs_ui/test_delete_utub_ui.py
@@ -1,7 +1,3 @@
-# Standard library
-from time import sleep
-
-# External libraries
 from flask import Flask
 import pytest
 from selenium.common.exceptions import NoSuchElementException
@@ -9,23 +5,20 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
-# Internal libraries
-from src.cli.mock_constants import MOCK_UTUB_NAME_BASE
+from src import db
+from src.models.utub_members import Utub_Members
+from src.models.utubs import Utubs
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import ModalLocators as ML
 from tests.functional.locators import HomePageLocators as HPL
-from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.urls_ui.utils_for_test_url_ui import get_selected_utub_id
 from tests.functional.utils_for_test import (
     dismiss_modal_with_click_out,
-    get_all_utub_selector_names,
-    login_user,
     login_user_select_utub_by_name_and_url_by_title,
-    select_utub_by_name,
-    user_is_selected_utub_owner,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
+    wait_until_visible_css_selector,
 )
 
 pytestmark = pytest.mark.utubs_ui
@@ -46,10 +39,19 @@ def test_open_delete_utub_modal(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
     )
 
-    if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
 
-    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
+    utub_delete_btn = wait_then_get_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
+    assert utub_delete_btn is not None
+    assert utub_delete_btn.is_displayed()
+
+    utub_delete_btn.click()
+
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL, time=3)
+    assert warning_modal_body is not None
+
     confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
 
     # Assert warning modal appears with appropriate text
@@ -71,12 +73,18 @@ def test_dismiss_delete_utub_modal_x(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
     )
 
-    if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
 
-    wait_then_click_element(browser, ML.BUTTON_X_MODAL_DISMISS)
+    delete_utub_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
+    assert not delete_utub_modal.is_displayed()
 
-    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
+
+    wait_then_click_element(browser, ML.BUTTON_X_MODAL_DISMISS, time=3)
+
+    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL, timeout=3)
 
     assert not modal_element.is_displayed()
 
@@ -96,8 +104,14 @@ def test_dismiss_delete_utub_modal_btn(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
     )
 
-    if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
+
+    delete_utub_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
+    assert not delete_utub_modal.is_displayed()
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
 
     wait_then_click_element(browser, ML.BUTTON_MODAL_DISMISS)
 
@@ -121,13 +135,16 @@ def test_dismiss_delete_utub_modal_key(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
     )
 
-    if not user_is_selected_utub_owner(browser):
-        utub_selector_names = get_all_utub_selector_names(browser)
-        select_utub_by_name(browser, utub_selector_names[0])
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
 
-    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
+    delete_utub_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
+    assert not delete_utub_modal.is_displayed()
 
-    sleep(4)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
+
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
 
     browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL).send_keys(Keys.ESCAPE)
 
@@ -151,17 +168,19 @@ def test_dismiss_delete_utub_modal_click(
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
     )
 
-    if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
 
     dismiss_modal_with_click_out(browser)
 
-    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL)
+    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL, timeout=3)
 
     assert not modal_element.is_displayed()
 
 
-# @pytest.mark.skip(reason="Testing another in isolation")
 def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Flask):
     """
     GIVEN a user trying to add a new UTub
@@ -175,40 +194,126 @@ def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Fla
         app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
     )
 
-    assert user_is_selected_utub_owner(browser)
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
+
     utub_id = get_selected_utub_id(browser)
     css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
-    assert browser.find_element(By.CSS_SELECTOR, css_selector)
-    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
-    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
+    assert browser.find_element(By.CSS_SELECTOR, css_selector)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
+
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT, time=3)
 
     # Wait for DELETE request
-    sleep(4)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
 
     # Assert UTub selector no longer exists
     with pytest.raises(NoSuchElementException):
         css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
-        assert browser.find_element(By.CSS_SELECTOR, css_selector)
+        browser.find_element(By.CSS_SELECTOR, css_selector)
 
 
-@pytest.mark.skip(reason="Test not yet implemented")
-def test_delete_last_utub(browser: WebDriver, create_test_utubs):
+def test_delete_last_utub_no_urls_no_tags_no_members(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
     """
-    GIVEN a user has one UTub
+    GIVEN a user has one UTub with no URLs, tags, or member
     WHEN they delete the UTub
     THEN ensure the main page shows appropriate prompts to create a new UTub
     """
+    app = provide_app
+    user_id_for_test = 1
+    login_user_select_utub_by_name_and_url_by_title(
+        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    )
 
-    login_user(browser)
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
 
-    # Find submit button to login
-    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
 
-    # Extract confirming result
-    selector_UTub1 = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT, time=3)
 
-    # Assert new UTub selector was created with input UTub Name
-    assert selector_UTub1.text == MOCK_UTUB_NAME_BASE + "1"
-    # Assert new UTub is now active and displayed to user
-    assert "active" in selector_UTub1.get_attribute("class")
+    # Wait for DELETE request
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+
+    # Make sure all relevant buttons and subheaders are hidden when no UTub selected
+    non_visible_elems = (
+        HPL.BUTTON_UTUB_DELETE,
+        HPL.BUTTON_MEMBER_CREATE,
+        HPL.BUTTON_UTUB_TAG_CREATE,
+        HPL.BUTTON_CORNER_URL_CREATE,
+        HPL.SUBHEADER_TAG_DECK,
+    )
+
+    for elem in non_visible_elems:
+        assert not browser.find_element(By.CSS_SELECTOR, elem).is_displayed()
+
+    assert (
+        browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK).text
+        == "Select a UTub"
+    )
+    assert (
+        browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_UTUB_DECK).text
+        == UTS.MESSAGE_NO_UTUBS
+    )
+
+
+def test_delete_last_utub_with_urls_tags_members(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a user has one UTub with no URLs, tags, or member
+    WHEN they delete the UTub
+    THEN ensure the main page shows appropriate prompts to create a new UTub
+    """
+    app = provide_app
+    user_id_for_test = 1
+
+    with app.app_context():
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        assert utub.utub_creator == user_id_for_test
+        Utub_Members.query.filter(
+            Utub_Members.user_id == user_id_for_test, Utub_Members.utub_id != utub.id
+        ).delete()
+        db.session.commit()
+
+    login_user_select_utub_by_name_and_url_by_title(
+        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
+
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT, time=3)
+
+    # Wait for DELETE request
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+
+    # Make sure all relevant buttons and subheaders are hidden when no UTub selected
+    non_visible_elems = (
+        HPL.BUTTON_UTUB_DELETE,
+        HPL.BUTTON_MEMBER_CREATE,
+        HPL.BUTTON_UTUB_TAG_CREATE,
+        HPL.BUTTON_CORNER_URL_CREATE,
+        HPL.SUBHEADER_TAG_DECK,
+    )
+
+    for elem in non_visible_elems:
+        assert not browser.find_element(By.CSS_SELECTOR, elem).is_displayed()
+
+    assert (
+        browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK).text
+        == "Select a UTub"
+    )
+    assert (
+        browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_UTUB_DECK).text
+        == UTS.MESSAGE_NO_UTUBS
+    )
+
+    assert len(browser.find_elements(By.CSS_SELECTOR, HPL.SELECTORS_UTUB)) == 0
+    assert len(browser.find_elements(By.CSS_SELECTOR, HPL.BADGES_MEMBERS)) == 0
+    assert len(browser.find_elements(By.CSS_SELECTOR, HPL.TAG_FILTERS)) == 0
+    assert len(browser.find_elements(By.CSS_SELECTOR, HPL.ROWS_URLS)) == 0

--- a/tests/functional/utubs_ui/test_delete_utub_ui.py
+++ b/tests/functional/utubs_ui/test_delete_utub_ui.py
@@ -13,7 +13,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from src.cli.mock_constants import MOCK_UTUB_NAME_BASE
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import ModalLocators as ML
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.urls_ui.utils_for_test_url_ui import get_selected_utub_id
 from tests.functional.utils_for_test import (
@@ -47,9 +47,9 @@ def test_open_delete_utub_modal(
     )
 
     if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, MPL.BUTTON_UTUB_DELETE)
+        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
 
     # Assert warning modal appears with appropriate text
@@ -72,11 +72,11 @@ def test_dismiss_delete_utub_modal_x(
     )
 
     if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, MPL.BUTTON_UTUB_DELETE)
+        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
     wait_then_click_element(browser, ML.BUTTON_X_MODAL_DISMISS)
 
-    modal_element = wait_until_hidden(browser, MPL.HOME_MODAL)
+    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL)
 
     assert not modal_element.is_displayed()
 
@@ -97,11 +97,11 @@ def test_dismiss_delete_utub_modal_btn(
     )
 
     if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, MPL.BUTTON_UTUB_DELETE)
+        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
     wait_then_click_element(browser, ML.BUTTON_MODAL_DISMISS)
 
-    modal_element = wait_until_hidden(browser, MPL.HOME_MODAL)
+    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL)
 
     assert not modal_element.is_displayed()
 
@@ -125,13 +125,13 @@ def test_dismiss_delete_utub_modal_key(
         utub_selector_names = get_all_utub_selector_names(browser)
         select_utub_by_name(browser, utub_selector_names[0])
 
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_DELETE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
     sleep(4)
 
-    browser.find_element(By.CSS_SELECTOR, MPL.HOME_MODAL).send_keys(Keys.ESCAPE)
+    browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL).send_keys(Keys.ESCAPE)
 
-    modal_element = wait_until_hidden(browser, MPL.HOME_MODAL)
+    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL)
 
     assert not modal_element.is_displayed()
 
@@ -152,11 +152,11 @@ def test_dismiss_delete_utub_modal_click(
     )
 
     if user_is_selected_utub_owner(browser):
-        wait_then_click_element(browser, MPL.BUTTON_UTUB_DELETE)
+        wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
     dismiss_modal_with_click_out(browser)
 
-    modal_element = wait_until_hidden(browser, MPL.HOME_MODAL)
+    modal_element = wait_until_hidden(browser, HPL.HOME_MODAL)
 
     assert not modal_element.is_displayed()
 
@@ -177,18 +177,18 @@ def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Fla
 
     assert user_is_selected_utub_owner(browser)
     utub_id = get_selected_utub_id(browser)
-    css_selector = f'{MPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
+    css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
     assert browser.find_element(By.CSS_SELECTOR, css_selector)
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_DELETE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE)
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for DELETE request
     sleep(4)
 
     # Assert UTub selector no longer exists
     with pytest.raises(NoSuchElementException):
-        css_selector = f'{MPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
+        css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
         assert browser.find_element(By.CSS_SELECTOR, css_selector)
 
 
@@ -206,7 +206,7 @@ def test_delete_last_utub(browser: WebDriver, create_test_utubs):
     wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
 
     # Extract confirming result
-    selector_UTub1 = wait_then_get_element(browser, MPL.SELECTOR_SELECTED_UTUB)
+    selector_UTub1 = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB)
 
     # Assert new UTub selector was created with input UTub Name
     assert selector_UTub1.text == MOCK_UTUB_NAME_BASE + "1"

--- a/tests/functional/utubs_ui/test_update_utub_description_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_description_ui.py
@@ -1,0 +1,474 @@
+from flask import Flask
+import pytest
+from selenium.common.exceptions import JavascriptException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from locators import HomePageLocators as HPL
+from src.cli.mock_constants import MOCK_UTUB_DESCRIPTION
+from src.utils.constants import CONSTANTS
+from tests.functional.utils_for_test import (
+    assert_not_visible_css_selector,
+    clear_then_send_keys,
+    login_user_and_select_utub_by_name,
+    login_user_to_home_page,
+    select_utub_by_name,
+    wait_then_click_element,
+    wait_then_get_element,
+    wait_until_hidden,
+    wait_until_visible,
+    wait_until_visible_css_selector,
+)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import (
+    create_utub,
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
+    hover_over_utub_title_to_show_add_utub_description,
+    open_update_utub_desc_input,
+    update_utub_description,
+    update_utub_to_empty_desc,
+)
+
+pytestmark = pytest.mark.utubs_ui
+
+
+def test_open_update_utub_description_input_creator(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a user's ability to open the updateUTubDescription input using the pencil button.
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user selects a UTub they created, then clicks the edit UTub description button
+    THEN ensure the updateUTubDescription input opens
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    url_deck_subheader = wait_then_get_element(browser, HPL.SUBHEADER_URL_DECK)
+    assert url_deck_subheader is not None
+    utub_description = url_deck_subheader.text
+
+    open_update_utub_desc_input(browser)
+
+    utub_description_update_input = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
+    )
+    assert utub_description_update_input is not None
+
+    assert utub_description_update_input.is_displayed()
+
+    assert utub_description == utub_description_update_input.get_attribute("value")
+
+
+def test_open_update_utub_description_input_member(
+    browser: WebDriver, create_test_utubmembers, provide_app: Flask
+):
+    """
+    Tests a user's ability to open the updateUTubName input using the pencil button.
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user selects a UTub they did not create, then tries to click the edit UTub description button
+    THEN ensure the updateUTubDescription button does not show
+    """
+    app = provide_app
+    user_id = 1
+    utub = get_utub_this_user_did_not_create(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub.name)
+
+    # Javascript Exception is raised when selenium tries to hover over the UTub Name,
+    # and then click on the edit UTub name button - but as a member, the button doesn't
+    # show on hover
+    with pytest.raises(JavascriptException):
+        open_update_utub_desc_input(browser)
+
+    assert_not_visible_css_selector(browser, HPL.BUTTON_UTUB_DESCRIPTION_UPDATE)
+
+
+def test_close_update_utub_description_input_btn(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a user's ability to close the updateUTubDescription input by clicking the 'x' button
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user opens the updateUTubDescription input, then clicks the 'x'
+    THEN ensure the updateUTubDescription input is closed
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    open_update_utub_desc_input(browser)
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_CANCEL_UPDATE)
+
+    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
+
+    assert not update_utub_name_input.is_displayed()
+
+
+def test_close_update_utub_description_input_key(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a user's ability to close the updateUTubDescription input by pressing the Escape key
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user opens the updateUTubDescription input, then presses 'Esc'
+    THEN ensure the updateUTubDescription input is closed
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    open_update_utub_desc_input(browser)
+
+    browser.switch_to.active_element.send_keys(Keys.ESCAPE)
+
+    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
+
+    assert not update_utub_name_input.is_displayed()
+
+
+def test_update_utub_description_btn(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to update the selected UTub description.
+
+    GIVEN a user is the UTub owner
+    WHEN the utubDescriptionUpdate form is populated and submitted
+    THEN ensure the new description is successfully added to the UTub.
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    update_utub_description(browser, MOCK_UTUB_DESCRIPTION)
+
+    # Submits new UTub description
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
+
+    utub_description_elem = browser.find_element(
+        By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK
+    )
+
+    # Wait for POST request
+    utub_description_elem = wait_until_visible(
+        browser, utub_description_elem, timeout=3
+    )
+    assert utub_description_elem is not None
+    assert utub_description_elem.text == MOCK_UTUB_DESCRIPTION
+
+
+def test_update_utub_description_key(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to update the selected UTub description.
+
+    GIVEN a user is the UTub owner
+    WHEN the utubDescriptionUpdate form is populated and submitted
+    THEN ensure the new description is successfully added to the UTub.
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    update_utub_description(browser, MOCK_UTUB_DESCRIPTION)
+
+    # Submits new UTub description
+    browser.switch_to.active_element.send_keys(Keys.ENTER)
+
+    utub_description_elem = browser.find_element(
+        By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK
+    )
+
+    # Wait for POST request
+    utub_description_elem = wait_until_visible(
+        browser, utub_description_elem, timeout=3
+    )
+    assert utub_description_elem is not None
+    assert utub_description_elem.text == MOCK_UTUB_DESCRIPTION
+
+
+def test_update_utub_description_length_exceeded(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to update a selected UTub's description.
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to enter a UTub description that is too long
+    THEN ensure the input field retains the max number of characters allowed.
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    new_utub_description = "a" * (CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH + 1)
+
+    update_utub_description(browser, new_utub_description)
+
+    update_utub_description_input = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
+    )
+    assert update_utub_description_input is not None
+    new_utub_description = update_utub_description_input.get_attribute("value")
+    assert new_utub_description is not None
+
+    assert len(new_utub_description) == CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH
+
+
+def test_update_utub_description_to_empty(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to update a selected UTub's description to an empty value
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to enter a UTub description that is empty
+    THEN ensure the description field remains hidden after updating
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    utub_description_elem = browser.find_element(
+        By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK
+    )
+    assert utub_description_elem.is_displayed()
+
+    update_utub_description(browser, utub_description="")
+
+    utub_description_elem = browser.find_element(
+        By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK
+    )
+    assert not utub_description_elem.is_displayed()
+
+    # Submits new UTub description
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
+
+    # Wait until the submit button is hidden and then verify description is still hidden
+    wait_until_hidden(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE, timeout=3)
+
+    utub_description_elem = browser.find_element(
+        By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK
+    )
+    assert not utub_description_elem.is_displayed()
+
+
+def test_update_empty_utub_description_btn_shows_after_updating_to_empty(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to select the "Add UTub Description" button after
+    updating the UTub description to an empty string
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to add a UTub description after updating it to an empty string
+    THEN ensure the Add UTub Description button shows
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    update_utub_description(browser, utub_description="")
+
+    # Submits new UTub description
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
+
+    # Wait until the submit button is hidden and then verify description is still hidden
+    wait_until_hidden(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE, timeout=3)
+
+    hover_over_utub_title_to_show_add_utub_description(browser)
+
+    add_utub_desc = wait_then_get_element(browser, HPL.BUTTON_ADD_UTUB_DESC_ON_EMPTY)
+    assert add_utub_desc is not None
+    assert add_utub_desc.is_displayed()
+
+
+def test_update_empty_utub_description_btn_shows_after_selecting_utub(
+    browser: WebDriver, create_test_utubmembers, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to select the "Add UTub Description" button after
+    updating the UTub description to an empty string
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to add a UTub description after selecting a UTub with an empty description
+    after having another UTub selected
+    THEN ensure the Add UTub Description button shows
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    update_utub_to_empty_desc(app, utub_user_created.id)
+    utub_user_did_not_create = get_utub_this_user_did_not_create(app, user_id)
+
+    login_user_and_select_utub_by_name(
+        app, browser, user_id, utub_user_did_not_create.name
+    )
+    select_utub_by_name(browser, utub_user_created.name)
+
+    hover_over_utub_title_to_show_add_utub_description(browser)
+
+    add_utub_desc = wait_then_get_element(browser, HPL.BUTTON_ADD_UTUB_DESC_ON_EMPTY)
+    assert add_utub_desc is not None
+    assert add_utub_desc.is_displayed()
+
+
+def test_update_empty_utub_description_btn_shows_after_creating_utub(
+    browser: WebDriver, create_test_users, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to select the "Add UTub Description" button after
+    updating the UTub description to an empty string
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to add a UTub description after creating a UTub with an empty name
+    THEN ensure the Add UTub Description button shows
+    """
+    app = provide_app
+    user_id = 1
+    login_user_to_home_page(app, browser, user_id)
+    create_utub(browser, utub_name="UTub Name", utub_description="")
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_SUBMIT_CREATE, time=3)
+    wait_until_visible_css_selector(browser, HPL.BUTTON_CORNER_URL_CREATE, timeout=3)
+
+    hover_over_utub_title_to_show_add_utub_description(browser)
+
+    add_utub_desc = wait_then_get_element(browser, HPL.BUTTON_ADD_UTUB_DESC_ON_EMPTY)
+    assert add_utub_desc is not None
+    assert add_utub_desc.is_displayed()
+
+
+def test_update_empty_utub_description_btn_opens_input(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to open UTub description input after the "Add UTub Description"button is shown when UTub description is empty
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to add a UTub description after owning a UTub with an empty name
+    THEN ensure the UTub Description input shows
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    update_utub_to_empty_desc(app, utub_user_created.id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    hover_over_utub_title_to_show_add_utub_description(browser)
+
+    wait_then_click_element(browser, HPL.BUTTON_ADD_UTUB_DESC_ON_EMPTY, time=3)
+
+    utub_description_update_input = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
+    )
+    assert utub_description_update_input is not None
+
+    assert utub_description_update_input.is_displayed()
+
+    assert "" == utub_description_update_input.get_attribute("value")
+
+
+def test_update_empty_utub_description_updates_description(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a UTub owner's ability to update UTub description after it was empty
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to add a UTub description after owning a UTub with an empty name
+    THEN ensure the UTub Description is updated properly
+    """
+    NEW_UTUB_DESC = "My New UTub Description!"
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    update_utub_to_empty_desc(app, utub_user_created.id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    hover_over_utub_title_to_show_add_utub_description(browser)
+
+    wait_then_click_element(browser, HPL.BUTTON_ADD_UTUB_DESC_ON_EMPTY, time=3)
+
+    wait_until_visible_css_selector(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE, timeout=3
+    )
+
+    update_utub_desc_input = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE, time=3
+    )
+    assert update_utub_desc_input is not None
+
+    clear_then_send_keys(update_utub_desc_input, NEW_UTUB_DESC)
+
+    # Submits new UTub description
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
+
+    utub_description_elem = browser.find_element(
+        By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK
+    )
+
+    # Wait for POST request
+    utub_description_elem = wait_until_visible(
+        browser, utub_description_elem, timeout=3
+    )
+    assert utub_description_elem is not None
+    assert utub_description_elem.text == NEW_UTUB_DESC
+
+
+def test_update_utub_description_form_closes_when_selecting_other_utub(
+    browser: WebDriver, create_test_utubmembers, provide_app: Flask
+):
+    """
+    Tests that UTub Description form closes between updates
+
+    GIVEN a user owns a UTub
+    WHEN they attempt to add a UTub description but then switches UTubs
+    THEN ensure the UTub Description form is closed
+    """
+    app = provide_app
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    utub_user_did_not_create = get_utub_this_user_did_not_create(app, user_id)
+
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+
+    open_update_utub_desc_input(browser)
+
+    utub_description_update_input = wait_then_get_element(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
+    )
+    assert utub_description_update_input is not None
+    assert utub_description_update_input.is_displayed()
+
+    select_utub_by_name(browser, utub_name=utub_user_did_not_create.name)
+    utub_desc_update_input = wait_until_hidden(
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE, timeout=3
+    )
+
+    assert not utub_desc_update_input.is_displayed()

--- a/tests/functional/utubs_ui/test_update_utub_name_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_name_ui.py
@@ -1,5 +1,3 @@
-from time import sleep
-
 from flask import Flask
 import pytest
 from selenium.common.exceptions import JavascriptException
@@ -7,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from locators import HomePageLocators as HPL
-from src.cli.mock_constants import MOCK_UTUB_NAME_BASE, MOCK_UTUB_DESCRIPTION
+from src.cli.mock_constants import MOCK_UTUB_NAME_BASE
 from src.models.utubs import Utubs
 from src.utils.constants import CONSTANTS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
@@ -17,7 +15,6 @@ from tests.functional.utils_for_test import (
     create_user_session_and_provide_session_id,
     get_all_url_ids_in_selected_utub,
     get_all_utub_selector_names,
-    get_selected_utub_decsription,
     get_selected_utub_name,
     login_user_and_select_utub_by_name,
     login_user_with_cookie_from_session,
@@ -29,10 +26,8 @@ from tests.functional.utils_for_test import (
 from tests.functional.utubs_ui.utils_for_test_utub_ui import (
     assert_active_utub,
     get_utub_this_user_created,
-    open_update_utub_desc_input,
     open_update_utub_name_input,
     update_utub_name,
-    update_utub_description,
 )
 
 pytestmark = pytest.mark.utubs_ui
@@ -356,200 +351,3 @@ def test_update_utub_name_similar(
 
     # Assert new UTub name is updated in UTub Deck
     assert new_utub_name in utub_selector_names
-
-
-def test_open_update_utub_description_input_creator(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a user's ability to open the updateUTubDescription input using the pencil button.
-
-    GIVEN a fresh load of the U4I Home page
-    WHEN user selects a UTub they created, then clicks the edit UTub description button
-    THEN ensure the updateUTubDescription input opens
-    """
-    app = provide_app
-    user_id = 1
-    utub_user_created = get_utub_this_user_created(app, user_id)
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
-    url_deck_subheader = wait_then_get_element(browser, HPL.SUBHEADER_URL_DECK)
-    assert url_deck_subheader is not None
-    utub_description = url_deck_subheader.text
-
-    open_update_utub_desc_input(browser)
-
-    utub_description_update_input = wait_then_get_element(
-        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
-    )
-    assert utub_description_update_input is not None
-
-    assert utub_description_update_input.is_displayed()
-
-    assert utub_description == utub_description_update_input.get_attribute("value")
-
-
-def test_open_update_utub_description_input_member(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a user's ability to open the updateUTubName input using the pencil button.
-
-    GIVEN a fresh load of the U4I Home page
-    WHEN user selects a UTub they did not create, then tries to click the edit UTub description button
-    THEN ensure the updateUTubDescription button does not show
-    """
-    app = provide_app
-    user_id = 1
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.utub_creator != user_id).first()
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub.name)
-
-    # Javascript Exception is raised when selenium tries to hover over the UTub Name,
-    # and then click on the edit UTub name button - but as a member, the button doesn't
-    # show on hover
-    with pytest.raises(JavascriptException):
-        open_update_utub_desc_input(browser)
-
-    assert_not_visible_css_selector(browser, HPL.BUTTON_UTUB_DESCRIPTION_UPDATE)
-
-
-def test_close_update_utub_description_input_btn(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a user's ability to close the updateUTubDescription input by clicking the 'x' button
-
-    GIVEN a fresh load of the U4I Home page
-    WHEN user opens the updateUTubDescription input, then clicks the 'x'
-    THEN ensure the updateUTubDescription input is closed
-    """
-    app = provide_app
-    user_id = 1
-    utub_user_created = get_utub_this_user_created(app, user_id)
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
-
-    open_update_utub_desc_input(browser)
-
-    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_CANCEL_UPDATE)
-
-    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
-
-    assert not update_utub_name_input.is_displayed()
-
-
-def test_close_update_utub_description_input_key(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a user's ability to close the updateUTubDescription input by pressing the Escape key
-
-    GIVEN a fresh load of the U4I Home page
-    WHEN user opens the updateUTubDescription input, then presses 'Esc'
-    THEN ensure the updateUTubDescription input is closed
-    """
-    app = provide_app
-    user_id = 1
-    utub_user_created = get_utub_this_user_created(app, user_id)
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
-
-    open_update_utub_desc_input(browser)
-
-    browser.switch_to.active_element.send_keys(Keys.ESCAPE)
-
-    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
-
-    assert not update_utub_name_input.is_displayed()
-
-
-def test_update_utub_description_btn(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a UTub owner's ability to update the selected UTub description.
-
-    GIVEN a user is the UTub owner
-    WHEN the utubDescriptionUpdate form is populated and submitted
-    THEN ensure the new description is successfully added to the UTub.
-    """
-    app = provide_app
-    user_id = 1
-    utub_user_created = get_utub_this_user_created(app, user_id)
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
-
-    update_utub_description(browser, MOCK_UTUB_DESCRIPTION)
-
-    # Submits new UTub description
-    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
-
-    # Wait for POST request
-    sleep(4)
-
-    utub_description = get_selected_utub_decsription(browser)
-
-    # Assert new member is added to UTub
-    assert MOCK_UTUB_DESCRIPTION == utub_description
-
-
-def test_update_utub_description_key(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a UTub owner's ability to update the selected UTub description.
-
-    GIVEN a user is the UTub owner
-    WHEN the utubDescriptionUpdate form is populated and submitted
-    THEN ensure the new description is successfully added to the UTub.
-    """
-    app = provide_app
-    user_id = 1
-    utub_user_created = get_utub_this_user_created(app, user_id)
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
-
-    update_utub_description(browser, MOCK_UTUB_DESCRIPTION)
-
-    # Submits new UTub description
-    browser.switch_to.active_element.send_keys(Keys.ENTER)
-
-    # Wait for POST request
-    sleep(4)
-
-    utub_description = get_selected_utub_decsription(browser)
-
-    # Assert new member is added to UTub
-    assert MOCK_UTUB_DESCRIPTION == utub_description
-
-
-def test_update_utub_description_length_exceeded(
-    browser: WebDriver, create_test_utubs, provide_app: Flask
-):
-    """
-    Tests a UTub owner's ability to update a selected UTub's description.
-
-    GIVEN a user owns a UTub
-    WHEN they attempt to enter a UTub description that is too long
-    THEN ensure the input field retains the max number of characters allowed.
-    """
-    app = provide_app
-    user_id = 1
-    utub_user_created = get_utub_this_user_created(app, user_id)
-
-    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
-
-    new_utub_description = "a" * (CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH + 1)
-
-    update_utub_description(browser, new_utub_description)
-
-    update_utub_description_input = wait_then_get_element(
-        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
-    )
-    assert update_utub_description_input is not None
-    new_utub_description = update_utub_description_input.get_attribute("value")
-    assert new_utub_description is not None
-
-    assert len(new_utub_description) == CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH

--- a/tests/functional/utubs_ui/test_update_utub_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_ui.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
-from locators import MainPageLocators as MPL
+from locators import HomePageLocators as HPL
 from src.cli.mock_constants import MOCK_UTUB_NAME_BASE, MOCK_UTUB_DESCRIPTION
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.utils_for_test import (
@@ -78,11 +78,11 @@ def test_open_update_utub_name_input(
     user_id = 1
     login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
 
-    utub_name = wait_then_get_element(browser, MPL.HEADER_URL_DECK).text
+    utub_name = wait_then_get_element(browser, HPL.HEADER_URL_DECK).text
 
     open_update_utub_input(browser, 1)
 
-    utub_name_update_input = wait_then_get_element(browser, MPL.INPUT_UTUB_NAME_UPDATE)
+    utub_name_update_input = wait_then_get_element(browser, HPL.INPUT_UTUB_NAME_UPDATE)
 
     assert utub_name_update_input.is_displayed()
 
@@ -107,9 +107,9 @@ def test_close_update_utub_name_input_btn(
 
     open_update_utub_input(browser, 1)
 
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_NAME_CANCEL_UPDATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_NAME_CANCEL_UPDATE)
 
-    update_utub_name_input = wait_until_hidden(browser, MPL.INPUT_UTUB_NAME_UPDATE, 5)
+    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
 
     assert not update_utub_name_input.is_displayed()
 
@@ -133,7 +133,7 @@ def test_close_update_utub_name_input_key(
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    update_utub_name_input = wait_until_hidden(browser, MPL.INPUT_UTUB_NAME_UPDATE, 5)
+    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
 
     assert not update_utub_name_input.is_displayed()
 
@@ -159,7 +159,7 @@ def test_update_utub_name_btn(
     update_utub_name(browser, new_utub_name)
 
     # Submits new UTub name
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_NAME_SUBMIT_UPDATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_NAME_SUBMIT_UPDATE)
 
     # Wait for POST request
     sleep(4)
@@ -240,12 +240,12 @@ def test_update_utub_name_similar(
     update_utub_name(browser, new_utub_name)
 
     # Submits new UTub name
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_NAME_SUBMIT_UPDATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_NAME_SUBMIT_UPDATE)
 
     # Wait for POST request
     sleep(4)
 
-    warning_modal_body = wait_then_get_element(browser, MPL.BODY_MODAL)
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
 
     utub_name_update_check_text = UTS.BODY_MODAL_UTUB_UPDATE_SAME_NAME
@@ -253,7 +253,7 @@ def test_update_utub_name_similar(
     # Assert warning modal appears with appropriate text
     assert confirmation_modal_body_text == utub_name_update_check_text
 
-    wait_then_click_element(browser, MPL.BUTTON_MODAL_SUBMIT)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for POST request
     sleep(4)
@@ -282,12 +282,12 @@ def test_open_update_utub_description_input(
 
     user_id = 1
     login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
-    utub_description = wait_then_get_element(browser, MPL.SUBHEADER_URL_DECK).text
+    utub_description = wait_then_get_element(browser, HPL.SUBHEADER_URL_DECK).text
 
     open_update_utub_input(browser, 0)
 
     utub_description_update_input = wait_then_get_element(
-        browser, MPL.INPUT_UTUB_DESCRIPTION_UPDATE
+        browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
     )
 
     assert utub_description_update_input.is_displayed()
@@ -312,9 +312,9 @@ def test_close_update_utub_description_input_btn(
 
     open_update_utub_input(browser, 0)
 
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_DESCRIPTION_CANCEL_UPDATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_CANCEL_UPDATE)
 
-    update_utub_name_input = wait_until_hidden(browser, MPL.INPUT_UTUB_NAME_UPDATE, 5)
+    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
 
     assert not update_utub_name_input.is_displayed()
 
@@ -338,7 +338,7 @@ def test_close_update_utub_description_input_key(
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
 
-    update_utub_name_input = wait_until_hidden(browser, MPL.INPUT_UTUB_NAME_UPDATE, 5)
+    update_utub_name_input = wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_UPDATE, 5)
 
     assert not update_utub_name_input.is_displayed()
 
@@ -362,7 +362,7 @@ def test_update_utub_description_btn(
     update_utub_description(browser, MOCK_UTUB_DESCRIPTION)
 
     # Submits new UTub description
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DESCRIPTION_SUBMIT_UPDATE)
 
     # Wait for POST request
     sleep(4)

--- a/tests/functional/utubs_ui/utils_for_test_utub_ui.py
+++ b/tests/functional/utubs_ui/utils_for_test_utub_ui.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 # Internal libraries
-from tests.functional.locators import MainPageLocators as MPL
+from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     clear_then_send_keys,
     user_is_selected_utub_owner,
@@ -28,15 +28,15 @@ def create_utub(browser: WebDriver, utub_name: str, utub_description: str):
     """
 
     # Click createUTub button to show input
-    wait_then_click_element(browser, MPL.BUTTON_UTUB_CREATE)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_CREATE)
 
     # Types new UTub name
-    create_utub_name_input = wait_then_get_element(browser, MPL.INPUT_UTUB_NAME_CREATE)
+    create_utub_name_input = wait_then_get_element(browser, HPL.INPUT_UTUB_NAME_CREATE)
     clear_then_send_keys(create_utub_name_input, utub_name)
 
     # Types new UTub description
     create_utub_description_input = wait_then_get_element(
-        browser, MPL.INPUT_UTUB_DESCRIPTION_CREATE
+        browser, HPL.INPUT_UTUB_DESCRIPTION_CREATE
     )
     clear_then_send_keys(create_utub_description_input, utub_description)
 
@@ -53,7 +53,7 @@ def assert_active_utub(browser: WebDriver, utub_name: str):
     """
 
     # Extract new UTub selector. Selector should be active.
-    selector_UTub = wait_then_get_element(browser, MPL.SELECTOR_SELECTED_UTUB)
+    selector_UTub = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB)
 
     # Assert new UTub is now active and displayed to user
     assert "active" in selector_UTub.get_attribute("class")
@@ -61,7 +61,7 @@ def assert_active_utub(browser: WebDriver, utub_name: str):
     # Assert new UTub selector was created with input UTub Name
     assert selector_UTub.text == utub_name
 
-    current_URL_deck_header = wait_then_get_element(browser, MPL.HEADER_URL_DECK)
+    current_URL_deck_header = wait_then_get_element(browser, HPL.HEADER_URL_DECK)
 
     # Assert new UTub name is displayed as the URL Deck header
     assert current_URL_deck_header.text == utub_name
@@ -82,19 +82,19 @@ def open_update_utub_input(browser: WebDriver, update_UTub_name_or_desc: int):
     actions = ActionChains(browser)
 
     wrap_locators = (
-        MPL.WRAP_UTUB_NAME_UPDATE
+        HPL.WRAP_UTUB_NAME_UPDATE
         if update_UTub_name_or_desc
-        else MPL.WRAP_UTUB_DESCRIPTION_UPDATE
+        else HPL.WRAP_UTUB_DESCRIPTION_UPDATE
     )
 
     update_element_locator = (
-        MPL.HEADER_URL_DECK if update_UTub_name_or_desc else MPL.SUBHEADER_URL_DECK
+        HPL.HEADER_URL_DECK if update_UTub_name_or_desc else HPL.SUBHEADER_URL_DECK
     )
 
     update_button_locator = (
-        MPL.BUTTON_UTUB_NAME_UPDATE
+        HPL.BUTTON_UTUB_NAME_UPDATE
         if update_UTub_name_or_desc
-        else MPL.BUTTON_UTUB_DESCRIPTION_UPDATE
+        else HPL.BUTTON_UTUB_DESCRIPTION_UPDATE
     )
 
     update_wrap_element = wait_then_get_element(browser, wrap_locators)
@@ -137,7 +137,7 @@ def update_utub_name(browser: WebDriver, utub_name: str):
 
         # Types new UTub name
         utub_name_update_input = wait_then_get_element(
-            browser, MPL.INPUT_UTUB_NAME_UPDATE
+            browser, HPL.INPUT_UTUB_NAME_UPDATE
         )
         clear_then_send_keys(utub_name_update_input, utub_name)
 
@@ -163,7 +163,7 @@ def update_utub_description(browser: WebDriver, utub_description: str):
 
         # Types new UTub description
         utub_description_update_input = wait_then_get_element(
-            browser, MPL.INPUT_UTUB_DESCRIPTION_UPDATE
+            browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
         )
         clear_then_send_keys(utub_description_update_input, utub_description)
 

--- a/tests/functional/utubs_ui/utils_for_test_utub_ui.py
+++ b/tests/functional/utubs_ui/utils_for_test_utub_ui.py
@@ -32,12 +32,14 @@ def create_utub(browser: WebDriver, utub_name: str, utub_description: str):
 
     # Types new UTub name
     create_utub_name_input = wait_then_get_element(browser, HPL.INPUT_UTUB_NAME_CREATE)
+    assert create_utub_name_input is not None
     clear_then_send_keys(create_utub_name_input, utub_name)
 
     # Types new UTub description
     create_utub_description_input = wait_then_get_element(
         browser, HPL.INPUT_UTUB_DESCRIPTION_CREATE
     )
+    assert create_utub_description_input is not None
     clear_then_send_keys(create_utub_description_input, utub_description)
 
 
@@ -53,21 +55,25 @@ def assert_active_utub(browser: WebDriver, utub_name: str):
     """
 
     # Extract new UTub selector. Selector should be active.
-    selector_UTub = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB)
+    selector_utub = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB)
+    assert selector_utub is not None
 
     # Assert new UTub is now active and displayed to user
-    assert "active" in selector_UTub.get_attribute("class")
+    class_attrib = selector_utub.get_attribute("class")
+    assert class_attrib is not None
+    assert "active" in class_attrib
 
     # Assert new UTub selector was created with input UTub Name
-    assert selector_UTub.text == utub_name
+    assert selector_utub.text == utub_name
 
-    current_URL_deck_header = wait_then_get_element(browser, HPL.HEADER_URL_DECK)
+    current_url_deck_header = wait_then_get_element(browser, HPL.HEADER_URL_DECK)
+    assert current_url_deck_header is not None
 
     # Assert new UTub name is displayed as the URL Deck header
-    assert current_URL_deck_header.text == utub_name
+    assert current_url_deck_header.text == utub_name
 
 
-def open_update_utub_input(browser: WebDriver, update_UTub_name_or_desc: int):
+def open_update_utub_input(browser: WebDriver, update_utub_name_or_desc: int):
     """
     Once logged in and UTub selected, this function conducts the actions for opening either the update UTub name or description input field. First hover over the UTub name or description to display the edit button. Then clicks the edit button.
 
@@ -83,21 +89,22 @@ def open_update_utub_input(browser: WebDriver, update_UTub_name_or_desc: int):
 
     wrap_locators = (
         HPL.WRAP_UTUB_NAME_UPDATE
-        if update_UTub_name_or_desc
+        if update_utub_name_or_desc
         else HPL.WRAP_UTUB_DESCRIPTION_UPDATE
     )
 
     update_element_locator = (
-        HPL.HEADER_URL_DECK if update_UTub_name_or_desc else HPL.SUBHEADER_URL_DECK
+        HPL.HEADER_URL_DECK if update_utub_name_or_desc else HPL.SUBHEADER_URL_DECK
     )
 
     update_button_locator = (
         HPL.BUTTON_UTUB_NAME_UPDATE
-        if update_UTub_name_or_desc
+        if update_utub_name_or_desc
         else HPL.BUTTON_UTUB_DESCRIPTION_UPDATE
     )
 
     update_wrap_element = wait_then_get_element(browser, wrap_locators)
+    assert update_wrap_element is not None
 
     # Hover over UTub name to display utubNameBtnUpdate button
     update_element = update_wrap_element.find_element(
@@ -120,7 +127,7 @@ def open_update_utub_input(browser: WebDriver, update_UTub_name_or_desc: int):
     # Update input field visible
 
 
-def update_utub_name(browser: WebDriver, utub_name: str):
+def update_utub_name(browser: WebDriver, utub_name: str) -> bool:
     """
     Once logged in and UTub selected, this function conducts the actions for editing the selected UTub name. First hover over the UTub name to display the edit button. Then clicks the edit button, interacts with the input field and submits it.
 
@@ -139,6 +146,7 @@ def update_utub_name(browser: WebDriver, utub_name: str):
         utub_name_update_input = wait_then_get_element(
             browser, HPL.INPUT_UTUB_NAME_UPDATE
         )
+        assert utub_name_update_input is not None
         clear_then_send_keys(utub_name_update_input, utub_name)
 
         return True
@@ -146,7 +154,7 @@ def update_utub_name(browser: WebDriver, utub_name: str):
         return False
 
 
-def update_utub_description(browser: WebDriver, utub_description: str):
+def update_utub_description(browser: WebDriver, utub_description: str) -> bool:
     """
     Once logged in and UTub selected, this function conducts the actions for editing the selected UTub description. First hover over the UTub decsription to display the edit button. Then clicks the edit button, interacts with the input field and submits it.
 
@@ -165,6 +173,7 @@ def update_utub_description(browser: WebDriver, utub_description: str):
         utub_description_update_input = wait_then_get_element(
             browser, HPL.INPUT_UTUB_DESCRIPTION_UPDATE
         )
+        assert utub_description_update_input is not None
         clear_then_send_keys(utub_description_update_input, utub_description)
 
         return True


### PR DESCRIPTION
Adding sad path tests for UTub UI on desktop.

Fixed UTub Tag creation button to not show when no UTub is selected.
Fixed UTub Description creation when the UTub description is empty. It now shows on hover of UTub Title, and hides when exiting the header of the URL deck.