### PR TITLE
Fix URL coloring bug, add tests for UTub selection

### DIFF
--- a/src/static/scripts/urls.js
+++ b/src/static/scripts/urls.js
@@ -86,6 +86,24 @@ function getNumOfVisibleURLs() {
   return $(".urlRow[filterable=true]").length;
 }
 
+function getOppositeColoredClassOfVisibleURLs() {
+  const urlCards = $(".urlRow[filterable=true]").toArray();
+  return $(urlCards[0]).hasClass("even") ? "odd" : "even";
+}
+
+function updateColorOfFollowingURLCards() {
+  const urlCards = $(".urlRow[filterable=true]").toArray();
+  let urlCard;
+  for (let i = 1; i < urlCards.length; i++) {
+    urlCard = $(urlCards[i]);
+    if (i % 2 === 0) {
+      urlCard.removeClass("odd").addClass("even");
+    } else {
+      urlCard.removeClass("even").addClass("odd");
+    }
+  }
+}
+
 // Simple function to streamline the jQuery selector extraction of selected URL card. Provides ease of reference by URL Functions.
 function getSelectedURLCard() {
   const selectedUrlCard = $(".urlRow[urlSelected=true]");

--- a/src/static/scripts/urls_routes.js
+++ b/src/static/scripts/urls_routes.js
@@ -84,11 +84,13 @@ function createURLSuccess(response) {
   const newUrlCard = createURLBlock(
     url,
     [], // Mimics an empty array of tags to match against
-  ).addClass(currentNumOfURLs % 2 === 0 ? "even" : "odd");
+  ).addClass("even");
 
   showIfHidden($("#accessAllURLsBtn"));
 
   newUrlCard.insertAfter($("#createURLWrap"));
+  if (currentNumOfURLs === 0) return;
+  updateColorOfFollowingURLCards();
 }
 
 // Displays appropriate prompts and options to user following a failed addition of a new URL

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -61,6 +61,7 @@ class HomePageLocators(GenericPageLocator):
     LIST_URL = "#listURLs"
     ROWS_URLS = ".urlRow"
     ROW_SELECTED_URL = ".urlRow[urlselected='true']"
+    ROW_VISIBLE_URL = ".urlRow[filterable='true']"
 
     BUTTON_CORNER_URL_CREATE = "#urlBtnCreate"
     BUTTON_DECK_URL_CREATE = "#urlBtnDeckCreate"

--- a/tests/functional/urls_ui/test_create_url_ui.py
+++ b/tests/functional/urls_ui/test_create_url_ui.py
@@ -24,6 +24,7 @@ from tests.functional.utils_for_test import (
     invalidate_csrf_token_on_page,
     login_user_and_select_utub_by_name,
     login_user_and_select_utub_by_utubid,
+    verify_url_coloring_is_correct,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
@@ -255,6 +256,8 @@ def test_create_url_submit_btn(
         By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS
     ).is_displayed()
 
+    verify_url_coloring_is_correct(browser)
+
 
 def test_create_url_using_enter_key(
     browser: WebDriver, create_test_utubs, provide_app: Flask
@@ -301,6 +304,8 @@ def test_create_url_using_enter_key(
     assert browser.find_element(
         By.CSS_SELECTOR, HPL.BUTTON_ACCESS_ALL_URLS
     ).is_displayed()
+
+    verify_url_coloring_is_correct(browser)
 
 
 def test_create_url_title_length_exceeded(

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -677,8 +677,19 @@ def verify_members_exist_in_member_deck(browser: WebDriver, member_ids: list[int
         WebDriverWait(browser, 10).until(
             lambda browser: element_is_visible(browser, member_selector)
         )
-        member_elem = browser.find_element(By.CSS_SELECTOR, member_selector)
-        assert member_elem.is_displayed()
+
+        def retry_assertion():
+            """Fetch element fresh and assert it's displayed to avoid stale reference."""
+            try:
+                fresh_elem = browser.find_element(By.CSS_SELECTOR, member_selector)
+                assert (
+                    fresh_elem.is_displayed()
+                ), f"Member element {member_id} is not displayed"
+                return True  # Success
+            except StaleElementReferenceException:
+                return False  # Retry
+
+        WebDriverWait(browser, 10).until(lambda _: retry_assertion())
 
 
 # URL Deck

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -660,22 +660,25 @@ def get_element(browser: WebDriver, selector: str) -> WebElement:
     return browser.find_element(By.CSS_SELECTOR, selector)
 
 
+def element_is_visible(browser: WebDriver, selector: str) -> bool:
+    """
+    Fetches the element fresh from the DOM each time and checks if it is displayed.
+    """
+    try:
+        element = browser.find_element(By.CSS_SELECTOR, selector)
+        return element.is_displayed()
+    except StaleElementReferenceException:
+        return False  # Retry if stale
+
+
 def verify_members_exist_in_member_deck(browser: WebDriver, member_ids: list[int]):
     for member_id in member_ids:
         member_selector = f"{HPL.BADGES_MEMBERS}[memberid='{member_id}']"
-
-        try:
-            WebDriverWait(browser, 5).until(
-                lambda driver: get_element(driver, member_selector).is_displayed()
-            )
-        except StaleElementReferenceException:
-            WebDriverWait(browser, 5).until(
-                lambda driver: get_element(driver, member_selector).is_displayed()
-            )
-        finally:
-            member_elem = wait_then_get_element(browser, member_selector, time=3)
-            assert member_elem is not None
-            assert member_elem.is_displayed()
+        WebDriverWait(browser, 10).until(
+            lambda browser: element_is_visible(browser, member_selector)
+        )
+        member_elem = browser.find_element(By.CSS_SELECTOR, member_selector)
+        assert member_elem.is_displayed()
 
 
 # URL Deck

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -283,6 +283,18 @@ def assert_not_visible_css_selector(
         assert False
 
 
+def assert_visible_css_selector(
+    browser: WebDriver, css_selector: str, time: float = 10
+):
+    try:
+        WebDriverWait(browser, time).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, css_selector))
+        )
+        assert True
+    except TimeoutException:
+        assert False
+
+
 def assert_on_404_page(browser: WebDriver):
     error_header = wait_then_get_element(browser, css_selector="h2", time=3)
     assert error_header is not None
@@ -365,6 +377,11 @@ def login_user_and_select_utub_by_utubid(
 ):
     session_id = create_user_session_and_provide_session_id(app, user_id)
     login_user_with_cookie_from_session(browser, session_id)
+
+    with app.app_context():
+        user: Users = Users.query.get(user_id)
+
+    assert_login_with_username(browser, user.username)
     wait_then_click_element(
         browser, f"{HPL.SELECTORS_UTUB}[utubid='{utub_id}']", time=10
     )
@@ -506,6 +523,7 @@ def verify_utub_selected(browser: WebDriver, app: Flask, utub_id: int):
         ).all()
         utub_url_ids: list[int] = [utub_url.id for utub_url in urls_in_utub]
         verify_utub_url_exists_in_url_deck(browser, utub_url_ids)
+        verify_url_coloring_is_correct(browser)
 
         tags_in_utub: list[Utub_Tags] = Utub_Tags.query.filter(
             Utub_Tags.utub_id == utub_id
@@ -875,6 +893,19 @@ def verify_update_url_state_is_hidden(url_row: WebElement):
     assert url_row.find_element(By.CSS_SELECTOR, HPL.GO_TO_URL_ICON).is_displayed()
 
 
+def verify_url_coloring_is_correct(browser: WebDriver):
+    url_cards = wait_then_get_elements(browser, HPL.ROW_VISIBLE_URL, time=3)
+    assert url_cards
+    url_cards_in_order = sorted(url_cards, key=lambda elem: elem.location["y"])
+
+    for idx, url_card in enumerate(url_cards_in_order):
+        if idx % 2 == 0:
+            assert "even" in url_card.get_dom_attribute("class")
+        else:
+            assert "odd" in url_card.get_dom_attribute("class")
+
+
+# Misc
 def invalidate_csrf_token_on_page(browser: WebDriver):
     browser.execute_script(
         """

--- a/tests/functional/utubs_ui/test_select_utub_ui.py
+++ b/tests/functional/utubs_ui/test_select_utub_ui.py
@@ -1,2 +1,113 @@
-# TODO Test when selecting UTub from home page
-# TODO Test when selecting UTub from another UTub
+from flask import Flask
+import pytest
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from tests.functional.utils_for_test import (
+    get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
+    login_user_and_select_utub_by_utubid,
+    login_user_to_home_page,
+    select_utub_by_id,
+    verify_url_coloring_is_correct,
+    verify_utub_selected,
+)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import (
+    assert_in_created_utub,
+    assert_in_member_utub,
+)
+
+pytestmark = pytest.mark.utubs_ui
+
+# TODO: Test when selecting UTub from home page
+# TODO: Test when selecting UTub from another UTub
+
+
+def test_select_member_utub_from_home_page(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a fresh load of the U4i Home page, where user is in multiple UTubs
+    WHEN user clicks one of the UTubs they did not create
+    THEN ensure the all appropriate elements are visible and ready
+    """
+
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_did_not_create = get_utub_this_user_did_not_create(app, user_id_for_test)
+
+    login_user_to_home_page(app, browser, user_id_for_test)
+    select_utub_by_id(browser, utub_user_did_not_create.id)
+    verify_utub_selected(browser, app, utub_user_did_not_create.id)
+    verify_url_coloring_is_correct(browser)
+    assert_in_member_utub(browser)
+
+
+def test_select_created_utub_from_home_page(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a fresh load of the U4i Home page, where user is in multiple UTubs
+    WHEN user clicks one of the UTubs they did create
+    THEN ensure the all appropriate elements are visible and ready
+    """
+
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_did_not_create = get_utub_this_user_created(app, user_id_for_test)
+
+    login_user_to_home_page(app, browser, user_id_for_test)
+    select_utub_by_id(browser, utub_user_did_not_create.id)
+    verify_utub_selected(browser, app, utub_user_did_not_create.id)
+    verify_url_coloring_is_correct(browser)
+    assert_in_created_utub(browser)
+
+
+def test_select_member_utub_from_created_utub(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a fresh load of the U4i Home page, where user is in multiple UTubs, and they select a UTub they created
+    WHEN user clicks one of the UTubs they did not create
+    THEN ensure the all appropriate elements are visible and ready
+    """
+
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_did_create = get_utub_this_user_created(app, user_id_for_test)
+    utub_user_did_not_create = get_utub_this_user_did_not_create(app, user_id_for_test)
+
+    login_user_to_home_page(app, browser, user_id_for_test)
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_did_create.id
+    )
+    verify_utub_selected(browser, app, utub_user_did_create.id)
+
+    select_utub_by_id(browser, utub_user_did_not_create.id)
+    verify_utub_selected(browser, app, utub_user_did_not_create.id)
+    verify_url_coloring_is_correct(browser)
+    assert_in_member_utub(browser)
+
+
+def test_select_created_utub_from_member_utub(
+    browser: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    GIVEN a fresh load of the U4i Home page, where user is in multiple UTubs and they select a UTub they did not create
+    WHEN user clicks one of the UTubs they did create
+    THEN ensure the all appropriate elements are visible and ready
+    """
+
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_did_not_create = get_utub_this_user_created(app, user_id_for_test)
+    utub_user_did_create = get_utub_this_user_created(app, user_id_for_test)
+
+    login_user_and_select_utub_by_utubid(
+        app, browser, user_id_for_test, utub_user_did_not_create.id
+    )
+    verify_utub_selected(browser, app, utub_user_did_not_create.id)
+
+    select_utub_by_id(browser, utub_user_did_create.id)
+    verify_utub_selected(browser, app, utub_user_did_create.id)
+    verify_url_coloring_is_correct(browser)
+    assert_in_created_utub(browser)

--- a/tests/functional/utubs_ui/test_select_utub_ui.py
+++ b/tests/functional/utubs_ui/test_select_utub_ui.py
@@ -18,9 +18,6 @@ from tests.functional.utubs_ui.utils_for_test_utub_ui import (
 
 pytestmark = pytest.mark.utubs_ui
 
-# TODO: Test when selecting UTub from home page
-# TODO: Test when selecting UTub from another UTub
-
 
 def test_select_member_utub_from_home_page(
     browser: WebDriver, create_test_tags, provide_app: Flask

--- a/tests/functional/utubs_ui/utils_for_test_utub_ui.py
+++ b/tests/functional/utubs_ui/utils_for_test_utub_ui.py
@@ -8,6 +8,8 @@ from src import db
 from src.models.utubs import Utubs
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
+    assert_not_visible_css_selector,
+    assert_visible_css_selector,
     clear_then_send_keys,
     wait_then_click_element,
     wait_then_get_element,
@@ -224,3 +226,23 @@ def hover_over_utub_title_to_show_add_utub_description(browser: WebDriver):
     assert wait_until_hidden(browser, HPL.SUBHEADER_URL_DECK, timeout=3) is not None
     utub_desc_elem = browser.find_element(By.CSS_SELECTOR, HPL.SUBHEADER_URL_DECK)
     assert not utub_desc_elem.is_displayed()
+
+
+def assert_in_created_utub(browser: WebDriver):
+    assert_visible_css_selector(browser, HPL.BUTTON_MEMBER_CREATE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UTUB_DELETE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UTUB_CREATE)
+    assert_not_visible_css_selector(browser, HPL.BUTTON_UTUB_LEAVE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UTUB_TAG_CREATE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UNSELECT_ALL)
+    assert_visible_css_selector(browser, HPL.BUTTON_CORNER_URL_CREATE)
+
+
+def assert_in_member_utub(browser: WebDriver):
+    assert_not_visible_css_selector(browser, HPL.BUTTON_MEMBER_CREATE)
+    assert_not_visible_css_selector(browser, HPL.BUTTON_UTUB_DELETE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UTUB_CREATE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UTUB_LEAVE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UTUB_TAG_CREATE)
+    assert_visible_css_selector(browser, HPL.BUTTON_UNSELECT_ALL)
+    assert_visible_css_selector(browser, HPL.BUTTON_CORNER_URL_CREATE)


### PR DESCRIPTION
Fixes URL coloring bug associated with #366 

Adds tests to verify UTub selection is done based on whether they are selecting a UTub they did not create or did create, and whether they are coming from the home page or from another (opposite) UTub.

Closes #366 