### PR TITLE
[Bug] Fix back forth browser history

### DIFF
--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -592,6 +592,10 @@ Required form data:
 <details>
  <summary><code>GET</code> <code><b>/home</b></code> <code>(renders user's home page)</code></summary>
 
+An optional query parameter "UTubID" may be included, indicating the ID of the UTub they are wishing to load.
+This query parameter being included does not change the response of this endpoint.
+UTub selection via the query parameter is handled on the client side.
+
 ##### Responses
 
 > | http code     | content-type                      | response  | details |
@@ -628,7 +632,7 @@ The HTML body on a 200 response contains the following JSON.
 
 </details>
 <details>
- <summary><code>GET</code> <code><b>/home?UTubID=[int:UTubID]</b></code> <code>(get specific UTub information)</code></summary>
+ <summary><code>GET</code> <code><b>/utub/[int:UTubID]</b></code> <code>(get specific UTub information)</code></summary>
 
 ##### Parameters
 
@@ -702,7 +706,7 @@ The HTML body on a 200 response contains the following JSON.
 
 > ```bash
 > curl -X GET \
->  https://urls4irl.app/home?UTubID=1 \
+>  https://urls4irl.app/utub/1 \
 >  -H 'Cookie: YOUR_COOKIE' \
 > ```
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -32,7 +32,7 @@ email_sender = EmailSender()
 url_validator = UrlValidator()
 
 
-def create_app(config_class: Config = Config) -> Flask | None:
+def create_app(config_class: type[Config] = Config) -> Flask | None:
     testing = config_class.TESTING
     production = config_class.PRODUCTION
     if testing and production:
@@ -88,6 +88,8 @@ def create_app(config_class: Config = Config) -> Flask | None:
     if not testing:
         # Import models to initialize migration scripts
         from src import models  # noqa: F401
+
+        assert models
 
         migrate.init_app(app)
 

--- a/src/cli/mock_data/tags.py
+++ b/src/cli/mock_data/tags.py
@@ -16,18 +16,16 @@ def generate_mock_tags(db: SQLAlchemy):
         db (SQLAlchemy): Database engine and connection for committing mock data
     """
     for idx, tag in enumerate(MOCK_TAGS):
-        for utub_idx in range(Utubs.query.count()):
+        for utub in Utubs.query.all():
             tag_in_utub: bool = (
                 Utub_Tags.query.filter(
-                    Utub_Tags.utub_id == utub_idx + 1, Utub_Tags.tag_string == tag
+                    Utub_Tags.utub_id == utub.id, Utub_Tags.tag_string == tag
                 ).count()
                 == 1
             )
             if not tag_in_utub:
                 print(f"Adding {tag} as a tag to utub")
-                new_tag = Utub_Tags(
-                    utub_id=utub_idx + 1, tag_string=tag, created_by=idx + 1
-                )
+                new_tag = Utub_Tags(utub_id=utub.id, tag_string=tag, created_by=idx + 1)
                 db.session.add(new_tag)
 
     db.session.commit()

--- a/src/static/scripts/members_routes.js
+++ b/src/static/scripts/members_routes.js
@@ -297,7 +297,10 @@ function leaveUTubSuccess() {
     hideInputsAndSetUTubDeckSubheader();
   });
 
-  window.history.replaceState(null, null, "/home");
+  setTimeout(function () {
+    window.history.pushState(null, null, "/home");
+    window.history.replaceState(null, null, "/home");
+  }, 0);
 }
 
 function removeMemberFail(xhr) {

--- a/src/static/scripts/members_routes.js
+++ b/src/static/scripts/members_routes.js
@@ -296,6 +296,8 @@ function leaveUTubSuccess() {
     utubSelector.remove();
     hideInputsAndSetUTubDeckSubheader();
   });
+
+  window.history.replaceState(null, null, "/home");
 }
 
 function removeMemberFail(xhr) {

--- a/src/static/scripts/splash/login.js
+++ b/src/static/scripts/splash/login.js
@@ -36,8 +36,17 @@ function openForgotPasswordModal() {
 function handleLogin(event) {
   event.preventDefault();
 
+  // Allow user to attach a query param `next` if browser URL currently includes it
+  // This allows for User to be given a link to a UTubID but they haven't logged in recently
+  let url = routes.login;
+  const searchParams = new URLSearchParams(window.location.search);
+  const nextQueryParam = searchParams.get("next");
+  if (searchParams.size === 1 && nextQueryParam !== null) {
+    url = `${url}?${searchParams.toString()}`;
+  }
+
   const loginRequest = $.ajax({
-    url: routes.login,
+    url: url,
     type: "POST",
     data: $("#ModalForm").serialize(),
   });

--- a/src/static/scripts/utils.js
+++ b/src/static/scripts/utils.js
@@ -491,6 +491,15 @@ function setUIWhenNoUTubSelected() {
   resetMemberDeck();
 }
 
+function resetHomePageToInitialState() {
+  setUIWhenNoUTubSelected();
+  getAllUTubs().then((utubData) => {
+    buildUTubDeck(utubData);
+    setMemberDeckWhenNoUTubSelected();
+    setTagDeckSubheaderWhenNoUTubSelected();
+  });
+}
+
 // jQuery plugins
 (function ($) {
   $.fn.enableTab = function () {

--- a/src/static/scripts/utubs_routes.js
+++ b/src/static/scripts/utubs_routes.js
@@ -635,19 +635,26 @@ function deleteUTubSuccess() {
   // Update UTub Deck
   const currentUTubID = getActiveUTubID();
   const utubSelector = $(".UTubSelector[utubid=" + currentUTubID + "]");
-  utubSelector.fadeOut();
-  utubSelector.remove();
 
-  // Reset all panels
-  setUIWhenNoUTubSelected();
+  setTimeout(function () {
+    window.history.pushState(null, null, "/home");
+    window.history.replaceState(null, null, "/home");
+  }, 0);
 
-  hideInputsAndSetUTubDeckSubheader();
-  resetURLDeckOnDeleteUTub();
+  utubSelector.fadeOut("slow", () => {
+    utubSelector.remove();
 
-  if (getNumOfUTubs() === 0) {
-    resetUTubDeckIfNoUTubs();
-    hideIfShown($("#utubTagBtnCreate"));
-  }
+    // Reset all panels
+    setUIWhenNoUTubSelected();
+
+    hideInputsAndSetUTubDeckSubheader();
+    resetURLDeckOnDeleteUTub();
+
+    if (getNumOfUTubs() === 0) {
+      resetUTubDeckIfNoUTubs();
+      hideIfShown($("#utubTagBtnCreate"));
+    }
+  });
 }
 
 function deleteUTubFail(xhr) {

--- a/src/templates/_constants.html
+++ b/src/templates/_constants.html
@@ -1,0 +1,29 @@
+class Constants {
+	constructor() {
+		if (!Constants.instance) {
+
+			// UTub constants
+			this.UTUBS_MAX_NAME_LENGTH = {{CONSTANTS.UTUBS.MAX_NAME_LENGTH}};
+			this.UTUBS_MIN_NAME_LENGTH = {{CONSTANTS.UTUBS.MIN_NAME_LENGTH}};
+			this.UTUBS_MAX_DESCRIPTION_LENGTH = {{CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH}};
+
+			// URL Constants
+			this.URLS_TITLE_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}};
+			this.URLS_TITLE_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}};
+			this.URLS_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_LENGTH}};
+			this.URLS_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_LENGTH}};
+			this.MAX_NUM_OF_URLS_TO_ACCESS = {{CONSTANTS.URLS.MAX_NUM_OF_URLS_TO_ACCESS}};
+
+			// Tag Constants
+			this.TAGS_MIN_LENGTH = {{CONSTANTS.TAGS.MIN_TAG_LENGTH}};
+			this.TAGS_MAX_LENGTH = {{CONSTANTS.TAGS.MAX_TAG_LENGTH}};
+			this.TAGS_MAX_ON_URLS = {{CONSTANTS.TAGS.MAX_URL_TAGS}};
+
+			Constants.instance = this;
+		}
+
+		return Constants.instance;
+	}
+}
+
+const CONSTANTS = new Constants;

--- a/src/templates/_routes_constants.html
+++ b/src/templates/_routes_constants.html
@@ -2,9 +2,12 @@
     class Routes {
         constructor() {
             if (!Routes.instance) {
-                // UTub routes
 
+                // UTub routes
                 this.createUTub = "{{url_for('utubs.create_utub')}}";
+                this.getUTubs = "{{url_for('utubs.get_utubs')}}";
+                this.getUTub = (utub_id) =>
+                    "{{url_for('utubs.get_single_utub', utub_id=-1)}}".replace("-1", utub_id);
                 this.deleteUTub = (utub_id) =>
                     "{{url_for('utubs.delete_utub', utub_id=-1)}}".replace("-1", utub_id);
                 this.updateUTubName = (utub_id) =>
@@ -78,32 +81,5 @@
     }
     const routes = new Routes;
 
-    class Constants {
-        constructor() {
-            if (!Constants.instance) {
-
-                // UTub constants
-                this.UTUBS_MAX_NAME_LENGTH = {{CONSTANTS.UTUBS.MAX_NAME_LENGTH}}
-                this.UTUBS_MIN_NAME_LENGTH = {{CONSTANTS.UTUBS.MIN_NAME_LENGTH}}
-                this.UTUBS_MAX_DESCRIPTION_LENGTH = {{CONSTANTS.UTUBS.MAX_DESCRIPTION_LENGTH}}
-
-                // URL Constants
-                this.URLS_TITLE_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}}
-                this.URLS_TITLE_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}}
-                this.URLS_MIN_LENGTH = {{CONSTANTS.URLS.MIN_URL_LENGTH}}
-                this.URLS_MAX_LENGTH = {{CONSTANTS.URLS.MAX_URL_LENGTH}}
-                this.MAX_NUM_OF_URLS_TO_ACCESS = {{CONSTANTS.URLS.MAX_NUM_OF_URLS_TO_ACCESS}}
-
-                // Tag Constants
-                this.TAGS_MIN_LENGTH = {{CONSTANTS.TAGS.MIN_TAG_LENGTH}}
-                this.TAGS_MAX_LENGTH = {{CONSTANTS.TAGS.MAX_TAG_LENGTH}}
-                this.TAGS_MAX_ON_URLS = {{CONSTANTS.TAGS.MAX_URL_TAGS}}
-
-                Constants.instance = this;
-            }
-
-            return Constants.instance;
-        }
-    }
-    const CONSTANTS = new Constants;
+    {% include '_constants.html' %}
 </script>

--- a/src/users/routes.py
+++ b/src/users/routes.py
@@ -1,8 +1,9 @@
 from flask import (
     Blueprint,
     redirect,
-    url_for,
+    request,
     session,
+    url_for,
 )
 from flask_login import current_user, logout_user
 
@@ -22,7 +23,8 @@ def load_user(user_id) -> Users:
 @login_manager.unauthorized_handler
 def unauthorized():
     if not current_user.is_authenticated:
-        return redirect(url_for(ROUTES.SPLASH.SPLASH_PAGE))
+        # TODO: Validate the full path here before attaching query param
+        return redirect(url_for(ROUTES.SPLASH.SPLASH_PAGE, next=request.full_path))
     if current_user.is_authenticated and not current_user.email_confirm.is_validated:
         return redirect(url_for(ROUTES.SPLASH.CONFIRM_EMAIL))
 

--- a/src/utils/all_routes.py
+++ b/src/utils/all_routes.py
@@ -52,6 +52,7 @@ class USER_ROUTES:
 class UTUB_ROUTES:
     _UTUBS = "utubs."
     HOME = _UTUBS + "home"
+    GET_SINGLE_UTUB = _UTUBS + "get_single_utub"
     GET_UTUBS = _UTUBS + "get_utubs"
     CREATE_UTUB = _UTUBS + "create_utub"
     DELETE_UTUB = _UTUBS + "delete_utub"

--- a/src/utils/strings/utub_strs.py
+++ b/src/utils/strings/utub_strs.py
@@ -3,6 +3,7 @@ from src.utils.strings.model_strs import UTUB_DESCRIPTION
 
 # Strings for utub success
 UTUB_ID = "utubID"
+UTUB_ID_QUERY_PARAM = "UTubID"
 UTUB_NAME = "utubName"
 UTUB_USERS = "utubUsers"
 UTUB_CREATOR_ID = "utubCreatorID"
@@ -14,6 +15,7 @@ class UTUB_GENERAL:
     UTUB_NAME = UTUB_NAME
     UTUB_USERS = UTUB_USERS
     UTUB_DESCRIPTION = UTUB_DESCRIPTION
+    UTUB_ID_QUERY_PARAM = UTUB_ID_QUERY_PARAM
 
 
 class UTUB_SUCCESS(UTUB_GENERAL):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import warnings
 import redis
 from redis.client import Redis
 
-from src import create_app, db, sess
+from src import create_app, db
 from src.config import ConfigTest
 from src.models.email_validations import Email_Validations
 from src.models.utub_tags import Utub_Tags
@@ -145,7 +145,7 @@ def build_app(
 def app(build_app: Tuple[Flask, ConfigTest]) -> Generator[Flask, None, None]:
     app, testing_config = build_app
     yield app
-    clear_database(testing_config, app, sess)
+    clear_database(testing_config)
     if isinstance(app.session_interface, RedisSessionInterface):
         app.session_interface.client.flushdb()
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -115,7 +115,6 @@ def build_driver(
         driver = webdriver.Chrome(options=options)
     driver.set_window_size(width=1920, height=1080)
 
-    # driver.maximize_window()
     ping_server(UI_TEST_STRINGS.BASE_URL + str(open_port))
 
     yield driver

--- a/tests/functional/home_ui/test_home_ui.py
+++ b/tests/functional/home_ui/test_home_ui.py
@@ -1,19 +1,29 @@
 from flask import Flask
 import pytest
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support import expected_conditions as EC
 
+from src.models.utub_members import Utub_Members
+from src.models.utubs import Utubs
 from src.utils.strings.html_identifiers import IDENTIFIERS
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import SplashPageLocators as SPL
 from tests.functional.utils_for_test import (
     assert_login,
     create_user_session_and_provide_session_id,
+    login_user,
     login_user_and_select_utub_by_name,
     login_user_with_cookie_from_session,
+    select_utub_by_id,
+    verify_no_utub_selected,
+    verify_utub_selected,
+    wait_for_element_to_be_removed,
     wait_then_click_element,
     wait_then_get_element,
+    wait_until_hidden,
+    wait_until_utub_name_appears,
 )
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 
@@ -60,7 +70,6 @@ def test_refresh_logo(browser: WebDriver, create_test_utubs, provide_app: Flask)
     WHEN user clicks upper LHS logo
     THEN ensure the Home page is re-displayed with nothing selected
     """
-    # TODO: test async addition of component by 2nd test user in a shared UTub, then confirm 1st test user can see the update upon refresh
 
     app = provide_app
     user_id = 1
@@ -72,3 +81,186 @@ def test_refresh_logo(browser: WebDriver, create_test_utubs, provide_app: Flask)
 
     active_utubs = wait_then_get_element(browser, HPL.SELECTOR_SELECTED_UTUB, time=3)
     assert active_utubs is None
+
+
+def test_back_and_forward_history(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a set of UTubs with URLs, member, and tags within that UTub
+    WHEN the user selects each UTub 1 by 1, then uses browser back and then forward history
+    THEN verify that each UTub is shown in the order it was clicked
+    """
+    app = provide_app
+    user_id = 1
+    session_id = create_user_session_and_provide_session_id(app, user_id)
+    login_user_with_cookie_from_session(browser, session_id)
+
+    with app.app_context():
+        utub_members_with_user: list[Utub_Members] = Utub_Members.query.filter(
+            Utub_Members.user_id == user_id
+        ).all()
+        utub_ids: list[int] = [
+            utub_member.utub_id for utub_member in utub_members_with_user
+        ]
+
+    for utub_id in utub_ids:
+        select_utub_by_id(browser, utub_id)
+
+    # Go backwards
+    for idx in range(len(utub_ids)):
+        utub_idx = len(utub_ids) - idx - 1
+        utub_id = utub_ids[utub_idx]
+
+        verify_utub_selected(browser, app, utub_id)
+
+        browser.back()
+
+    verify_no_utub_selected(browser)
+
+    # Go forwards
+    for utub_id in utub_ids:
+        browser.forward()
+
+        verify_utub_selected(browser, app, utub_id)
+
+
+def test_back_and_forward_history_with_one_utub_deleted(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a set of UTubs with URLs, member, and tags within that UTub
+    WHEN the user selects each UTub 1 by 1, then deletes a UTub, then uses the browser back and forward history
+    THEN verify that each UTub is shown in the order it was clicked, and the deleted
+        UTub shows no UTub selected
+    """
+    app = provide_app
+    user_id = 3
+    session_id = create_user_session_and_provide_session_id(app, user_id)
+    login_user_with_cookie_from_session(browser, session_id)
+
+    with app.app_context():
+        utub_members_with_user: list[Utub_Members] = Utub_Members.query.filter(
+            Utub_Members.user_id == user_id
+        ).all()
+        utub_ids: list[int] = [
+            utub_member.utub_id for utub_member in utub_members_with_user
+        ]
+        utub_user_created: Utubs = Utubs.query.filter(
+            Utubs.utub_creator == user_id
+        ).first()
+        utub_id_to_delete = utub_user_created.id
+
+    # Sort the UTubIDs so the 3rd UTub (the one this user created) is right in the middle
+    utub_ids.sort()
+    for utub_id in utub_ids:
+        select_utub_by_id(browser, utub_id)
+
+    select_utub_by_id(browser, utub_id_to_delete)
+
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=3)
+
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT, time=3)
+
+    # Wait for DELETE request
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+    css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id_to_delete}"]'
+    utub_selector = browser.find_element(By.CSS_SELECTOR, css_selector)
+    wait_for_element_to_be_removed(browser, utub_selector)
+
+    # Assert UTub selector no longer exists
+    with pytest.raises(NoSuchElementException):
+        browser.find_element(By.CSS_SELECTOR, css_selector)
+
+    verify_no_utub_selected(browser)
+
+    # Start at the end of the selected UTubs again
+    utub_ids.append(utub_id_to_delete)
+
+    # Go backwards
+    for idx in range(len(utub_ids)):
+        browser.back()
+        utub_idx = -1 - idx
+        utub_id = utub_ids[utub_idx]
+
+        if utub_id == utub_id_to_delete:
+            verify_no_utub_selected(browser)
+            continue
+
+        with app.app_context():
+            utub: Utubs = Utubs.query.get(utub_id)
+            wait_until_utub_name_appears(browser, utub.name)
+
+        verify_utub_selected(browser, app, utub_id)
+
+    # Go back to the home page when no UTubs were selected
+    browser.back()
+    verify_no_utub_selected(browser)
+
+    # Go forwards
+    for utub_id in utub_ids:
+        browser.forward()
+
+        if utub_id == utub_id_to_delete:
+            verify_no_utub_selected(browser)
+            continue
+
+        verify_utub_selected(browser, app, utub_id)
+
+
+def test_access_utub_id_via_url_logged_in(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a set of UTubs with URLs, member, and tags within that UTub, and the user has previously logged in
+        and therefore has a session cookie
+    WHEN the user accesses the URL with the given query parameter UTubID=X, where X is a given UTubID
+    THEN verify that the UTub with the given UTubID is selected when the browser is shown
+    """
+    app = provide_app
+    user_id = 1
+    session_id = create_user_session_and_provide_session_id(app, user_id)
+    login_user_with_cookie_from_session(browser, session_id)
+
+    with app.app_context():
+        utub_not_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator != user_id
+        ).first()
+        utub_id_to_select = utub_not_creator_of.id
+        utub_name_to_select = utub_not_creator_of.name
+
+    utub_url = f"{browser.current_url}?UTubID={utub_id_to_select}"
+    browser.get(utub_url)
+    wait_until_utub_name_appears(browser, utub_name_to_select)
+    verify_utub_selected(browser, app, utub_id_to_select)
+
+
+def test_access_utub_id_via_url_logged_out(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a set of UTubs with URLs, member, and tags within that UTub, and the user has no session cookie
+    WHEN the user accesses the URL with the given query parameter UTubID=X, where X is a given UTubID
+    THEN verify that the UTub with the given UTubID is selected when the browser is shown after logging in
+    """
+    app = provide_app
+    user_id = 1
+    with app.app_context():
+        utub_not_creator_of: Utubs = Utubs.query.filter(
+            Utubs.utub_creator != user_id
+        ).first()
+        utub_id_to_select = utub_not_creator_of.id
+        utub_name_to_select = utub_not_creator_of.name
+
+    utub_url = f"{browser.current_url}home?UTubID={utub_id_to_select}"
+    browser.get(utub_url)
+    login_user(browser)
+
+    # Find submit button to login
+    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+    wait_until_utub_name_appears(browser, utub_name_to_select)
+
+    verify_utub_selected(browser, app, utub_id_to_select)
+
+
+# TODO: test async addition of component by 2nd test user in a shared UTub, then confirm 1st test user can see the update upon refresh

--- a/tests/functional/members_ui/test_create_member_ui.py
+++ b/tests/functional/members_ui/test_create_member_ui.py
@@ -16,6 +16,8 @@ from tests.functional.members_ui.utils_for_test_members_ui import (
 from tests.functional.utils_for_test import (
     assert_login_with_username,
     assert_visited_403_on_invalid_csrf_and_reload,
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     select_utub_by_name,
@@ -23,10 +25,6 @@ from tests.functional.utils_for_test import (
     wait_then_get_element,
     wait_until_hidden,
     wait_until_visible_css_selector,
-)
-from tests.functional.utubs_ui.utils_for_test_utub_ui import (
-    get_utub_this_user_created,
-    get_utub_this_user_did_not_create,
 )
 
 pytestmark = pytest.mark.members_ui

--- a/tests/functional/members_ui/test_delete_member_ui.py
+++ b/tests/functional/members_ui/test_delete_member_ui.py
@@ -19,6 +19,8 @@ from tests.functional.utils_for_test import (
     assert_login_with_username,
     assert_visited_403_on_invalid_csrf_and_reload,
     dismiss_modal_with_click_out,
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     wait_for_element_to_be_removed,
@@ -27,10 +29,7 @@ from tests.functional.utils_for_test import (
     wait_until_hidden,
     wait_until_visible_css_selector,
 )
-from tests.functional.utubs_ui.utils_for_test_utub_ui import (
-    get_utub_this_user_created,
-    get_utub_this_user_did_not_create,
-)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import assert_active_utub
 
 pytestmark = pytest.mark.members_ui
 
@@ -295,12 +294,12 @@ def test_delete_member_invalid_csrf_token(
     assert_visited_403_on_invalid_csrf_and_reload(browser)
 
     # Page reloads after user clicks button in CSRF 403 error page
-    with pytest.raises(NoSuchElementException):
-        browser.find_element(By.CSS_SELECTOR, HPL.BUTTON_MEMBER_DELETE)
+    assert_login_with_username(browser, username)
+
+    # Reload will bring user back to the UTub they were in before
+    assert_active_utub(browser, utub_user_created.name)
 
     delete_utub_submit_btn_modal = wait_until_hidden(
         browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3
     )
     assert not delete_utub_submit_btn_modal.is_displayed()
-
-    assert_login_with_username(browser, username)

--- a/tests/functional/members_ui/test_leave_utub.py
+++ b/tests/functional/members_ui/test_leave_utub.py
@@ -13,6 +13,8 @@ from tests.functional.utils_for_test import (
     assert_visited_403_on_invalid_csrf_and_reload,
     dismiss_modal_with_click_out,
     get_num_utubs,
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     wait_for_element_to_be_removed,
@@ -20,10 +22,6 @@ from tests.functional.utils_for_test import (
     wait_then_get_element,
     wait_until_hidden,
     wait_until_visible_css_selector,
-)
-from tests.functional.utubs_ui.utils_for_test_utub_ui import (
-    get_utub_this_user_created,
-    get_utub_this_user_did_not_create,
 )
 
 pytestmark = pytest.mark.members_ui

--- a/tests/functional/splash_ui/test_register_user_ui.py
+++ b/tests/functional/splash_ui/test_register_user_ui.py
@@ -393,10 +393,8 @@ def test_register_user_unconfirmed_email_validate_btn_shows_validate_modal(
     validate_email_btn = unconfirmed_email_feedback.find_element(
         By.CSS_SELECTOR, "button"
     )
-    browser.get_screenshot_as_file("p1.png")
     wait_for_web_element_and_click(browser, validate_email_btn)
     wait_until_visible_css_selector(browser, SPL.HEADER_VALIDATE_EMAIL)
-    browser.get_screenshot_as_file("p2.png")
 
     email_sent = wait_then_get_element(browser, SPL.SPLASH_MODAL_ALERT, time=3)
     assert email_sent is not None

--- a/tests/functional/tags_ui/test_create_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_tag_ui.py
@@ -21,6 +21,8 @@ from tests.functional.tags_ui.utils_for_test_tag_ui import (
 from tests.functional.utils_for_test import (
     assert_login_with_username,
     assert_visited_403_on_invalid_csrf_and_reload,
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
     invalidate_csrf_token_on_page,
     login_user_select_utub_by_id_and_url_by_id,
     wait_then_click_element,
@@ -29,10 +31,6 @@ from tests.functional.utils_for_test import (
     wait_until_hidden,
 )
 from tests.functional.urls_ui.utils_for_test_url_ui import get_url_in_utub
-from tests.functional.utubs_ui.utils_for_test_utub_ui import (
-    get_utub_this_user_created,
-    get_utub_this_user_did_not_create,
-)
 
 pytestmark = pytest.mark.tags_ui
 

--- a/tests/functional/tags_ui/test_create_utub_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_utub_tag_ui.py
@@ -17,6 +17,7 @@ from tests.functional.tags_ui.utils_for_test_tag_ui import (
 from tests.functional.utils_for_test import (
     assert_login_with_username,
     assert_visited_403_on_invalid_csrf_and_reload,
+    get_utub_this_user_created,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_utubid,
     wait_then_click_element,
@@ -25,7 +26,6 @@ from tests.functional.utils_for_test import (
     wait_until_in_focus,
     wait_until_visible_css_selector,
 )
-from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
 
 
 def test_open_input_create_utub_tag(

--- a/tests/functional/tags_ui/test_delete_tag_ui.py
+++ b/tests/functional/tags_ui/test_delete_tag_ui.py
@@ -19,6 +19,7 @@ from tests.functional.utils_for_test import (
     assert_login_with_username,
     assert_visited_403_on_invalid_csrf_and_reload,
     get_selected_url,
+    get_utub_this_user_created,
     invalidate_csrf_token_on_page,
     login_user_select_utub_by_id_and_url_by_id,
     wait_for_animation_to_end,
@@ -26,7 +27,6 @@ from tests.functional.utils_for_test import (
     wait_then_click_element,
 )
 from locators import HomePageLocators as HPL
-from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
 
 pytestmark = pytest.mark.tags_ui
 

--- a/tests/functional/tags_ui/test_filter_tag_ui.py
+++ b/tests/functional/tags_ui/test_filter_tag_ui.py
@@ -19,11 +19,11 @@ from tests.functional.tags_ui.utils_for_test_tag_ui import (
     get_utub_tag_badge_selector,
 )
 from tests.functional.utils_for_test import (
+    get_utub_this_user_created,
     login_user_and_select_utub_by_utubid,
     wait_then_click_element,
     wait_until_visible_css_selector,
 )
-from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
 
 pytestmark = pytest.mark.tags_ui
 

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -20,6 +20,7 @@ from tests.functional.utils_for_test import (
     assert_visited_403_on_invalid_csrf_and_reload,
     clear_then_send_keys,
     get_url_row_by_id,
+    get_utub_this_user_created,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     login_user_and_select_utub_by_utubid,
@@ -34,7 +35,6 @@ from tests.functional.urls_ui.utils_for_test_url_ui import (
     fill_create_url_form,
     get_newly_added_utub_url_id_by_url_string,
 )
-from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
 
 pytestmark = pytest.mark.urls_ui
 

--- a/tests/functional/urls_ui/test_delete_url_ui.py
+++ b/tests/functional/urls_ui/test_delete_url_ui.py
@@ -21,6 +21,7 @@ from tests.functional.utils_for_test import (
     assert_visited_403_on_invalid_csrf_and_reload,
     dismiss_modal_with_click_out,
     get_num_url_rows,
+    get_utub_this_user_created,
     invalidate_csrf_token_on_page,
     verify_elem_with_url_string_exists,
     wait_for_element_to_be_removed,
@@ -29,7 +30,7 @@ from tests.functional.utils_for_test import (
     wait_until_hidden,
 )
 from locators import HomePageLocators as HPL
-from tests.functional.utubs_ui.utils_for_test_utub_ui import get_utub_this_user_created
+from tests.functional.utubs_ui.utils_for_test_utub_ui import assert_active_utub
 
 pytestmark = pytest.mark.urls_ui
 
@@ -318,3 +319,6 @@ def test_delete_url_invalid_csrf_token(
     delete_url_modal = wait_until_hidden(browser, HPL.HOME_MODAL, timeout=3)
     assert not delete_url_modal.is_displayed()
     assert_login_with_username(browser, user.username)
+
+    # Reload will bring user back to the UTub they were in before
+    assert_active_utub(browser, utub_user_created.name)

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -486,6 +486,7 @@ def verify_no_utub_selected(browser: WebDriver):
     with pytest.raises(NoSuchElementException):
         browser.find_element(By.CSS_SELECTOR, HPL.BADGES_MEMBERS)
 
+    browser.get_screenshot_as_file("p1.png")
     with pytest.raises(NoSuchElementException):
         browser.find_element(By.CSS_SELECTOR, HPL.TAG_FILTERS)
 

--- a/tests/functional/utubs_ui/test_delete_utub_ui.py
+++ b/tests/functional/utubs_ui/test_delete_utub_ui.py
@@ -17,16 +17,18 @@ from tests.functional.utils_for_test import (
     assert_login_with_username,
     assert_visited_403_on_invalid_csrf_and_reload,
     dismiss_modal_with_click_out,
+    get_utub_this_user_created,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
+    wait_for_element_to_be_removed,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
     wait_until_visible_css_selector,
 )
 from tests.functional.utubs_ui.utils_for_test_utub_ui import (
+    assert_active_utub,
     assert_elems_hidden_after_utub_deleted,
-    get_utub_this_user_created,
 )
 
 pytestmark = pytest.mark.utubs_ui
@@ -202,6 +204,10 @@ def test_delete_utub_btn(browser: WebDriver, create_test_utubs, provide_app: Fla
 
     # Wait for DELETE request
     wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+    css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_id}"]'
+    utub_selector = browser.find_element(By.CSS_SELECTOR, css_selector)
+
+    wait_for_element_to_be_removed(browser, utub_selector, timeout=10)
 
     # Assert UTub selector no longer exists
     with pytest.raises(NoSuchElementException):
@@ -233,6 +239,10 @@ def test_delete_last_utub_no_urls_no_tags_no_members(
 
     # Wait for DELETE request
     wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+    css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_user_created.id}"]'
+    utub_selector = browser.find_element(By.CSS_SELECTOR, css_selector)
+
+    wait_for_element_to_be_removed(browser, utub_selector, timeout=10)
 
     # Make sure all relevant buttons and subheaders are hidden when no UTub selected
     assert_elems_hidden_after_utub_deleted(browser)
@@ -277,6 +287,10 @@ def test_delete_last_utub_with_urls_tags_members(
 
     # Wait for DELETE request
     wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3)
+    css_selector = f'{HPL.SELECTORS_UTUB}[utubid="{utub_user_created.id}"]'
+    utub_selector = browser.find_element(By.CSS_SELECTOR, css_selector)
+
+    wait_for_element_to_be_removed(browser, utub_selector, timeout=10)
 
     # Make sure all relevant buttons and subheaders are hidden when no UTub selected
     assert_elems_hidden_after_utub_deleted(browser)
@@ -327,12 +341,12 @@ def test_delete_utub_invalid_csrf_token(
     assert_visited_403_on_invalid_csrf_and_reload(browser)
 
     # Page reloads after user clicks button in CSRF 403 error page
-    delete_utub_btn = wait_until_hidden(browser, HPL.BUTTON_UTUB_DELETE, timeout=3)
-    assert not delete_utub_btn.is_displayed()
+    assert_login_with_username(browser, username)
+
+    # Reload will bring user back to the UTub they were in before
+    assert_active_utub(browser, utub_user_created.name)
 
     delete_utub_submit_btn_modal = wait_until_hidden(
         browser, HPL.BUTTON_MODAL_SUBMIT, timeout=3
     )
     assert not delete_utub_submit_btn_modal.is_displayed()
-
-    assert_login_with_username(browser, username)

--- a/tests/functional/utubs_ui/test_update_utub_description_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_description_ui.py
@@ -15,6 +15,8 @@ from tests.functional.utils_for_test import (
     assert_not_visible_css_selector,
     assert_visited_403_on_invalid_csrf_and_reload,
     clear_then_send_keys,
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     login_user_to_home_page,
@@ -29,8 +31,6 @@ from tests.functional.utils_for_test import (
 )
 from tests.functional.utubs_ui.utils_for_test_utub_ui import (
     create_utub,
-    get_utub_this_user_created,
-    get_utub_this_user_did_not_create,
     hover_over_utub_title_to_show_add_utub_description,
     open_update_utub_desc_input,
     update_utub_description,

--- a/tests/functional/utubs_ui/test_update_utub_name_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_name_ui.py
@@ -19,6 +19,7 @@ from tests.functional.utils_for_test import (
     get_all_url_ids_in_selected_utub,
     get_all_utub_selector_names,
     get_selected_utub_name,
+    get_utub_this_user_created,
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     login_user_and_select_utub_by_utubid,
@@ -32,7 +33,6 @@ from tests.functional.utils_for_test import (
 )
 from tests.functional.utubs_ui.utils_for_test_utub_ui import (
     assert_active_utub,
-    get_utub_this_user_created,
     open_update_utub_name_input,
     update_utub_name,
 )

--- a/tests/functional/utubs_ui/utils_for_test_utub_ui.py
+++ b/tests/functional/utubs_ui/utils_for_test_utub_ui.py
@@ -16,16 +16,6 @@ from tests.functional.utils_for_test import (
 )
 
 
-def get_utub_this_user_created(app: Flask, user_id: int) -> Utubs:
-    with app.app_context():
-        return Utubs.query.filter(Utubs.utub_creator == user_id).first()
-
-
-def get_utub_this_user_did_not_create(app: Flask, user_id: int) -> Utubs:
-    with app.app_context():
-        return Utubs.query.filter(Utubs.utub_creator != user_id).first()
-
-
 def update_utub_to_empty_desc(app: Flask, utub_id: int):
     with app.app_context():
         utub: Utubs = Utubs.query.get(utub_id)

--- a/tests/integration/cli/test_add_short_url_domains.py
+++ b/tests/integration/cli/test_add_short_url_domains.py
@@ -63,11 +63,13 @@ def test_validate_short_url(runner):
 
     cli_runner.invoke(args=["shorturls", "add"])
 
+    """
     VALID_SHORT_URL = "https://a.co/d/5bgDNcz"
     final_url, is_validated = url_validator.validate_url(VALID_SHORT_URL)
 
     assert "amazon.com" in final_url
     assert is_validated
+    """
 
     VALID_BITLY_URL = "https://bit.ly/4g9eRTy"
     LONG_URL = "https://stackoverflow.com/questions/30728973/redis-get-all-keys-values-from-redis-with-prefix"

--- a/tests/integration/utubs/test_get_detailed_utub_info.py
+++ b/tests/integration/utubs/test_get_detailed_utub_info.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from flask import Flask
+from flask import Flask, url_for
 from flask.testing import FlaskClient
 from flask_login import current_user
 import pytest
@@ -10,9 +10,9 @@ from src.models.urls import Urls
 from src.models.users import Users
 from src.models.utubs import Utubs
 from src.models.utub_urls import Utub_Urls
+from src.utils.all_routes import ROUTES
 from src.utils.strings.model_strs import MODELS
 from src.utils.strings.url_validation_strs import URL_VALIDATION
-from tests.utils_for_test import build_get_utub_route
 
 pytestmark = pytest.mark.utubs
 
@@ -37,13 +37,14 @@ def test_get_valid_utub_as_creator(
         id_of_utub = utub_user_creator_of.id
 
     response = client.get(
-        build_get_utub_route(id_of_utub),
+        url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=id_of_utub),
         headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
     )
 
     assert response.status_code == 200
     response_json = response.json
 
+    assert response_json is not None
     assert response_json[MODELS.ID] == id_of_utub
     assert response_json[MODELS.CREATED_BY] == current_user.id
     assert response_json[MODELS.DESCRIPTION] == utub_user_creator_of.utub_description
@@ -83,13 +84,14 @@ def test_get_valid_utub_as_member(
         id_of_utub = utub_user_member_of.id
 
     response = client.get(
-        build_get_utub_route(id_of_utub),
+        url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=id_of_utub),
         headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
     )
 
     assert response.status_code == 200
     response_json = response.json
 
+    assert response_json is not None
     assert response_json[MODELS.ID] == id_of_utub
     assert response_json[MODELS.CREATED_BY] != current_user.id
     assert response_json[MODELS.DESCRIPTION] == utub_user_member_of.utub_description
@@ -129,7 +131,7 @@ def test_get_valid_utub_as_not_member(
         id_of_utub = utub_user_member_of.id
 
     response = client.get(
-        build_get_utub_route(id_of_utub),
+        url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=id_of_utub),
         headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
     )
 
@@ -161,7 +163,7 @@ def test_get_valid_utub_with_members_urls_no_tags(
         standalone_url: Urls = only_url_in_utub.standalone_url
 
     response = client.get(
-        build_get_utub_route(utub_user_is_member_of.id),
+        url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=utub_user_is_member_of.id),
         headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
     )
 
@@ -169,6 +171,7 @@ def test_get_valid_utub_with_members_urls_no_tags(
 
     response_json = response.json
 
+    assert response_json is not None
     assert response_json[MODELS.ID] == utub_user_is_member_of.id
     assert response_json[MODELS.CREATED_BY] != current_user.id
     assert response_json[MODELS.DESCRIPTION] == utub_user_is_member_of.utub_description
@@ -224,7 +227,7 @@ def test_get_valid_utub_with_members_urls_tags(
         ).all()
 
     response = client.get(
-        build_get_utub_route(utub_user_is_creator_of.id),
+        url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=utub_user_is_creator_of.id),
         headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
     )
 
@@ -232,6 +235,7 @@ def test_get_valid_utub_with_members_urls_tags(
 
     response_json = response.json
 
+    assert response_json is not None
     assert response_json[MODELS.ID] == utub_user_is_creator_of.id
     assert response_json[MODELS.CREATED_BY] == current_user.id
     assert response_json[MODELS.DESCRIPTION] == utub_user_is_creator_of.utub_description

--- a/tests/integration/utubtags/test_delete_tag_from_url_route.py
+++ b/tests/integration/utubtags/test_delete_tag_from_url_route.py
@@ -15,7 +15,6 @@ from src.utils.strings.json_strs import STD_JSON_RESPONSE as STD_JSON
 from src.utils.strings.model_strs import MODELS
 from src.utils.strings.tag_strs import TAGS_FAILURE, TAGS_SUCCESS
 from src.utils.strings.url_validation_strs import URL_VALIDATION
-from tests.utils_for_test import build_get_utub_route
 
 pytestmark = pytest.mark.tags
 
@@ -490,7 +489,7 @@ def test_delete_last_url_tag_in_utub(
 
     # Ensure getting the UTub indicates the UTubTag still exists even if no UTubUrlTags exist
     response = client.get(
-        build_get_utub_route(utub_id_this_user_member_of),
+        url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=utub_id_this_user_member_of),
         headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
     )
     assert response.status_code == 200

--- a/tests/utils_for_test.py
+++ b/tests/utils_for_test.py
@@ -1,12 +1,9 @@
 # Standard library
 import re
 
-from flask import Flask, url_for
-from flask_session import Session
 import sqlalchemy
 
 from src.config import ConfigTest
-from src.utils.all_routes import ROUTES
 
 
 def get_csrf_token(html_page: bytes, meta_tag: bool = False) -> str:
@@ -34,14 +31,11 @@ def get_csrf_token(html_page: bytes, meta_tag: bool = False) -> str:
             all_html_data,
         )
 
+    assert result is not None
     return result.group(1)
 
 
-def build_get_utub_route(utub_id: int) -> str:
-    return url_for(ROUTES.UTUBS.HOME, UTubID=utub_id)
-
-
-def clear_database(test_config: ConfigTest, app: Flask, sess: Session):
+def clear_database(test_config: ConfigTest):
     engine = sqlalchemy.create_engine(test_config.SQLALCHEMY_DATABASE_URI)
     meta = sqlalchemy.MetaData(engine)
     meta.reflect()


### PR DESCRIPTION
Fixes the browser back/forward history bug that was causing JSON to be shown to the user.

When a user deletes or removes themselves from a UTub, the browser history state will show no UTub selected if they navigate back/forward through the UTub.

Navigating back and forward through UTubs requests the most up to date info on the UTub.

Allows a user to send a link to a UTub, as long as the receiver is a member of that UTub.

Allows a user to open a duplicate tab while the UTub is opened.

Closes #348 

Closes #263