### PR TITLE
Frontend sad path url tests for create URL, and fix for URL validation

### DIFF
--- a/src/extensions/url_validation/url_validator.py
+++ b/src/extensions/url_validation/url_validator.py
@@ -311,6 +311,17 @@ class UrlValidator:
                 return response
 
             redirect_url = response.headers.get(VALIDATION_STRS.LOCATION, "")
+
+            # Check for proper schema, some responses include a relative URL in the LOCATION header
+            # so that needs to be checked here as well
+            if (
+                deconstruct_url(redirect_url).scheme != "https"
+                and response.next
+                and response.next.url
+                and deconstruct_url(response.next.url).scheme == "https"
+            ):
+                redirect_url = response.next.url
+
             response = requests.get(
                 redirect_url,
                 timeout=(
@@ -702,9 +713,10 @@ if __name__ == "__main__":
         "https://developers.google.com/calendar/api/guides/overview",
         "https://developers.google.com/keep/api/reference/rest",
         "https://www.lenovo.com/us/en/p/laptops/thinkpad/thinkpadt/thinkpad-t16-gen-2-16-inch-amd/len101t0076#ports_slots",
+        "https://www.stackoverflow.com/",
     )
 
-    print(validator.validate_url(INVALID_URLS[1]))
+    print(validator.validate_url(INVALID_URLS[-1]))
     # for invalid_url in INVALID_URLS:
     #    print(validator.validate_url(invalid_url))
     print("Trying to run as script")

--- a/src/templates/_routes_constants.html
+++ b/src/templates/_routes_constants.html
@@ -5,7 +5,7 @@
                 // UTub routes
 
                 this.createUTub = "{{url_for('utubs.create_utub')}}";
-                this.deleteUTub = (utub_id) => 
+                this.deleteUTub = (utub_id) =>
                     "{{url_for('utubs.delete_utub', utub_id=-1)}}".replace("-1", utub_id);
                 this.updateUTubName = (utub_id) =>
                     "{{url_for('utubs.update_utub_name', utub_id=-1)}}".replace("-1", utub_id);
@@ -50,9 +50,9 @@
                         .replace("-1", utub_id)
 
                 // Member routes
-                this.createMember = (utub_id) => 
+                this.createMember = (utub_id) =>
                     "{{url_for('members.create_member', utub_id=-1)}}".replace("-1", utub_id);
-                this.removeMember = (utub_id, user_id) => 
+                this.removeMember = (utub_id, user_id) =>
                     "{{url_for('members.remove_member', utub_id=-1, user_id=-4)}}"
                         .replace("-1", utub_id)
                         .replace("-4", user_id);
@@ -63,10 +63,10 @@
                 this.confirmEmailAfterRegister = "{{url_for('splash.confirm_email_after_register')}}";
                 this.sendValidationEmail = "{{url_for('splash.send_validation_email')}}";
                 this.forgotPassword = "{{url_for('splash.forgot_password')}}";
-                
+
                 // Util routes
                 this.errorPage = "{{url_for('splash.error_page')}}";
-                
+
                 // Logout
                 this.logout = "{{url_for('users.logout')}}";
 
@@ -83,26 +83,28 @@
             if (!Constants.instance) {
 
                 // UTub constants
-                this.UTUBS_MAX_NAME_LENGTH = {{CONSTANTS.UTUBS.MAX_NAME_LENGTH}};
-                this.UTUBS_MIN_NAME_LENGTH = {{CONSTANTS.UTUBS.MIN_NAME_LENGTH}};
+                this.UTUBS_MAX_NAME_LENGTH = {{CONSTANTS.UTUBS.MAX_NAME_LENGTH}
+            };
+            this.UTUBS_MIN_NAME_LENGTH = {{CONSTANTS.UTUBS.MIN_NAME_LENGTH}
+        };
                 this.UTUBS_MAX_DESCRIPTION_LENGTH = {{CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH}}
 
-                // URL Constants
-                this.URLS_TITLE_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}}
-                this.URLS_TITLE_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}}
-                this.URLS_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_LENGTH}}
-                this.URLS_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_LENGTH}}
-                this.MAX_NUM_OF_URLS_TO_ACCESS = {{CONSTANTS.URLS.MAX_NUM_OF_URLS_TO_ACCESS}}
+    // URL Constants
+    this.URLS_TITLE_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}}
+    this.URLS_TITLE_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}}
+    this.URLS_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_LENGTH}}
+    this.URLS_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_LENGTH}}
+    this.MAX_NUM_OF_URLS_TO_ACCESS = {{CONSTANTS.URLS.MAX_NUM_OF_URLS_TO_ACCESS}}
 
-                // Tag Constants
-                this.TAGS_MIN_LENGTH = {{CONSTANTS.TAGS.MIN_TAG_LENGTH}}
-                this.TAGS_MAX_LENGTH = {{CONSTANTS.TAGS.MAX_TAG_LENGTH}}
-                this.TAGS_MAX_ON_URLS = {{CONSTANTS.TAGS.MAX_URL_TAGS}}
+    // Tag Constants
+    this.TAGS_MIN_LENGTH = {{CONSTANTS.TAGS.MIN_TAG_LENGTH}}
+    this.TAGS_MAX_LENGTH = {{CONSTANTS.TAGS.MAX_TAG_LENGTH}}
+    this.TAGS_MAX_ON_URLS = {{CONSTANTS.TAGS.MAX_URL_TAGS}}
 
-                Constants.instance = this;
+    Constants.instance = this;
             }
 
-            return Constants.instance;
+    return Constants.instance;
         }
     }
     const CONSTANTS = new Constants;

--- a/src/templates/_routes_constants.html
+++ b/src/templates/_routes_constants.html
@@ -83,28 +83,26 @@
             if (!Constants.instance) {
 
                 // UTub constants
-                this.UTUBS_MAX_NAME_LENGTH = {{CONSTANTS.UTUBS.MAX_NAME_LENGTH}
-            };
-            this.UTUBS_MIN_NAME_LENGTH = {{CONSTANTS.UTUBS.MIN_NAME_LENGTH}
-        };
+                this.UTUBS_MAX_NAME_LENGTH = {{CONSTANTS.UTUBS.MAX_NAME_LENGTH}}
+                this.UTUBS_MIN_NAME_LENGTH = {{CONSTANTS.UTUBS.MIN_NAME_LENGTH}}
                 this.UTUBS_MAX_DESCRIPTION_LENGTH = {{CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH}}
 
-    // URL Constants
-    this.URLS_TITLE_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}}
-    this.URLS_TITLE_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}}
-    this.URLS_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_LENGTH}}
-    this.URLS_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_LENGTH}}
-    this.MAX_NUM_OF_URLS_TO_ACCESS = {{CONSTANTS.URLS.MAX_NUM_OF_URLS_TO_ACCESS}}
+                // URL Constants
+                this.URLS_TITLE_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}}
+                this.URLS_TITLE_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}}
+                this.URLS_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_LENGTH}}
+                this.URLS_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_LENGTH}}
+                this.MAX_NUM_OF_URLS_TO_ACCESS = {{CONSTANTS.URLS.MAX_NUM_OF_URLS_TO_ACCESS}}
 
-    // Tag Constants
-    this.TAGS_MIN_LENGTH = {{CONSTANTS.TAGS.MIN_TAG_LENGTH}}
-    this.TAGS_MAX_LENGTH = {{CONSTANTS.TAGS.MAX_TAG_LENGTH}}
-    this.TAGS_MAX_ON_URLS = {{CONSTANTS.TAGS.MAX_URL_TAGS}}
+                // Tag Constants
+                this.TAGS_MIN_LENGTH = {{CONSTANTS.TAGS.MIN_TAG_LENGTH}}
+                this.TAGS_MAX_LENGTH = {{CONSTANTS.TAGS.MAX_TAG_LENGTH}}
+                this.TAGS_MAX_ON_URLS = {{CONSTANTS.TAGS.MAX_URL_TAGS}}
 
-    Constants.instance = this;
+                Constants.instance = this;
             }
 
-    return Constants.instance;
+            return Constants.instance;
         }
     }
     const CONSTANTS = new Constants;

--- a/src/utils/strings/ui_testing_strs.py
+++ b/src/utils/strings/ui_testing_strs.py
@@ -52,6 +52,5 @@ class UI_TEST_STRINGS:
     TEST_URL_TITLE_UPDATE = "MS Support"
 
     MAX_CHAR_LIM_URL_STRING = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Obcaecati necessitatibus suscipit labore sapiente dignissimos hic voluptatem modi vero ipsam cupiditate?"
-    MAX_CHAR_LIM_URL_TITLE = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Obcaecati necessitatibus suscipit labore sapiente dignissimos hic voluptatem modi vero ipsam cupiditate?"
 
     MESSAGE_NO_URLS = "No URLs here - add one!"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -109,6 +109,7 @@ def build_driver(
     if config.DOCKER:
         driver_path = environ.get("CHROMEDRIVER_PATH", "")
         service = webdriver.ChromeService(executable_path=driver_path)
+        options.add_argument("--user-data-dir=/tmp/chrome-user-data")
         driver = webdriver.Chrome(service=service, options=options)
     else:
         driver = webdriver.Chrome(options=options)

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -1,7 +1,3 @@
-# Standard libraries
-from time import sleep
-
-# External libraries
 from flask import Flask
 import pytest
 from selenium.webdriver.common.by import By
@@ -13,19 +9,25 @@ from src.cli.mock_constants import (
     MOCK_URL_TITLES,
     MOCK_URL_STRINGS,
 )
+from src.utils.constants import CONSTANTS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     assert_not_visible_css_selector,
     clear_then_send_keys,
     get_selected_url,
+    get_url_row_by_id,
     login_user_and_select_utub_by_name,
+    login_user_and_select_utub_by_utubid,
     login_user_select_utub_by_name_and_url_by_title,
     wait_then_click_element,
     wait_then_get_element,
-    wait_then_get_elements,
+    wait_until_hidden,
 )
-from tests.functional.urls_ui.utils_for_test_url_ui import create_url
+from tests.functional.urls_ui.utils_for_test_url_ui import (
+    get_newly_added_utub_url_id_by_url_string,
+)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
 
 pytestmark = pytest.mark.urls_ui
 
@@ -53,6 +55,7 @@ def test_create_url_open_input_no_urls_corner_btn(
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     assert_not_visible_css_selector(browser, HPL.BUTTON_DECK_URL_CREATE)
@@ -87,6 +90,7 @@ def test_create_url_open_input_no_urls_deck_btn(
     wait_then_click_element(browser, HPL.BUTTON_DECK_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     assert_not_visible_css_selector(browser, HPL.BUTTON_DECK_URL_CREATE)
@@ -124,6 +128,7 @@ def test_create_url_open_input_with_added_urls(
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     url_title_create_elemnent = browser.find_element(
@@ -156,6 +161,7 @@ def test_create_url_cancel_input_click_button(
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     wait_then_click_element(browser, HPL.BUTTON_URL_CANCEL_CREATE)
@@ -187,6 +193,7 @@ def test_create_url_cancel_input_escape(
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     browser.switch_to.active_element.send_keys(Keys.ESCAPE)
@@ -207,8 +214,10 @@ def test_create_url_submit_btn(
     """
     app = provide_app
     user_id_for_test = 1
-    login_user_and_select_utub_by_name(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
     )
 
     url_title = MOCK_URL_TITLES[0]
@@ -217,36 +226,35 @@ def test_create_url_submit_btn(
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     # Input new URL Title
     url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
+    assert url_title_input_field is not None
     clear_then_send_keys(url_title_input_field, url_title)
 
     # Input new URL String
     url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
+    assert url_string_input_field is not None
     clear_then_send_keys(url_string_input_field, url_string)
 
-    submit_btn = browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_URL_SUBMIT_CREATE)
-    submit_btn.click()
+    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE, time=3)
 
     # Wait for HTTP request to complete
-    sleep(4)
-
-    # Extract URL title and string from new row in URL deck
-    url_row = wait_then_get_elements(browser, HPL.ROWS_URLS)
-    assert url_row is not None
-    url_row = url_row[0]
-
+    wait_until_hidden(browser, HPL.INPUT_URL_STRING_CREATE, timeout=3)
     url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    url_row_title = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_TITLE_READ)[
-        0
-    ].get_attribute("innerText")
-    url_row_string = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_STRING_READ)[
-        0
-    ].get_attribute("innerText")
+    # Extract URL title and string from new row in URL deck
+    utub_url_id = get_newly_added_utub_url_id_by_url_string(
+        app, utub_user_created.id, url_string
+    )
+    url_row = get_url_row_by_id(browser, utub_url_id)
+    assert url_row is not None
+
+    url_row_title = url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).text
+    url_row_string = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).text
 
     assert url_title == url_row_title
     assert url_string == url_row_string
@@ -254,8 +262,6 @@ def test_create_url_submit_btn(
     assert browser.find_element(
         By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS
     ).is_displayed()
-
-    assert not browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE).is_displayed()
 
 
 def test_create_url_using_enter_key(
@@ -270,8 +276,10 @@ def test_create_url_using_enter_key(
     """
     app = provide_app
     user_id_for_test = 1
-    login_user_and_select_utub_by_name(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
     )
 
     url_title = MOCK_URL_TITLES[0]
@@ -280,35 +288,35 @@ def test_create_url_using_enter_key(
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
     url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
     assert url_creation_row.is_displayed()
 
     # Input new URL Title
     url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
+    assert url_title_input_field is not None
     clear_then_send_keys(url_title_input_field, url_title)
 
     # Input new URL String
     url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
+    assert url_string_input_field is not None
     clear_then_send_keys(url_string_input_field, url_string)
 
     browser.switch_to.active_element.send_keys(Keys.ENTER)
 
     # Wait for HTTP request to complete
-    sleep(4)
-
-    # Extract URL title and string from new row in URL deck
-    url_row = wait_then_get_elements(browser, HPL.ROWS_URLS)
-    assert url_row is not None
-    url_row = url_row[0]
-
+    wait_until_hidden(browser, HPL.INPUT_URL_STRING_CREATE, timeout=3)
     url_creation_row = browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE)
     assert not url_creation_row.is_displayed()
 
-    url_row_title = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_TITLE_READ)[
-        0
-    ].get_attribute("innerText")
-    url_row_string = url_row.find_elements(By.CSS_SELECTOR, HPL.URL_STRING_READ)[
-        0
-    ].get_attribute("innerText")
+    # Extract URL title and string from new row in URL deck
+    utub_url_id = get_newly_added_utub_url_id_by_url_string(
+        app, utub_user_created.id, url_string
+    )
+    url_row = get_url_row_by_id(browser, utub_url_id)
+    assert url_row is not None
+
+    url_row_title = url_row.find_element(By.CSS_SELECTOR, HPL.URL_TITLE_READ).text
+    url_row_string = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).text
 
     assert url_title == url_row_title
     assert url_string == url_row_string
@@ -317,12 +325,7 @@ def test_create_url_using_enter_key(
         By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS
     ).is_displayed()
 
-    assert not browser.find_element(By.CSS_SELECTOR, HPL.WRAP_URL_CREATE).is_displayed()
 
-
-@pytest.mark.skip(
-    reason="Not on happy path. This test tests functionality that is not yet captured on the frontend"
-)
 def test_create_url_title_length_exceeded(
     browser: WebDriver, create_test_utubs, provide_app: Flask
 ):
@@ -337,15 +340,33 @@ def test_create_url_title_length_exceeded(
     # Login test user and select first test UTub
     app = provide_app
 
-    user_id = 1
-    login_user_and_select_utub_by_name(app, browser, user_id, UTS.TEST_UTUB_NAME_1)
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
 
-    create_url(browser, UTS.MAX_CHAR_LIM_URL_TITLE, MOCK_URL_STRINGS[0])
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
 
-    warning_modal_body = wait_then_get_element(browser, HPL.BODY_MODAL)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
+    assert url_creation_row.is_displayed()
 
-    # Assert new UTub is now active and displayed to user
-    assert warning_modal_body.text == "Try shortening your UTub name"
+    # Input new URL Title
+    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
+    assert url_title_input_field is not None
+    clear_then_send_keys(
+        url_title_input_field, "a" * CONSTANTS.URLS.MAX_URL_TITLE_LENGTH
+    )
+
+    create_url_title_input = wait_then_get_element(
+        browser, HPL.INPUT_URL_TITLE_CREATE, time=3
+    )
+    assert create_url_title_input is not None
+    new_url_title = create_url_title_input.get_attribute("value")
+    assert new_url_title is not None
+
+    assert len(new_url_title) == CONSTANTS.URLS.MAX_URL_TITLE_LENGTH
 
 
 def test_select_url(browser: WebDriver, create_test_urls, provide_app: Flask):
@@ -358,17 +379,18 @@ def test_select_url(browser: WebDriver, create_test_urls, provide_app: Flask):
     """
     app = provide_app
     user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
     login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, UTS.TEST_UTUB_NAME_1, UTS.TEST_URL_TITLE_1
+        app, browser, user_id_for_test, utub_user_created.name, UTS.TEST_URL_TITLE_1
     )
 
     url_row = get_selected_url(browser)
 
     assert "true" == url_row.get_attribute("urlselected")
-    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TAGS_READ).is_displayed
+    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TAGS_READ).is_displayed()
     assert url_row.find_element(
         By.CSS_SELECTOR, HPL.URL_BUTTONS_OPTIONS_READ
-    ).is_displayed
+    ).is_displayed()
     url_string = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
     assert url_string.get_attribute(HPL.URL_STRING_IN_DATA) in MOCK_URL_STRINGS
 

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -4,28 +4,33 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
-# Internal libraries
 from src.cli.mock_constants import (
     MOCK_URL_TITLES,
     MOCK_URL_STRINGS,
 )
+from src.models.users import Users
+from src.models.utub_urls import Utub_Urls
 from src.utils.constants import CONSTANTS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from src.utils.strings.url_strs import URL_FAILURE
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
+    assert_login_with_username,
     assert_not_visible_css_selector,
+    assert_visited_403_on_invalid_csrf_and_reload,
     clear_then_send_keys,
-    get_selected_url,
     get_url_row_by_id,
+    invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     login_user_and_select_utub_by_utubid,
-    login_user_select_utub_by_name_and_url_by_title,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
+    wait_until_visible_css_selector,
 )
 from tests.functional.urls_ui.utils_for_test_url_ui import (
+    create_url,
+    fill_create_url_form,
     get_newly_added_utub_url_id_by_url_string,
 )
 from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
@@ -224,22 +229,7 @@ def test_create_url_submit_btn(
     url_title = MOCK_URL_TITLES[0]
     url_string = MOCK_URL_STRINGS[0]
 
-    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
-
-    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
-    assert url_creation_row is not None
-    assert url_creation_row.is_displayed()
-
-    # Input new URL Title
-    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
-    assert url_title_input_field is not None
-    clear_then_send_keys(url_title_input_field, url_title)
-
-    # Input new URL String
-    url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
-    assert url_string_input_field is not None
-    clear_then_send_keys(url_string_input_field, url_string)
-
+    fill_create_url_form(browser, url_title, url_string)
     wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE, time=3)
 
     # Wait for HTTP request to complete
@@ -286,22 +276,7 @@ def test_create_url_using_enter_key(
     url_title = MOCK_URL_TITLES[0]
     url_string = MOCK_URL_STRINGS[0]
 
-    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
-
-    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
-    assert url_creation_row is not None
-    assert url_creation_row.is_displayed()
-
-    # Input new URL Title
-    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
-    assert url_title_input_field is not None
-    clear_then_send_keys(url_title_input_field, url_title)
-
-    # Input new URL String
-    url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
-    assert url_string_input_field is not None
-    clear_then_send_keys(url_string_input_field, url_string)
-
+    fill_create_url_form(browser, url_title, url_string)
     browser.switch_to.active_element.send_keys(Keys.ENTER)
 
     # Wait for HTTP request to complete
@@ -411,31 +386,220 @@ def test_create_url_empty_fields(
     assert invalid_url_string_error.text == URL_FAILURE.FIELD_REQUIRED_STR
 
 
-def test_select_url(browser: WebDriver, create_test_urls, provide_app: Flask):
+def test_create_url_empty_title(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
     """
-    Tests a user's ability to select a URL and see more details
+    Tests the site error response to a user's attempt to create a new URL with an empty URL title.
 
-    GIVEN a user trying to add a new UTub
-    WHEN they submit the addUTub form
-    THEN ensure the appropriate input field is shown and in focus
+    GIVEN a user and selected UTub
+    WHEN the createURL form is submitted with an empty URL title
+    THEN ensure the appropriate error and prompt is shown to user.
+    """
+    # Login test user and select first test UTub
+    app = provide_app
+
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
+
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
+    assert url_creation_row.is_displayed()
+
+    url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
+    assert url_string_input_field is not None
+    clear_then_send_keys(url_string_input_field, MOCK_URL_STRINGS[0])
+
+    # Submit URL
+    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE, time=3)
+
+    invalid_url_title_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_TITLE_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_title_error is not None
+    assert invalid_url_title_error.text == URL_FAILURE.FIELD_REQUIRED_STR
+
+
+def test_create_url_empty_string(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests the site error response to a user's attempt to create a new URL with an empty URL string.
+
+    GIVEN a user and selected UTub
+    WHEN the createURL form is submitted with an empty URL string
+    THEN ensure the appropriate error and prompt is shown to user.
+    """
+    # Login test user and select first test UTub
+    app = provide_app
+
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
+
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
+    assert url_creation_row.is_displayed()
+
+    url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
+    assert url_title_input_field is not None
+    clear_then_send_keys(url_title_input_field, "Testing")
+
+    # Submit URL
+    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE, time=3)
+
+    invalid_url_string_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_STRING_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_string_error is not None
+    assert invalid_url_string_error.text == URL_FAILURE.FIELD_REQUIRED_STR
+
+
+def test_invalid_url_input(browser: WebDriver, create_test_utubs, provide_app: Flask):
+    """
+    Tests the site error response to a user's attempt to create an invalid URL
+
+    GIVEN a user and selected UTub
+    WHEN the createURL form is submitted with an invalid URL
+    THEN ensure the appropriate error and prompt is shown to user.
+    """
+    # Login test user and select first test UTub
+    app = provide_app
+
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
+
+    browser.execute_script(
+        """
+        (function() {
+            var originalBeforeSend = $.ajaxSetup().beforeSend;
+
+            $.ajaxSetup({
+                beforeSend: function(xhr, settings) {
+                    if (originalBeforeSend) {
+                        originalBeforeSend(xhr, settings); // Preserve existing behavior
+                    }
+                    xhr.setRequestHeader("X-U4I-Testing-Invalid", "true");
+                }
+            });
+        })();
+    """
+    )
+
+    create_url(browser, url_title="Test", url_string="Test")
+
+    wait_until_visible_css_selector(
+        browser, HPL.INPUT_URL_STRING_CREATE + HPL.INVALID_FIELD_SUFFIX, timeout=3
+    )
+
+    invalid_url_string_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_STRING_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_string_error is not None
+    assert invalid_url_string_error.text == URL_FAILURE.UNABLE_TO_VALIDATE_THIS_URL
+
+
+def test_create_url_sanitized_title(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests the site error response to a user's attempt to create a URL with a title that
+    contains improper or unsanitized inputs
+
+    GIVEN a user and selected UTub
+    WHEN the createURL form is submitted with an invalid URL title that is sanitized
+    THEN ensure the appropriate error and prompt is shown to user.
     """
     app = provide_app
     user_id_for_test = 1
     utub_user_created = get_utub_this_user_created(app, user_id_for_test)
-    login_user_select_utub_by_name_and_url_by_title(
-        app, browser, user_id_for_test, utub_user_created.name, UTS.TEST_URL_TITLE_1
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
     )
 
-    url_row = get_selected_url(browser)
+    create_url(browser, url_title='<img src="evl.jpg">', url_string=MOCK_URL_STRINGS[0])
+    wait_until_visible_css_selector(
+        browser, HPL.INPUT_URL_TITLE_CREATE + HPL.INVALID_FIELD_SUFFIX, timeout=3
+    )
 
-    assert "true" == url_row.get_attribute("urlselected")
-    assert url_row.find_element(By.CSS_SELECTOR, HPL.URL_TAGS_READ).is_displayed()
-    assert url_row.find_element(
-        By.CSS_SELECTOR, HPL.URL_BUTTONS_OPTIONS_READ
-    ).is_displayed()
-    url_string = url_row.find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ)
-    assert url_string.get_attribute(HPL.URL_STRING_IN_DATA) in MOCK_URL_STRINGS
+    invalid_url_title_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_TITLE_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_title_error is not None
+    assert invalid_url_title_error.text == URL_FAILURE.INVALID_INPUT
 
 
-# TODO: Check url title sanitization for sad path tests
-# TODO Check invalid CSRF token for sad path tests
+def test_create_url_duplicate_url(
+    browser: WebDriver, create_test_urls, provide_app: Flask
+):
+    """
+    Tests the site error response to a user's attempt to create a URL that is already in the UTub
+
+    GIVEN a user and selected UTub
+    WHEN the createURL form is submitted with a duplicate URL string
+    THEN ensure the appropriate error and prompt is shown to user.
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    with app.app_context():
+        utub_url: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_created.id
+        ).first()
+        url_string_already_added = utub_url.standalone_url.url_string
+
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
+
+    create_url(browser, url_title="Testing", url_string=url_string_already_added)
+
+    invalid_url_string_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_STRING_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_string_error is not None
+    assert invalid_url_string_error.text == URL_FAILURE.URL_IN_UTUB
+
+
+def test_create_url_invalid_csrf_token(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a user's ability to attempt to create a new URL with an invalid CSRF token
+
+    GIVEN a user attempting to create a new URL in a UTub
+    WHEN the createURL form is sent with an invalid CSRF token
+    THEN ensure U4I responds with a proper error message
+    """
+    app = provide_app
+    user_id_for_test = 1
+    with app.app_context():
+        user: Users = Users.query.get(user_id_for_test)
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
+
+    invalidate_csrf_token_on_page(browser)
+    create_url(browser, url_title="Testing", url_string=MOCK_URL_STRINGS[0])
+
+    assert_visited_403_on_invalid_csrf_and_reload(browser)
+
+    # Page reloads after user clicks button in CSRF 403 error page
+    create_utub_name_input = wait_until_hidden(
+        browser, HPL.INPUT_URL_STRING_CREATE, timeout=3
+    )
+    assert not create_utub_name_input.is_displayed()
+    assert_login_with_username(browser, user.username)

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -11,6 +11,7 @@ from src.cli.mock_constants import (
 )
 from src.utils.constants import CONSTANTS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
+from src.utils.strings.url_strs import URL_FAILURE
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     assert_not_visible_css_selector,
@@ -367,6 +368,47 @@ def test_create_url_title_length_exceeded(
     assert new_url_title is not None
 
     assert len(new_url_title) == CONSTANTS.URLS.MAX_URL_TITLE_LENGTH
+
+
+def test_create_url_empty_fields(
+    browser: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests the site error response to a user's attempt to create a new URL with empty fields.
+
+    GIVEN a user and selected UTub
+    WHEN the createURL form is submitted empty
+    THEN ensure the appropriate error and prompt is shown to user.
+    """
+    # Login test user and select first test UTub
+    app = provide_app
+
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_created.id
+    )
+
+    wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
+
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
+    assert url_creation_row.is_displayed()
+
+    # Submit URL
+    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE, time=3)
+
+    invalid_url_title_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_TITLE_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_title_error is not None
+    assert invalid_url_title_error.text == URL_FAILURE.FIELD_REQUIRED_STR
+
+    invalid_url_string_error = wait_then_get_element(
+        browser, HPL.INPUT_URL_STRING_CREATE + HPL.INVALID_FIELD_SUFFIX, time=3
+    )
+    assert invalid_url_string_error is not None
+    assert invalid_url_string_error.text == URL_FAILURE.FIELD_REQUIRED_STR
 
 
 def test_select_url(browser: WebDriver, create_test_urls, provide_app: Flask):

--- a/tests/functional/urls_ui/test_select_url_ui.py
+++ b/tests/functional/urls_ui/test_select_url_ui.py
@@ -138,6 +138,7 @@ def test_select_urls_as_url_creator_and_utub_member(
         assert get_selected_url(browser) == url_row
 
         current_utub_url_id = url_row.get_attribute("urlid")
+        assert current_utub_url_id is not None and isinstance(current_utub_url_id, str)
         if int(current_utub_url_id) == utub_url_id_user_added:
             verify_select_url_as_utub_owner_or_url_creator(browser, url_row)
 

--- a/tests/functional/urls_ui/utils_for_test_url_ui.py
+++ b/tests/functional/urls_ui/utils_for_test_url_ui.py
@@ -1,9 +1,7 @@
-# Standard library
 from time import sleep
 import time
 from typing import Tuple
 
-# External libraries
 from flask import Flask
 import pytest
 from selenium.common.exceptions import NoSuchElementException
@@ -12,7 +10,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 
-# Internal libraries
+from src.models.urls import Urls
 from src.models.utub_urls import Utub_Urls
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import ModalLocators as ML
@@ -312,3 +310,16 @@ def verify_keyed_url_is_selected(browser: WebDriver, url_row: WebElement):
     access_url_btn = wait_until_visible(browser, access_url_btn)
     assert access_url_btn.is_enabled()
     assert access_url_btn.is_displayed()
+
+
+def get_newly_added_utub_url_id_by_url_string(
+    app: Flask, utub_id: int, url_string: str
+) -> int:
+    with app.app_context():
+        url: Urls = Urls.query.filter(Urls.url_string == url_string).first()
+        assert url is not None
+        utub_url: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.url_id == url.id, Utub_Urls.utub_id == utub_id
+        ).first()
+        assert utub_url is not None
+        return utub_url.id

--- a/tests/functional/urls_ui/utils_for_test_url_ui.py
+++ b/tests/functional/urls_ui/utils_for_test_url_ui.py
@@ -34,9 +34,27 @@ def create_url(browser: WebDriver, url_title: str, url_string: str):
         URL title
         URL
     """
+    fill_create_url_form(browser, url_title, url_string)
+
+    # Submit
+    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE)
+
+
+def fill_create_url_form(browser: WebDriver, url_title: str, url_string: str):
+    """
+    Streamlines actions required to create a URL in the selected UTub.
+
+    Args:
+        WebDriver open to a selected UTub
+        URL title
+        URL
+    """
 
     # Select createURL button
     wait_then_click_element(browser, HPL.BUTTON_CORNER_URL_CREATE)
+    url_creation_row = wait_then_get_element(browser, HPL.WRAP_URL_CREATE)
+    assert url_creation_row is not None
+    assert url_creation_row.is_displayed()
 
     # Input new URL Title
     url_title_input_field = wait_then_get_element(browser, HPL.INPUT_URL_TITLE_CREATE)
@@ -47,9 +65,6 @@ def create_url(browser: WebDriver, url_title: str, url_string: str):
     url_string_input_field = wait_then_get_element(browser, HPL.INPUT_URL_STRING_CREATE)
     assert url_string_input_field is not None
     clear_then_send_keys(url_string_input_field, url_string)
-
-    # Submit
-    wait_then_click_element(browser, HPL.BUTTON_URL_SUBMIT_CREATE)
 
 
 def update_url_string(browser: WebDriver, url_row: WebElement, url_string: str):
@@ -208,6 +223,8 @@ def verify_select_url_as_utub_owner_or_url_creator(
     Args:
         url_row (WebElement): URL Card with all visible elements
     """
+
+    assert "true" == url_row.get_attribute("urlselected")
 
     visible_elements = (
         HPL.BUTTON_URL_ACCESS,

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -1,8 +1,6 @@
-# Standard library
 import secrets
 from time import sleep
 
-# External libraries
 from flask import Flask, session
 from flask.testing import FlaskCliRunner
 import pytest
@@ -20,7 +18,6 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 
-# Internal libraries
 from src.models.users import Users
 from src.utils.strings.html_identifiers import IDENTIFIERS
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
@@ -885,8 +882,10 @@ def get_selected_url_title(browser: WebDriver):
     ).get_attribute("innerText")
 
 
-def get_url_row_by_id(browser: WebDriver, urlid: int):
-    return browser.find_element(By.CSS_SELECTOR, HPL.ROWS_URLS + f'[urlid="{urlid}"]')
+def get_url_row_by_id(browser: WebDriver, urlid: int) -> WebElement:
+    url_row = wait_then_get_element(browser, HPL.ROWS_URLS + f'[urlid="{urlid}"]')
+    assert url_row is not None
+    return url_row
 
 
 def get_tag_badge_by_id(browser: WebDriver, urlid: int, tagid: int):

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -66,7 +66,7 @@ valid_urls = {
         "flask-limiter.readthedocs.io",
         "flask-limiter.readthedocs.io/",
     ],
-    "https://stackoverflow.com/": [
+    "https://stackoverflow.com/questions": [
         "www.stackoverflow.com",
         "stackoverflow.com",
     ],


### PR DESCRIPTION
Another fix for URL validation - handle when URLs do a redirect but include a relative URL in the `location` header.

Add sad path tests for the UI used during URL creation.