### PR TITLE
Adds sad path member tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -48,9 +48,10 @@ def init_multiprocessing():
 
 
 @pytest.fixture(scope="session")
-def provide_port() -> int:
+def provide_port(flask_logs: bool) -> int:
     open_port = find_open_port()
-    print(f"Found an open port: {open_port}")
+    if flask_logs:
+        print(f"\nFound an open port: {open_port}")
     sleep(2)
     return open_port
 
@@ -196,7 +197,7 @@ def browser_mobile(
     This fixture clears cookies, accesses the U4I site and supplies driver for use by the test. A new instance is invoked per test.
     """
     open_port = provide_port
-    driver = build_driver
+    driver = build_driver_mobile
 
     driver.delete_all_cookies()
 

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -12,6 +12,7 @@ class HomePageLocators:
     SUBHEADER_UTUB_DECK = "#UTubDeckSubheader"
     LIST_UTUB = "#listUTubs"
     SELECTORS_UTUB = ".UTubSelector"
+    SELECTORS_UTUB_NAME = ".UTubName"
     SELECTOR_SELECTED_UTUB = ".UTubSelector.active"
 
     BUTTON_UTUB_CREATE = "#utubBtnCreate"

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -106,6 +106,7 @@ class HomePageLocators:
     BUTTON_MEMBER_SUBMIT_CREATE = "#memberSubmitBtnCreate"
     BUTTON_UTUB_LEAVE = "#memberSelfBtnDelete"
     BUTTON_MEMBER_DELETE = ".memberOtherBtnDelete"
+    INPUT_MEMBER_CREATE_ERROR = INPUT_MEMBER_CREATE + INVALID_FIELD_SUFFIX
 
     SUBHEADER_UTUB = "#MemberDeckSubheader"
     LIST_MEMBERS = "#listMembers"

--- a/tests/functional/members_ui/test_delete_member_ui.py
+++ b/tests/functional/members_ui/test_delete_member_ui.py
@@ -1,26 +1,31 @@
-# Standard library
-from time import sleep
-
-# External libraries
 from flask import Flask
 import pytest
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
-# Internal libraries
 from locators import HomePageLocators as HPL
-from src.cli.mock_constants import USERNAME_BASE
+from src.models.utub_members import Member_Role, Utub_Members
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.members_ui.utils_for_test_members_ui import (
     delete_member_active_utub,
     get_all_member_usernames,
+    get_other_member_in_utub,
 )
 from tests.functional.utils_for_test import (
+    dismiss_modal_with_click_out,
     login_user_and_select_utub_by_name,
+    wait_for_element_to_be_removed,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
+    wait_until_visible_css_selector,
+)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import (
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
 )
 
 pytestmark = pytest.mark.members_ui
@@ -32,22 +37,23 @@ def test_open_delete_member_modal(
     provide_app: Flask,
 ):
     """
-    Tests a UTub owner's ability to open the delete member modal.
-
     GIVEN a user owns a UTub with members
-    WHEN they submit the addUTub form
-    THEN ensure the appropriate input field is shown and in focus
+    WHEN they click on the delete member button after hovering over the member
+    THEN ensure the modal to confirm deleting a member is shown
     """
     app = provide_app
 
     user_id = 1
-    login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    other_member = get_other_member_in_utub(app, utub_user_created.id, user_id)
 
-    member_name = USERNAME_BASE + "2"
+    member_name = other_member.username
 
     delete_member_active_utub(browser, member_name)
 
     warning_modal = wait_then_get_element(browser, HPL.HOME_MODAL)
+    assert warning_modal is not None
 
     assert warning_modal.is_displayed()
 
@@ -66,22 +72,85 @@ def test_dismiss_delete_member_modal_btn(
     provide_app: Flask,
 ):
     """
-    Tests a UTub owner's ability to close the delete member modal.
-
     GIVEN a user owns a UTub with members
-    WHEN they submit the addUTub form
-    THEN ensure the appropriate input field is shown and in focus
+    WHEN they open the delete member modal, but dismiss it by clicking the cancel button
+    THEN ensure the modal is then dismissed
     """
     app = provide_app
 
     user_id = 1
-    login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    other_member = get_other_member_in_utub(app, utub_user_created.id, user_id)
 
-    member_name = USERNAME_BASE + "2"
+    member_name = other_member.username
 
     delete_member_active_utub(browser, member_name)
 
     wait_then_click_element(browser, HPL.BUTTON_MODAL_DISMISS)
+
+    create_member_input = wait_until_hidden(browser, HPL.HOME_MODAL)
+
+    # Assert warning modal appears with appropriate text
+    assert not create_member_input.is_displayed()
+
+
+def test_dismiss_delete_member_modal_x(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    GIVEN a user owns a UTub with members
+    WHEN they open the delete member modal, but dismiss it by clicking the X button on the modal
+    THEN ensure the modal is then dismissed
+    """
+    app = provide_app
+
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    other_member = get_other_member_in_utub(app, utub_user_created.id, user_id)
+
+    member_name = other_member.username
+
+    delete_member_active_utub(browser, member_name)
+
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
+    home_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
+    x_btn = home_modal.find_element(By.CSS_SELECTOR, HPL.BUTTON_X_CLOSE)
+    assert x_btn.is_displayed()
+    x_btn.click()
+
+    create_member_input = wait_until_hidden(browser, HPL.HOME_MODAL)
+
+    # Assert warning modal appears with appropriate text
+    assert not create_member_input.is_displayed()
+
+
+def test_dismiss_delete_member_modal_click_outside_modal(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    GIVEN a user owns a UTub with members
+    WHEN they open the delete member modal, but dismiss it by clicking outside the modal
+    THEN ensure the modal is then dismissed
+    """
+    app = provide_app
+
+    user_id = 1
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    other_member = get_other_member_in_utub(app, utub_user_created.id, user_id)
+
+    member_name = other_member.username
+
+    delete_member_active_utub(browser, member_name)
+
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
+    dismiss_modal_with_click_out(browser)
 
     create_member_input = wait_until_hidden(browser, HPL.HOME_MODAL)
 
@@ -95,22 +164,24 @@ def test_dismiss_delete_member_modal_key(
     provide_app: Flask,
 ):
     """
-    Tests a UTub owner's ability to delete a member from the UTub.
-
     GIVEN a user owns a UTub with members
-    WHEN they submit the addUTub form
-    THEN ensure the appropriate input field is shown and in focus
+    WHEN they open the delete member modal, but dismiss it by pressing the escape key
+    THEN ensure the modal is then dismissed
     """
     app = provide_app
 
     user_id = 1
-    login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    other_member = get_other_member_in_utub(app, utub_user_created.id, user_id)
 
-    member_name = USERNAME_BASE + "2"
+    member_name = other_member.username
+    delete_member_active_utub(browser, other_member.username)
 
     delete_member_active_utub(browser, member_name)
 
     home_modal = wait_then_get_element(browser, HPL.HOME_MODAL)
+    assert home_modal is not None
 
     home_modal.send_keys(Keys.ESCAPE)
 
@@ -126,27 +197,66 @@ def test_delete_member_btn(
     provide_app: Flask,
 ):
     """
-    Tests a UTub owner's ability to delete a member from the UTub.
-
     GIVEN a user owns a UTub with members
-    WHEN they submit the addUTub form
-    THEN ensure the appropriate input field is shown and in focus
+    WHEN they submit the delete UTub Member modal
+    THEN ensure the member is removed from the UTub
     """
     app = provide_app
 
     user_id = 1
-    login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
+    utub_user_created = get_utub_this_user_created(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_created.name)
+    other_member = get_other_member_in_utub(app, utub_user_created.id, user_id)
 
-    member_name = USERNAME_BASE + "2"
-
-    delete_member_active_utub(browser, member_name)
+    member_name = other_member.username
+    delete_member_active_utub(browser, other_member.username)
 
     wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
 
     # Wait for DELETE request
-    sleep(4)
+    member_selector = f'{HPL.BADGES_MEMBERS}[memberid="{other_member.id}"]'
+    member_elem = browser.find_element(By.CSS_SELECTOR, member_selector)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+    wait_for_element_to_be_removed(browser, member_elem)
 
     member_usernames = get_all_member_usernames(browser)
 
     # Assert member no longer exists
     assert member_name not in member_usernames
+
+
+def test_open_delete_member_modal_fails_as_member(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    GIVEN a user who is a member of a UTub
+    WHEN they hover over another member in the UTub
+    THEN ensure delete member button is not shown to the user
+    """
+    app = provide_app
+
+    user_id = 1
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id)
+    login_user_and_select_utub_by_name(app, browser, user_id, utub_user_member_of.name)
+
+    with app.app_context():
+        other_member: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.user_id != user_id,
+            Utub_Members.utub_id == utub_user_member_of.id,
+            Utub_Members.member_role == Member_Role.MEMBER,
+        ).first()
+        other_user = other_member.to_user
+
+    member_selector = f'{HPL.BADGES_MEMBERS}[memberid="{other_user.id}"]'
+
+    other_member_element = wait_then_get_element(browser, member_selector, time=3)
+    assert other_member_element is not None
+
+    actions = ActionChains(browser)
+    actions.move_to_element(other_member_element).perform()
+    actions.pause(1).perform()
+
+    with pytest.raises(NoSuchElementException):
+        other_member_element.find_element(By.CSS_SELECTOR, HPL.BUTTON_MEMBER_DELETE)

--- a/tests/functional/members_ui/test_leave_utub.py
+++ b/tests/functional/members_ui/test_leave_utub.py
@@ -1,30 +1,182 @@
-# Standard library
-from time import sleep
-
-# External libraries
 from flask import Flask
 import pytest
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
-# Internal libraries
 from locators import HomePageLocators as HPL
-from src.cli.mock_constants import MOCK_UTUB_NAME_BASE
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
-from tests.functional.members_ui.utils_for_test_members_ui import (
-    leave_active_utub,
-)
 from tests.functional.utils_for_test import (
+    dismiss_modal_with_click_out,
     get_num_utubs,
     login_user_and_select_utub_by_name,
-    select_utub_by_name,
+    wait_for_element_to_be_removed,
     wait_then_click_element,
     wait_then_get_element,
+    wait_until_hidden,
+    wait_until_visible_css_selector,
+)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import (
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
 )
 
 pytestmark = pytest.mark.members_ui
 
 
-# @pytest.mark.skip(reason="Testing another in isolation")
+def test_open_leave_utub_modal(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    Tests a UTub user's ability to open the leave UTub modal
+
+    GIVEN a user is a UTub member
+    WHEN the memberSelfBtnDelete button is clicked
+    THEN ensure the user is shown the modal confirming if they want to leave the UTub
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_member_of.name
+    )
+
+    leave_utub_btn = wait_then_get_element(browser, HPL.BUTTON_UTUB_LEAVE, time=3)
+    assert leave_utub_btn is not None
+    assert leave_utub_btn.is_displayed()
+
+    leave_utub_btn.click()
+
+    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL, time=3)
+    assert warning_modal_body is not None
+    assert warning_modal_body.is_displayed()
+
+    confirmation_modal_body_text = warning_modal_body.text
+
+    # Assert warning modal appears with appropriate text
+    assert confirmation_modal_body_text == UTS.BODY_MODAL_LEAVE_UTUB
+
+
+def test_dismiss_leave_utub_modal_btn(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    Tests a UTub user's ability to dismiss the leave UTub modal
+
+    GIVEN a user is a UTub member, and has opened the leave UTub modal
+    WHEN the "Stay In UTub" button is clicked
+    THEN ensure the modal is hidden
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_member_of.name
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE, time=3)
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
+
+    dismiss_modal_btn = browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_MODAL_DISMISS)
+    assert dismiss_modal_btn.is_displayed()
+    dismiss_modal_btn.click()
+
+    modal = wait_until_hidden(browser, HPL.BODY_MODAL, timeout=3)
+    assert not modal.is_displayed()
+
+
+def test_dismiss_leave_utub_modal_x(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    Tests a UTub user's ability to dismiss the leave UTub modal
+
+    GIVEN a user is a UTub member, and has opened the leave UTub modal
+    WHEN the user clicks the X button on the modal
+    THEN ensure the modal is hidden
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_member_of.name
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE, time=3)
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
+
+    home_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
+    x_btn = home_modal.find_element(By.CSS_SELECTOR, HPL.BUTTON_X_CLOSE)
+    assert x_btn.is_displayed()
+    x_btn.click()
+
+    modal = wait_until_hidden(browser, HPL.BODY_MODAL, timeout=3)
+    assert not modal.is_displayed()
+
+
+def test_dismiss_leave_utub_modal_key(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    Tests a UTub user's ability to dismiss the leave UTub modal
+
+    GIVEN a user is a UTub member, and has opened the leave UTub modal
+    WHEN the user presses the escape key
+    THEN ensure the modal is hidden
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_member_of.name
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE, time=3)
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
+
+    home_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
+    home_modal.send_keys(Keys.ESCAPE)
+
+    modal = wait_until_hidden(browser, HPL.BODY_MODAL, timeout=3)
+    assert not modal.is_displayed()
+
+
+def test_dismiss_leave_utub_modal_click_outside_modal(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    Tests a UTub user's ability to dismiss the leave UTub modal
+
+    GIVEN a user is a UTub member, and has opened the leave UTub modal
+    WHEN the user clicks outside the modal
+    THEN ensure the modal is hidden
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_member_of.name
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE, time=3)
+    wait_until_visible_css_selector(browser, HPL.HOME_MODAL, timeout=3)
+    dismiss_modal_with_click_out(browser)
+
+    modal = wait_until_hidden(browser, HPL.BODY_MODAL, timeout=3)
+    assert not modal.is_displayed()
+
+
 def test_leave_utub(
     browser: WebDriver,
     create_test_utubmembers,
@@ -34,32 +186,60 @@ def test_leave_utub(
     Tests a UTub user's ability to leave a UTub.
 
     GIVEN a user is a UTub member
-    WHEN the memberSelfBtnDelete button is selected
+    WHEN the memberSelfBtnDelete button is selected and user submits the confirm modal
     THEN ensure the user is successfully removed from the UTub.
     """
 
     app = provide_app
     user_id_for_test = 1
-    utub_name = MOCK_UTUB_NAME_BASE + "2"
-    login_user_and_select_utub_by_name(app, browser, user_id_for_test, utub_name)
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_member_of.name
+    )
 
-    num_utubs = get_num_utubs(browser)
+    init_num_utubs = get_num_utubs(browser)
 
-    leave_active_utub(browser)
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE, time=3)
 
     warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
-    confirmation_modal_body_text = warning_modal_body.get_attribute("innerText")
+    assert warning_modal_body is not None
 
-    # Assert warning modal appears with appropriate text
-    assert confirmation_modal_body_text == UTS.BODY_MODAL_LEAVE_UTUB
+    # Get UTub selector to verify it will be deleted
+    utub_css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_user_member_of.id}"]'
+    utub_selector = browser.find_element(By.CSS_SELECTOR, utub_css_selector)
 
-    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
-
-    # Wait for POST request
-    sleep(4)
-
-    # Assert member no longer has access to UTub
-    assert not select_utub_by_name(browser, utub_name)
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT, time=3)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+    wait_for_element_to_be_removed(browser, utub_selector)
 
     # Assert UTub count is one less than before
-    assert get_num_utubs(browser) == num_utubs - 1
+    assert get_num_utubs(browser) == init_num_utubs - 1
+
+    with pytest.raises(NoSuchElementException):
+        browser.find_element(By.CSS_SELECTOR, utub_css_selector)
+
+    # Assert no UTub is selector
+    with pytest.raises(NoSuchElementException):
+        browser.find_element(By.CSS_SELECTOR, HPL.SELECTOR_SELECTED_UTUB)
+
+
+def test_cannot_leave_utub_as_utub_creator(
+    browser: WebDriver,
+    create_test_utubmembers,
+    provide_app: Flask,
+):
+    """
+    GIVEN a user is a UTub creator
+    WHEN the user tries to leave the UTub
+    THEN ensure the leave UTub button is not visible to the user
+    """
+
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_creator_of = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_creator_of.name
+    )
+
+    leave_utub_btn = browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_UTUB_LEAVE)
+    assert not leave_utub_btn.is_displayed()

--- a/tests/functional/members_ui/utils_for_test_members_ui.py
+++ b/tests/functional/members_ui/utils_for_test_members_ui.py
@@ -1,5 +1,4 @@
 from flask import Flask
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -105,18 +104,3 @@ def delete_member_active_utub(browser: WebDriver, member_name: str):
             actions.click(member_delete_button)
 
             actions.perform()
-
-
-def leave_active_utub(browser: WebDriver):
-    """
-    Args:
-        WebDriver open to a selected UTub
-
-    Returns:
-        WebDriver handoff to member tests
-    """
-
-    try:
-        wait_then_click_element(browser, HPL.BUTTON_UTUB_LEAVE)
-    except NoSuchElementException:
-        return False

--- a/tests/functional/members_ui/utils_for_test_members_ui.py
+++ b/tests/functional/members_ui/utils_for_test_members_ui.py
@@ -1,24 +1,30 @@
-# Standard library
-
-
-# External libraries
+from flask import Flask
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
 
-# Internal libraries
+from src.models.users import Users
+from src.models.utub_members import Utub_Members
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     clear_then_send_keys,
-    user_is_selected_utub_owner,
     wait_then_click_element,
     wait_then_get_element,
     wait_then_get_elements,
 )
 
 
-def get_all_member_badges(browser: WebDriver):
+def get_other_member_in_utub(app: Flask, utub_id: int, current_user_id: int) -> Users:
+    with app.app_context():
+        other_member: Utub_Members = Utub_Members.query.filter(
+            Utub_Members.user_id != current_user_id, Utub_Members.utub_id == utub_id
+        ).first()
+        return other_member.to_user
+
+
+def get_all_member_badges(browser: WebDriver) -> list[WebElement]:
     """
     Args:
         WebDriver open to a selected UTub
@@ -31,7 +37,7 @@ def get_all_member_badges(browser: WebDriver):
     return wait_then_get_elements(browser, HPL.BADGES_MEMBERS)
 
 
-def get_all_member_usernames(browser: WebDriver):
+def get_all_member_usernames(browser: WebDriver) -> list[str]:
     """
     Args:
         WebDriver open to a selected UTub
@@ -42,13 +48,7 @@ def get_all_member_usernames(browser: WebDriver):
     """
 
     members = get_all_member_badges(browser)
-    member_names = []
-
-    for member in members:
-        member_name = member.get_attribute("innerText")
-        member_names.append(member_name)
-
-    return member_names
+    return [member.text for member in members] if members else []
 
 
 def create_member_active_utub(browser: WebDriver, member_name: str):
@@ -61,19 +61,13 @@ def create_member_active_utub(browser: WebDriver, member_name: str):
         Boolean confirmation of successful creation of member
         WebDriver handoff to member tests
     """
+    # Click createMember button to show input
+    wait_then_click_element(browser, HPL.BUTTON_MEMBER_CREATE)
 
-    if user_is_selected_utub_owner(browser):
-
-        # Click createMember button to show input
-        wait_then_click_element(browser, HPL.BUTTON_MEMBER_CREATE)
-
-        # Types new member name
-        create_member_input = wait_then_get_element(browser, HPL.INPUT_MEMBER_CREATE)
-        clear_then_send_keys(create_member_input, member_name)
-
-        return True
-    else:
-        return False
+    # Types new member name
+    create_member_input = wait_then_get_element(browser, HPL.INPUT_MEMBER_CREATE)
+    assert create_member_input is not None
+    clear_then_send_keys(create_member_input, member_name)
 
 
 def delete_member_active_utub(browser: WebDriver, member_name: str):
@@ -88,37 +82,29 @@ def delete_member_active_utub(browser: WebDriver, member_name: str):
     """
 
     actions = ActionChains(browser)
-    if user_is_selected_utub_owner(browser):
 
-        member_badges = get_all_member_badges(browser)
+    member_badges = get_all_member_badges(browser)
 
-        # Find index for appropriate member to delete
-        member_usernames = get_all_member_usernames(browser)
-        for i, username in enumerate(member_usernames):
-            # Delete only indicated member
-            if username == member_name:
-                member_badge_to_delete = member_badges[i]
-                # Hover over badge to display deleteMember button
-                actions.move_to_element(member_badge_to_delete)
+    # Find index for appropriate member to delete
+    for member_badge in member_badges:
+        # Delete only indicated member
+        username = member_badge.text
+        if username == member_name:
+            # Hover over badge to display deleteMember button
+            actions.move_to_element(member_badge)
 
-                # Pause to make sure deleteMember button is visible
-                actions.pause(3).perform()
+            # Pause to make sure deleteMember button is visible
+            actions.pause(3).perform()
 
-                member_delete_button = member_badge_to_delete.find_element(
-                    By.CSS_SELECTOR, HPL.BUTTON_MEMBER_DELETE
-                )
+            member_delete_button = member_badge.find_element(
+                By.CSS_SELECTOR, HPL.BUTTON_MEMBER_DELETE
+            )
 
-                actions.move_to_element(member_delete_button).pause(2)
+            actions.move_to_element(member_delete_button).pause(2)
 
-                actions.click(member_delete_button)
+            actions.click(member_delete_button)
 
-                actions.perform()
-
-                return True
-
-        return False
-    else:
-        return False
+            actions.perform()
 
 
 def leave_active_utub(browser: WebDriver):

--- a/tests/functional/urls_ui/test_update_url_ui.py
+++ b/tests/functional/urls_ui/test_update_url_ui.py
@@ -69,7 +69,7 @@ def test_update_url_string_submit_btn(
 
     url_row = get_selected_url(browser)
 
-    update_url_string(url_row, random_url_to_change_to)
+    update_url_string(browser, url_row, random_url_to_change_to)
     verify_update_url_state_is_shown(url_row)
     url_row.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_STRING_SUBMIT_UPDATE).click()
 
@@ -130,7 +130,7 @@ def test_update_url_string_press_enter_key(
 
     url_row = get_selected_url(browser)
 
-    update_url_string(url_row, random_url_to_change_to)
+    update_url_string(browser, url_row, random_url_to_change_to)
     verify_update_url_state_is_shown(url_row)
     browser.switch_to.active_element.send_keys(Keys.ENTER)
 
@@ -537,7 +537,7 @@ def test_update_url_title_length_exceeded(browser: WebDriver, create_test_urls):
 
     login_utub_url(browser)
 
-    update_url_title(browser, UTS.MAX_CHAR_LIM_URL_TITLE, MOCK_URL_STRINGS[0])
+    # update_url_title(browser, UTS.MAX_CHAR_LIM_URL_TITLE, MOCK_URL_STRINGS[0])
 
     warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     assert warning_modal_body is not None
@@ -558,7 +558,7 @@ def test_update_url_string_length_exceeded(browser: WebDriver, create_test_urls)
 
     login_utub_url(browser)
 
-    update_url_string(browser, MOCK_URL_STRINGS[0], UTS.MAX_CHAR_LIM_URL_STRING)
+    # update_url_string(browser, MOCK_URL_STRINGS[0], UTS.MAX_CHAR_LIM_URL_STRING)
 
     warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
     assert warning_modal_body is not None

--- a/tests/functional/urls_ui/utils_for_test_url_ui.py
+++ b/tests/functional/urls_ui/utils_for_test_url_ui.py
@@ -54,7 +54,7 @@ def create_url(browser: WebDriver, url_title: str, url_string: str):
     wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE)
 
 
-def update_url_string(url_row: WebElement, url_string: str):
+def update_url_string(browser: WebDriver, url_row: WebElement, url_string: str):
     """
     Streamlines actions required to updated a URL in the selected URL.
 
@@ -72,6 +72,9 @@ def update_url_string(url_row: WebElement, url_string: str):
     # Input new URL string
     url_string_input_field = url_row.find_element(
         By.CSS_SELECTOR, HPL.INPUT_URL_STRING_UPDATE
+    )
+    url_string_input_field = wait_until_visible(
+        browser, url_string_input_field, timeout=3
     )
     clear_then_send_keys(url_string_input_field, url_string)
 

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -422,6 +422,7 @@ def select_utub_by_name(browser: WebDriver, utub_name: str):
 
         if utub_name_elem.text == utub_name:
             selector.click()
+            return
 
 
 def login_utub(
@@ -620,14 +621,10 @@ def select_url_by_title(browser: WebDriver, url_title: str):
     Args:
         WebDriver open to a selected UTub
         URL Title
-
-    Returns:
-        Boolean indicating a successful click of the indicated URL row with the provided URL title
     """
 
     url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
-    if url_rows is None:
-        return False
+    assert url_rows
 
     for url_row in url_rows:
 
@@ -636,12 +633,10 @@ def select_url_by_title(browser: WebDriver, url_title: str):
         ).get_attribute("innerText")
         if url_row_title == url_title:
             url_row.click()
-            return True
-
-    return False
+            return
 
 
-def select_url_by_url_string(browser: WebDriver, url_string: str) -> bool:
+def select_url_by_url_string(browser: WebDriver, url_string: str):
     """
     If a UTub is selected and the UTub contains URLs, this function shall select the URL row associated with the supplied URL url string.
 
@@ -654,8 +649,7 @@ def select_url_by_url_string(browser: WebDriver, url_string: str) -> bool:
     """
 
     url_rows = wait_then_get_elements(browser, HPL.ROWS_URLS)
-    if url_rows is None:
-        return False
+    assert url_rows
 
     for url_row in url_rows:
 
@@ -664,9 +658,7 @@ def select_url_by_url_string(browser: WebDriver, url_string: str) -> bool:
         ).get_attribute("data-url")
         if url_row_string == url_string:
             url_row.click()
-            return True
-
-    return False
+            return
 
 
 def verify_elem_with_url_string_exists(browser: WebDriver, url_string: str) -> bool:
@@ -879,7 +871,13 @@ def get_tag_badge_by_name(url_row: WebElement, tag_name: str) -> WebElement | No
 
 
 def add_mock_urls(runner: FlaskCliRunner, urls: list[str]):
-    args = ["addmock", "url"] + urls
+    args = (
+        ["addmock", "url"]
+        + urls
+        + [
+            "--no-dupes",
+        ]
+    )
     runner.invoke(args=args)
 
 

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -405,33 +405,23 @@ def assert_login(browser: WebDriver):
 
 
 # UTub Deck
-def select_utub_by_name(browser: WebDriver, utub_name: str) -> bool:
+def select_utub_by_name(browser: WebDriver, utub_name: str):
     """
     Selects the first UTub selector matching the supplied UTub name
 
     Args:
         WebDriver open to U4I Home Page
         Name of UTub to be selected
-
-    Returns:
-        Boolean confirmation of UTub selection
     """
 
-    try:
-        utub_list = wait_then_get_element(browser, HPL.LIST_UTUB)
-        assert utub_list is not None
+    utub_selectors = wait_then_get_elements(browser, HPL.SELECTORS_UTUB)
+    assert utub_selectors
 
-        utub_selectors = utub_list.find_elements(By.CSS_SELECTOR, "*")
+    for selector in utub_selectors:
+        utub_name_elem = selector.find_element(By.CSS_SELECTOR, HPL.SELECTORS_UTUB_NAME)
 
-        for selector in utub_selectors:
-            utub_selector_name = selector.get_attribute("innerText")
-
-            if utub_selector_name == utub_name:
-                selector.click()
-                return True
-    except AttributeError:
-        return False
-    return False
+        if utub_name_elem.text == utub_name:
+            selector.click()
 
 
 def login_utub(
@@ -513,23 +503,7 @@ def get_selected_utub_name(browser: WebDriver) -> str:
         By.CSS_SELECTOR, HPL.SELECTOR_SELECTED_UTUB
     )
 
-    utub_name = selected_utub_selector.get_attribute("innerText")
-    assert isinstance(utub_name, str)
-
-    return utub_name
-
-
-def get_selected_utub_decsription(browser: WebDriver):
-    """
-    Extracts description of selected UTub.
-
-    Args:
-        WebDriver open to a selected UTub
-
-    Returns:
-        String containing the selected UTub description.
-    """
-    return browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK).text
+    return selected_utub_selector.text
 
 
 # Members Deck

--- a/tests/functional/utubs_ui/test_delete_utub_ui.py
+++ b/tests/functional/utubs_ui/test_delete_utub_ui.py
@@ -14,12 +14,13 @@ from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.urls_ui.utils_for_test_url_ui import get_selected_utub_id
 from tests.functional.utils_for_test import (
     dismiss_modal_with_click_out,
-    login_user_select_utub_by_name_and_url_by_title,
+    login_user_and_select_utub_by_name,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
     wait_until_visible_css_selector,
 )
+from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
 
 pytestmark = pytest.mark.utubs_ui
 
@@ -35,13 +36,10 @@ def test_open_delete_utub_modal(
 
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
-
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
 
     utub_delete_btn = wait_then_get_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
     assert utub_delete_btn is not None
@@ -69,13 +67,10 @@ def test_dismiss_delete_utub_modal_x(
 
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
-
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
 
     delete_utub_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
     assert not delete_utub_modal.is_displayed()
@@ -100,13 +95,10 @@ def test_dismiss_delete_utub_modal_btn(
 
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
-
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
 
     delete_utub_modal = browser.find_element(By.CSS_SELECTOR, HPL.HOME_MODAL)
     assert not delete_utub_modal.is_displayed()
@@ -131,8 +123,9 @@ def test_dismiss_delete_utub_modal_key(
 
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
 
     with app.app_context():
@@ -164,13 +157,10 @@ def test_dismiss_delete_utub_modal_click(
 
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
-
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
 
     wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
 
@@ -190,13 +180,10 @@ def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Fla
 
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
-
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
 
     utub_id = get_selected_utub_id(browser)
     css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
@@ -225,13 +212,10 @@ def test_delete_last_utub_no_urls_no_tags_no_members(
     """
     app = provide_app
     user_id_for_test = 1
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
-
-    with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
 
     wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
 
@@ -273,16 +257,17 @@ def test_delete_last_utub_with_urls_tags_members(
     app = provide_app
     user_id_for_test = 1
 
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+
     with app.app_context():
-        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
-        assert utub.utub_creator == user_id_for_test
         Utub_Members.query.filter(
-            Utub_Members.user_id == user_id_for_test, Utub_Members.utub_id != utub.id
+            Utub_Members.user_id == user_id_for_test,
+            Utub_Members.utub_id != utub_user_created.id,
         ).delete()
         db.session.commit()
 
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+    login_user_and_select_utub_by_name(
+        app, browser, user_id_for_test, utub_user_created.name
     )
 
     wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)

--- a/tests/ui_test_utils.py
+++ b/tests/ui_test_utils.py
@@ -19,8 +19,15 @@ def run_app(port: int, show_flask_logs: bool):
     app_for_test = create_app(config)
     assert app_for_test is not None
     if not show_flask_logs:
+        # Hide all possible logs from showing when running tests
+        # https://stackoverflow.com/a/72145406
         log = logging.getLogger("werkzeug")
         log.disabled = True
+        app_for_test.logger.disabled = True
+
+        import flask.cli
+
+        flask.cli.show_server_banner = lambda *args: None
     app_for_test.run(debug=False, port=port)
 
 


### PR DESCRIPTION
Adds sad path tests for members in a UTub, involving - 

- [x] Creating a UTub member as UTub creator
- [x] Deleting a UTub member as UTub creator
- [x] Leaving a UTub as a UTub member  

Removes unnecessary logs shown when the `--FL` option is not passed running the UI tests.

Closes #349 