### PR TITLE
[Bug] Fix error page when user adds strings to query param

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,7 @@ services:
       export SECRET_KEY=$(cat /run/secrets/SECRET_KEY) &&
       export BASE_EMAIL=$(cat /run/secrets/BASE_EMAIL) &&
       export REDIS_PASSWORD=$(cat /run/secrets/REDIS_PASSWORD) &&
+      export ASSET_VERSION=$(date +%s) &&
       . /code/venv/bin/activate &&
       flask db upgrade &&
       flask shorturls add &&

--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -708,6 +708,7 @@ The HTML body on a 200 response contains the following JSON.
 > curl -X GET \
 >  https://urls4irl.app/utub/1 \
 >  -H 'Cookie: YOUR_COOKIE' \
+>  -H 'X-Requested-With: XMLHTTPRequest' \
 > ```
 
 </details>
@@ -749,6 +750,7 @@ The HTML body on a 200 response contains the following JSON.
 > curl -X GET \
 >  https://urls4irl.app/utubs \
 >  -H 'Cookie: YOUR_COOKIE' \
+>  -H 'X-Requested-With: XMLHTTPRequest' \
 > ```
 
 </details>
@@ -1316,6 +1318,15 @@ User not member of this UTub.
 >     "status": "Failure",
 >     "message": "Unable to retrieve this URL.",
 > }
+> ```
+
+##### Example cURL
+
+> ```bash
+> curl -X GET \
+>  https://urls4irl.app/utubs/1/urls/2 \
+>  -H 'Cookie: YOUR_COOKIE' \
+>  -H 'X-Requested-With: XMLHTTPRequest' \
 > ```
 
 </details>

--- a/src/static/scripts/utubs.js
+++ b/src/static/scripts/utubs.js
@@ -114,7 +114,8 @@ window.addEventListener("pageshow", function (e) {
   const searchParams = new URLSearchParams(window.location.search);
   if (searchParams.size === 0) return;
 
-  const utubId = searchParams.get("UTubID");
+  const utubId = searchParams.get(STRINGS.UTUB_QUERY_PARAM);
+  console.log(`utub id is: ${utubId}`);
   if (searchParams.size > 1 || utubId === null) {
     window.location.assign(routes.errorPage);
   }
@@ -472,10 +473,11 @@ function buildSelectedUTub(selectedUTub) {
       JSON.stringify(selectedUTub.id)
   ) {
     // Push UTub state to browser history if no history, or if previous UTub history is different
+    const utubid_key = STRINGS.UTUB_QUERY_PARAM;
     window.history.pushState(
       { UTubID: selectedUTub.id },
       "",
-      "/home?UTubID=" + selectedUTub.id,
+      `/home?${utubid_key}=${selectedUTub.id}`,
     );
 
     sessionStorage.setItem("fullyLoaded", "true");

--- a/src/templates/_routes_constants.html
+++ b/src/templates/_routes_constants.html
@@ -82,4 +82,5 @@
     const routes = new Routes;
 
     {% include '_constants.html' %}
+    {% include '_strings.html' %}
 </script>

--- a/src/templates/_strings.html
+++ b/src/templates/_strings.html
@@ -1,0 +1,14 @@
+class Strings {
+	constructor() {
+		if (!Strings.instance) {
+
+			// Query Param Strings
+			this.UTUB_QUERY_PARAM = "{{CONSTANTS.STRINGS.UTUB_QUERY_PARAM}}";
+			Strings.instance = this;
+		}
+
+		return Strings.instance;
+	}
+}
+
+const STRINGS = new Strings;

--- a/src/urls/routes.py
+++ b/src/urls/routes.py
@@ -23,6 +23,7 @@ from src.urls.utils import build_form_errors
 from src.utils.email_validation import email_validation_required
 from src.utils.strings.json_strs import STD_JSON_RESPONSE
 from src.utils.strings.url_strs import URL_SUCCESS, URL_FAILURE, URL_NO_CHANGE
+from src.utils.strings.url_validation_strs import URL_VALIDATION
 
 urls = Blueprint("urls", __name__)
 logger = logging.getLogger(__name__)
@@ -309,6 +310,13 @@ def get_url(utub_id: int, utub_url_id: int):
         utub_id (int): The UTub ID containing the relevant URL
         utub_url_id (int): The URL ID to be modified
     """
+    if (
+        request.headers.get(URL_VALIDATION.X_REQUESTED_WITH, None)
+        != URL_VALIDATION.XMLHTTPREQUEST
+    ):
+        # Ensure JSON not shown in the browser
+        abort(404)
+
     # Following line enforces standard response of 404 error page
     Utubs.query.get_or_404(utub_id)
 

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,3 +1,6 @@
+from src.utils.strings.utub_strs import UTUB_ID_QUERY_PARAM
+
+
 class EMAIL_CONSTANTS:
     MAX_EMAIL_ATTEMPTS_IN_HOUR = 5
     WAIT_TO_RETRY_BEFORE_MAX_ATTEMPTS = 60
@@ -40,6 +43,10 @@ class CONFIG_CONSTANTS:
     SESSION_LIFETIME = 31 * 86400  # 31 days before session and CSRF expiration
 
 
+class STRINGS:
+    UTUB_QUERY_PARAM = UTUB_ID_QUERY_PARAM
+
+
 class CONSTANTS:
     EMAILS = EMAIL_CONSTANTS()
     USERS = USER_CONSTANTS()
@@ -47,3 +54,4 @@ class CONSTANTS:
     URLS = URL_CONSTANTS()
     TAGS = TAG_CONSTANTS()
     CONFIG = CONFIG_CONSTANTS()
+    STRINGS = STRINGS()

--- a/tests/integration/utubs/test_get_home_route.py
+++ b/tests/integration/utubs/test_get_home_route.py
@@ -1,0 +1,82 @@
+from typing import Tuple
+
+from flask import Flask, url_for
+from flask.testing import FlaskClient
+import pytest
+
+from src.models.users import Users
+from src.utils.all_routes import ROUTES
+from src.utils.strings.utub_strs import UTUB_ID_QUERY_PARAM
+
+pytestmark = pytest.mark.utubs
+
+
+def test_get_invalid_utub_on_home_page(
+    every_user_makes_a_unique_utub,
+    login_first_user_without_register: Tuple[FlaskClient, str, Users, Flask],
+):
+    """
+    GIVEN a user who is not a member a newly formed UTub
+    WHEN the user requests the details of that newly formed UTub
+    THEN verify the server resopnds with a 404 message
+
+    Args:
+        every_user_makes_a_unique_utub (None): Fixture to create a new UTub for every user, with no members but the creators
+        login_second_user_without_register: Tuple[FlaskClient, str, Users, Flask]): Fixture to login in the member instead of UTub creator
+    """
+    for utubid in ("5/asdf", "5.1", "9.abc", "-1"):
+        client, _, _, _ = login_first_user_without_register
+        url_to_get = url_for(ROUTES.UTUBS.HOME) + f"?{UTUB_ID_QUERY_PARAM}={utubid}"
+
+        response = client.get(url_to_get)
+
+        assert response.status_code == 404
+
+
+def test_get_nonexistent_utub_on_home_page(
+    every_user_makes_a_unique_utub,
+    login_first_user_without_register: Tuple[FlaskClient, str, Users, Flask],
+):
+    """
+    GIVEN a user who is not a member a newly formed UTub
+    WHEN the user requests the details of that newly formed UTub
+    THEN verify the server resopnds with a 404 message
+
+    Args:
+        every_user_makes_a_unique_utub (None): Fixture to create a new UTub for every user, with no members but the creators
+        login_second_user_without_register: Tuple[FlaskClient, str, Users, Flask]): Fixture to login in the member instead of UTub creator
+    """
+    for utubid in (
+        2147483648,
+        999999,
+    ):
+        client, _, _, _ = login_first_user_without_register
+        url_to_get = url_for(ROUTES.UTUBS.HOME) + f"?{UTUB_ID_QUERY_PARAM}={utubid}"
+
+        response = client.get(url_to_get)
+        assert response.status_code == 404
+
+
+def test_get_home_page(
+    every_user_makes_a_unique_utub,
+    login_first_user_without_register: Tuple[FlaskClient, str, Users, Flask],
+):
+    """
+    GIVEN a user who is not a member a newly formed UTub
+    WHEN the user requests the details of that newly formed UTub
+    THEN verify the server resopnds with a 404 message
+
+    Args:
+        every_user_makes_a_unique_utub (None): Fixture to create a new UTub for every user, with no members but the creators
+        login_second_user_without_register: Tuple[FlaskClient, str, Users, Flask]): Fixture to login in the member instead of UTub creator
+    """
+    client, _, user, _ = login_first_user_without_register
+    logged_in_username = user.username
+    url_to_get = url_for(ROUTES.UTUBS.HOME)
+
+    response = client.get(url_to_get)
+    assert response.status_code == 200
+    assert (
+        f'<b id="loggedInAsHeader">Logged in as {logged_in_username}</b>'.encode()
+        in response.data
+    )

--- a/tests/integration/utubs/test_get_utubs_summary_route.py
+++ b/tests/integration/utubs/test_get_utubs_summary_route.py
@@ -9,7 +9,9 @@ from src.models.users import Users
 from src.models.utubs import Utubs
 from src.utils.all_routes import ROUTES
 from src.utils.strings.form_strs import UTUB_FORM
+from src.utils.strings.html_identifiers import IDENTIFIERS
 from src.utils.strings.model_strs import MODELS
+from src.utils.strings.url_validation_strs import URL_VALIDATION
 
 pytestmark = pytest.mark.utubs
 
@@ -25,7 +27,10 @@ def test_get_utubs_if_has_no_utubs(
     """
     client, _, _, _ = login_first_user_with_register
 
-    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+        headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
+    )
 
     assert response.status_code == 200
     response_json = response.json
@@ -52,7 +57,10 @@ def test_get_utubs_if_has_one_utub(
             if current_user.id in [member.user_id for member in utub.members]
         ]
 
-    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+        headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
+    )
 
     assert response.status_code == 200
     assert utub_summary == response.json
@@ -78,9 +86,14 @@ def test_get_utubs_if_has_multiple_utubs(
             if current_user.id in [member.user_id for member in utub.members]
         ]
 
-    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+        headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
+    )
 
     assert response.status_code == 200
+    assert isinstance(response.json, list)
+    assert isinstance(response.json[0], dict)
     assert sorted(utub_summary, key=lambda x: x[MODELS.ID]) == sorted(
         response.json, key=lambda x: x[MODELS.ID]
     )
@@ -102,10 +115,13 @@ def test_get_utubs_sorted_based_on_last_updated(
     with app.app_context():
         utub_summary = _get_ordered_utub_summary()
 
-    last_utub_id: int = utub_summary[-1][MODELS.ID]
-    last_utub_name: str = utub_summary[-1][MODELS.NAME]
+    last_utub_id = int(utub_summary[-1][MODELS.ID])
+    last_utub_name = str(utub_summary[-1][MODELS.NAME])
 
-    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+        headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
+    )
 
     assert response.status_code == 200
     assert utub_summary == response.json
@@ -123,15 +139,18 @@ def test_get_utubs_sorted_based_on_last_updated(
     assert response.status_code == 200
 
     # Check last UTub is now first
-    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+        headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
+    )
     assert response.status_code == 200
     with app.app_context():
         utub_summary = _get_ordered_utub_summary()
     assert utub_summary == response.json
     assert utub_summary[0][MODELS.ID] == last_utub_id
 
-    middle_utub_id: int = utub_summary[-2][MODELS.ID]
-    middle_utub_name: str = utub_summary[-2][MODELS.NAME]
+    middle_utub_id = int(utub_summary[-2][MODELS.ID])
+    middle_utub_name = str(utub_summary[-2][MODELS.NAME])
 
     utub_name_form = {
         UTUB_FORM.UTUB_NAME: middle_utub_name + "88",
@@ -146,7 +165,10 @@ def test_get_utubs_sorted_based_on_last_updated(
     assert response.status_code == 200
 
     # Check middle UTub is now first
-    response = client.get(url_for(ROUTES.UTUBS.GET_UTUBS))
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+        headers={URL_VALIDATION.X_REQUESTED_WITH: URL_VALIDATION.XMLHTTPREQUEST},
+    )
     assert response.status_code == 200
     with app.app_context():
         utub_summary = _get_ordered_utub_summary()
@@ -161,3 +183,23 @@ def _get_ordered_utub_summary() -> list[dict[str, int | str]]:
         for utub in all_utubs
         if current_user.id in [member.user_id for member in utub.members]
     ]
+
+
+def test_get_utubs_without_ajax_request(
+    every_user_makes_a_unique_utub,
+    login_first_user_without_register: Tuple[FlaskClient, str, Users, Flask],
+):
+    """
+    GIVEN a logged in user with ID == 1, with one UTub.
+    WHEN the user requests a summary of all
+        their UTubs
+    THEN verify the response body contains an array with one UTub in the JSON
+    """
+    client, _, _, _ = login_first_user_without_register
+
+    response = client.get(
+        url_for(ROUTES.UTUBS.GET_UTUBS),
+    )
+
+    assert response.status_code == 404
+    assert IDENTIFIERS.HTML_404.encode() in response.data


### PR DESCRIPTION
Fixes invalid query parameters being appended to the URL when using `UTubID` as the initial query parameter.

Adds tests to verify the behavior.

Passes a new STRINGS object in Jinja templating to allow to for future addition of strings passed from backend to frontend to allow a single source of STRING truth.

Closes #399 