### PR TITLE
Ensure update UTub desc btn hidden when no UTub selected, and hidden on home page load

### DIFF
--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -295,6 +295,9 @@ function resetURLDeckOnDeleteUTub() {
   hideIfShown($("#urlBtnCreate"));
   hideIfShown($("#NoURLsSubheader"));
   hideIfShown($("#urlBtnDeckCreateWrap"));
+  $("#updateUTubDescriptionBtn")
+    .removeClass("visibleBtn")
+    .addClass("hiddenBtn");
 }
 
 // Prevent editing URL title when needed

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -193,6 +193,10 @@ function createUTubSuccess(response) {
 
 // Handle error response display to user
 function createUTubFail(xhr) {
+  if (!xhr.hasOwnProperty("responseJSON")) {
+    window.location.assign(routes.errorPage);
+    return;
+  }
   switch (xhr.status) {
     case 400:
       const responseJSON = xhr.responseJSON;

--- a/src/templates/home/URLDeck/URLDeckSubheader.html
+++ b/src/templates/home/URLDeck/URLDeckSubheader.html
@@ -2,7 +2,7 @@
 	<div class="flex-row align-center" id="UTubDescriptionSubheaderWrap">
 		<h5 id="URLDeckSubheader">Select a UTub</h5>
 		<!-- Update UTub description button -->
-		<i id="updateUTubDescriptionBtn" class="mx-1" style="display: none;">
+		<i id="updateUTubDescriptionBtn" class="mx-1 hiddenBtn" style="display: none;">
 			<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"
 				class="bi bi-pencil-square updateIcon" viewBox="0 0 16 16">
 				<path

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -415,6 +415,31 @@ def assert_login(browser: WebDriver):
     assert user_logged_in.text == userLoggedInText
 
 
+def assert_login_with_username(browser: WebDriver, username: str):
+    """
+    Streamlines actions needed to confirm a user is logged in.
+
+    Args:
+        WebDriver open to U4I Home Page
+
+    Returns:
+        Boolean True, if logged in
+    """
+
+    # Confirm user logged in
+    # Logout button visible
+    btn_logout = wait_then_get_element(browser, HPL.BUTTON_LOGOUT)
+    assert btn_logout is not None
+    assert btn_logout.text == "Logout"
+
+    # Correct user logged in
+    user_logged_in = wait_then_get_element(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert user_logged_in is not None
+    userLoggedInText = "Logged in as " + username
+
+    assert user_logged_in.text == userLoggedInText
+
+
 # UTub Deck
 def select_utub_by_name(browser: WebDriver, utub_name: str):
     """

--- a/tests/functional/utubs_ui/test_delete_utub_ui.py
+++ b/tests/functional/utubs_ui/test_delete_utub_ui.py
@@ -20,7 +20,10 @@ from tests.functional.utils_for_test import (
     wait_until_hidden,
     wait_until_visible_css_selector,
 )
-from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
+from tests.functional.utubs_ui.utils_for_test_utub_ui import (
+    assert_elems_hidden_after_utub_deleted,
+    get_utub_this_user_created,
+)
 
 pytestmark = pytest.mark.utubs_ui
 
@@ -173,9 +176,9 @@ def test_dismiss_delete_utub_modal_click(
 
 def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Flask):
     """
-    GIVEN a user trying to add a new UTub
-    WHEN they submit the addUTub form
-    THEN ensure the appropriate input field is shown and in focus
+    GIVEN a user trying to delete one of the UTubs they created
+    WHEN they try to delete the UTub
+    THEN ensure the UTub selector is removed, and all relevant buttons are hidden
     """
 
     app = provide_app
@@ -201,6 +204,9 @@ def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Fla
         css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
         browser.find_element(By.CSS_SELECTOR, css_selector)
 
+    # Assert that the no utub selected UI is shown
+    assert_elems_hidden_after_utub_deleted(browser)
+
 
 def test_delete_last_utub_no_urls_no_tags_no_members(
     browser: WebDriver, create_test_utubs, provide_app: Flask
@@ -225,16 +231,7 @@ def test_delete_last_utub_no_urls_no_tags_no_members(
     wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
 
     # Make sure all relevant buttons and subheaders are hidden when no UTub selected
-    non_visible_elems = (
-        HPL.BUTTON_UTUB_DELETE,
-        HPL.BUTTON_MEMBER_CREATE,
-        HPL.BUTTON_UTUB_TAG_CREATE,
-        HPL.BUTTON_CORNER_URL_CREATE,
-        HPL.SUBHEADER_TAG_DECK,
-    )
-
-    for elem in non_visible_elems:
-        assert not browser.find_element(By.CSS_SELECTOR, elem).is_displayed()
+    assert_elems_hidden_after_utub_deleted(browser)
 
     assert (
         browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK).text
@@ -278,16 +275,7 @@ def test_delete_last_utub_with_urls_tags_members(
     wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
 
     # Make sure all relevant buttons and subheaders are hidden when no UTub selected
-    non_visible_elems = (
-        HPL.BUTTON_UTUB_DELETE,
-        HPL.BUTTON_MEMBER_CREATE,
-        HPL.BUTTON_UTUB_TAG_CREATE,
-        HPL.BUTTON_CORNER_URL_CREATE,
-        HPL.SUBHEADER_TAG_DECK,
-    )
-
-    for elem in non_visible_elems:
-        assert not browser.find_element(By.CSS_SELECTOR, elem).is_displayed()
+    assert_elems_hidden_after_utub_deleted(browser)
 
     assert (
         browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK).text

--- a/tests/functional/utubs_ui/test_update_utub_description_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_description_ui.py
@@ -7,9 +7,11 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 from locators import HomePageLocators as HPL
 from src.cli.mock_constants import MOCK_UTUB_DESCRIPTION
+from src.models.users import Users
 from src.utils.constants import CONSTANTS
 from src.utils.strings.utub_strs import UTUB_FAILURE
 from tests.functional.utils_for_test import (
+    assert_login_with_username,
     assert_not_visible_css_selector,
     clear_then_send_keys,
     login_user_and_select_utub_by_name,
@@ -507,3 +509,30 @@ def test_update_utub_description_form_closes_when_selecting_other_utub(
     )
 
     assert not utub_desc_update_input.is_displayed()
+
+
+def test_open_update_utub_description_btn_not_visible_with_no_utub_selected(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a user's ability to not see the update UTub description button when no UTub selected.
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user selects a UTub they created, then clicks the edit UTub description button
+    THEN ensure the updateUTubDescription input opens
+    """
+    app = provide_app
+    user_id = 1
+    with app.app_context():
+        user: Users = Users.query.get(user_id)
+        username = user.username
+    selected_utub = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB, time=3)
+    assert selected_utub is None
+
+    login_user_to_home_page(app, browser, user_id)
+    assert_login_with_username(browser, username)
+
+    update_utub_desc_btn = browser.find_element(
+        By.CSS_SELECTOR, HPL.BUTTON_UTUB_DESCRIPTION_UPDATE
+    )
+    assert not update_utub_desc_btn.is_displayed()

--- a/tests/functional/utubs_ui/utils_for_test_utub_ui.py
+++ b/tests/functional/utubs_ui/utils_for_test_utub_ui.py
@@ -92,6 +92,32 @@ def assert_active_utub(browser: WebDriver, utub_name: str):
     assert current_url_deck_header.text == utub_name
 
 
+def assert_elems_hidden_after_utub_deleted(browser: WebDriver):
+    non_visible_elems = (
+        HPL.BUTTON_UTUB_DELETE,
+        HPL.BUTTON_MEMBER_CREATE,
+        HPL.BUTTON_UTUB_TAG_CREATE,
+        HPL.BUTTON_CORNER_URL_CREATE,
+        HPL.SUBHEADER_TAG_DECK,
+    )
+
+    for elem in non_visible_elems:
+        assert not browser.find_element(By.CSS_SELECTOR, elem).is_displayed()
+
+    update_utub_desc_btn = browser.find_element(
+        By.CSS_SELECTOR, HPL.BUTTON_UTUB_DESCRIPTION_UPDATE
+    )
+    assert HPL.HIDDEN_BTN_CLASS in update_utub_desc_btn.get_dom_attribute("class")
+
+    update_utub_name_btn = browser.find_element(
+        By.CSS_SELECTOR, HPL.BUTTON_UTUB_NAME_UPDATE
+    )
+    assert (
+        HPL.HIDDEN_BTN_CLASS in update_utub_name_btn.get_dom_attribute("class")
+        or not update_utub_name_btn.is_displayed()
+    )
+
+
 def open_update_utub_name_input(browser: WebDriver):
     """
     Once logged in and UTub selected, this function conducts the actions for opening either the update UTub name or description input field. First hover over the UTub name or description to display the edit button. Then clicks the edit button.


### PR DESCRIPTION
Ensures the update UTub description button is hidden on page load, and hidden after deleting a UTub a user created.

Closes #365 