### PR TITLE
Fix bug where members could try and update empty utub descriptions

### DIFF
--- a/src/static/scripts/utubs.js
+++ b/src/static/scripts/utubs.js
@@ -498,9 +498,9 @@ function buildSelectedUTub(selectedUTub) {
     utubDescriptionHeader.text(utubDescription);
     removeEventListenersForShowCreateUTubDescIfEmptyDesc();
   } else {
-    //const utubTitle = $("#URLDeckHeader");
-    //utubTitle.off("mouseenter.createUTubdescription");
-    allowHoverOnUTubTitleToCreateDescriptionIfDescEmpty();
+    isCurrentUserOwner
+      ? allowHoverOnUTubTitleToCreateDescriptionIfDescEmpty()
+      : null;
     utubDescriptionHeader.text(null);
   }
 


### PR DESCRIPTION
Fixes bug where members could try and update UTub descriptions if they were empty.

Closes #395 