### PR TITLE
Make accessing a UTub update it's last updated field

### DIFF
--- a/src/utubs/routes.py
+++ b/src/utubs/routes.py
@@ -94,6 +94,10 @@ def get_single_utub(utub_id: int):
 
     utub: Utubs = Utubs.query.get_or_404(utub_id)
     utub_data_serialized = utub.serialized(current_user.id)
+
+    utub.set_last_updated()
+    db.session.commit()
+
     return jsonify(utub_data_serialized)
 
 

--- a/tests/integration/utubs/test_get_detailed_utub_info.py
+++ b/tests/integration/utubs/test_get_detailed_utub_info.py
@@ -35,6 +35,9 @@ def test_get_valid_utub_as_creator(
             Utubs.utub_creator == current_user.id
         ).first()
         id_of_utub = utub_user_creator_of.id
+        initial_last_updated = utub_user_creator_of.last_updated
+        current_user_id = current_user.id
+        current_user_username = current_user.username
 
     response = client.get(
         url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=id_of_utub),
@@ -46,20 +49,26 @@ def test_get_valid_utub_as_creator(
 
     assert response_json is not None
     assert response_json[MODELS.ID] == id_of_utub
-    assert response_json[MODELS.CREATED_BY] == current_user.id
+    assert response_json[MODELS.CREATED_BY] == current_user_id
     assert response_json[MODELS.DESCRIPTION] == utub_user_creator_of.utub_description
     assert response_json[MODELS.NAME] == utub_user_creator_of.name
     assert response_json[MODELS.IS_CREATOR] == (
-        current_user.id == utub_user_creator_of.utub_creator
+        current_user_id == utub_user_creator_of.utub_creator
     )
 
     user_dict: dict[str, int | str] = {
-        MODELS.ID: current_user.id,
-        MODELS.USERNAME: current_user.username,
+        MODELS.ID: current_user_id,
+        MODELS.USERNAME: current_user_username,
     }
     assert user_dict in response_json[MODELS.MEMBERS]
     assert len(response_json[MODELS.TAGS]) == 0
     assert len(response_json[MODELS.URLS]) == 0
+
+    with app.app_context():
+        utub_user_creator_of = Utubs.query.get(id_of_utub)
+        assert (
+            utub_user_creator_of.last_updated - initial_last_updated
+        ).total_seconds() > 0
 
 
 def test_get_valid_utub_as_member(
@@ -82,6 +91,9 @@ def test_get_valid_utub_as_member(
             Utubs.utub_creator != current_user.id
         ).first()
         id_of_utub = utub_user_member_of.id
+        initial_last_updated = utub_user_member_of.last_updated
+        current_user_id = current_user.id
+        current_user_username = current_user.username
 
     response = client.get(
         url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=id_of_utub),
@@ -93,20 +105,26 @@ def test_get_valid_utub_as_member(
 
     assert response_json is not None
     assert response_json[MODELS.ID] == id_of_utub
-    assert response_json[MODELS.CREATED_BY] != current_user.id
+    assert response_json[MODELS.CREATED_BY] != current_user_id
     assert response_json[MODELS.DESCRIPTION] == utub_user_member_of.utub_description
     assert response_json[MODELS.NAME] == utub_user_member_of.name
     assert response_json[MODELS.IS_CREATOR] == (
-        current_user.id == utub_user_member_of.utub_creator
+        current_user_id == utub_user_member_of.utub_creator
     )
 
     user_dict: dict[str, int | str] = {
-        MODELS.ID: current_user.id,
-        MODELS.USERNAME: current_user.username,
+        MODELS.ID: current_user_id,
+        MODELS.USERNAME: current_user_username,
     }
     assert user_dict in response_json[MODELS.MEMBERS]
     assert len(response_json[MODELS.TAGS]) == 0
     assert len(response_json[MODELS.URLS]) == 0
+
+    with app.app_context():
+        utub_user_member_of = Utubs.query.get(id_of_utub)
+        assert (
+            utub_user_member_of.last_updated - initial_last_updated
+        ).total_seconds() > 0
 
 
 def test_get_valid_utub_as_not_member(
@@ -158,9 +176,12 @@ def test_get_valid_utub_with_members_urls_no_tags(
         utub_user_is_member_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator != current_user.id
         ).first()
+        id_of_utub = utub_user_is_member_of.id
         all_urls_in_utub: list[Utub_Urls] = utub_user_is_member_of.utub_urls
         only_url_in_utub: Utub_Urls = all_urls_in_utub[-1]
         standalone_url: Urls = only_url_in_utub.standalone_url
+        initial_last_updated = utub_user_is_member_of.last_updated
+        current_user_id = current_user.id
 
     response = client.get(
         url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=utub_user_is_member_of.id),
@@ -173,26 +194,32 @@ def test_get_valid_utub_with_members_urls_no_tags(
 
     assert response_json is not None
     assert response_json[MODELS.ID] == utub_user_is_member_of.id
-    assert response_json[MODELS.CREATED_BY] != current_user.id
+    assert response_json[MODELS.CREATED_BY] != current_user_id
     assert response_json[MODELS.DESCRIPTION] == utub_user_is_member_of.utub_description
     assert response_json[MODELS.NAME] == utub_user_is_member_of.name
     assert response_json[MODELS.IS_CREATOR] == (
-        current_user.id == utub_user_is_member_of.utub_creator
+        current_user_id == utub_user_is_member_of.utub_creator
     )
 
     # Clarify that this user did not add the URL to the UTub
-    assert only_url_in_utub.user_id != current_user.id
+    assert only_url_in_utub.user_id != current_user_id
 
     for url in all_urls_in_utub:
         url_dict = {
-            MODELS.CAN_DELETE: current_user.id == url.user_id
-            or current_user.id == utub_user_is_member_of.utub_creator,
+            MODELS.CAN_DELETE: current_user_id == url.user_id
+            or current_user_id == utub_user_is_member_of.utub_creator,
             MODELS.UTUB_URL_ID: url.id,
             MODELS.URL_STRING: standalone_url.url_string,
             MODELS.URL_TAG_IDS: [],
             MODELS.URL_TITLE: url.url_title,
         }
         assert url_dict in response_json[MODELS.URLS]
+
+    with app.app_context():
+        utub_user_member_of = Utubs.query.get(id_of_utub)
+        assert (
+            utub_user_member_of.last_updated - initial_last_updated
+        ).total_seconds() > 0
 
 
 def test_get_valid_utub_with_members_urls_tags(
@@ -218,6 +245,7 @@ def test_get_valid_utub_with_members_urls_tags(
         utub_user_is_creator_of: Utubs = Utubs.query.filter(
             Utubs.utub_creator == current_user.id
         ).first()
+        id_of_utub = utub_user_is_creator_of.id
         all_urls_in_utub: list[Utub_Urls] = Utub_Urls.query.filter(
             Utub_Urls.utub_id == utub_user_is_creator_of.id
         ).all()
@@ -225,6 +253,8 @@ def test_get_valid_utub_with_members_urls_tags(
         all_tags: list[Utub_Tags] = Utub_Tags.query.filter(
             Utub_Tags.utub_id == utub_user_is_creator_of.id
         ).all()
+        initial_last_updated = utub_user_is_creator_of.last_updated
+        current_user_id = current_user.id
 
     response = client.get(
         url_for(ROUTES.UTUBS.GET_SINGLE_UTUB, utub_id=utub_user_is_creator_of.id),
@@ -237,11 +267,11 @@ def test_get_valid_utub_with_members_urls_tags(
 
     assert response_json is not None
     assert response_json[MODELS.ID] == utub_user_is_creator_of.id
-    assert response_json[MODELS.CREATED_BY] == current_user.id
+    assert response_json[MODELS.CREATED_BY] == current_user_id
     assert response_json[MODELS.DESCRIPTION] == utub_user_is_creator_of.utub_description
     assert response_json[MODELS.NAME] == utub_user_is_creator_of.name
     assert response_json[MODELS.IS_CREATOR] == (
-        current_user.id == utub_user_is_creator_of.utub_creator
+        current_user_id == utub_user_is_creator_of.utub_creator
     )
 
     assert len(response_json[MODELS.MEMBERS]) == len(all_users)
@@ -260,8 +290,8 @@ def test_get_valid_utub_with_members_urls_tags(
             url_object for url_object in all_urls if url_object.id == url.url_id
         ][-1].url_string
         url_dict = {
-            MODELS.CAN_DELETE: current_user.id == url.id
-            or current_user.id == utub_user_is_creator_of.utub_creator,
+            MODELS.CAN_DELETE: current_user_id == url.id
+            or current_user_id == utub_user_is_creator_of.utub_creator,
             MODELS.UTUB_URL_ID: url.id,
             MODELS.URL_STRING: url_string,
             MODELS.URL_TAG_IDS: sorted([tag.id for tag in all_tags]),
@@ -272,3 +302,9 @@ def test_get_valid_utub_with_members_urls_tags(
     for tag in all_tags:
         tag_dict = {MODELS.ID: tag.id, MODELS.TAG_STRING: tag.tag_string}
         assert tag_dict in response_json[MODELS.TAGS]
+
+    with app.app_context():
+        utub_user_is_creator_of = Utubs.query.get(id_of_utub)
+        assert (
+            utub_user_is_creator_of.last_updated - initial_last_updated
+        ).total_seconds() > 0


### PR DESCRIPTION
Updates so that whenever a User accesses a UTub, the UTub's `last_updated` field is also updated.

Includes tests to verify `last_updated` is field when a UTub is accessed.

Closes #400 