### PR TITLE
Fix dev static file deployment

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -103,7 +103,7 @@ jobs:
               docker compose -f compose-dev.yaml up --force-recreate --build -d;
               rm -rf ./secrets;
               docker image prune -f;
-              docker exec u4i-dev-flask tar -cf - -C /code/u4i/src static | tar -xf - -C ~/static;
+              docker exec u4i-dev-flask tar -cf - -C /code/u4i/src/static . | tar -xf - -C ~/static;
               ';
               sleep 30;
           


### PR DESCRIPTION
Dev server wasn't serving the latest static files, turns out the deploy script was placing them in the wrong place. This should fix.