### PR TITLE
Fix race condition causing display issues on pageshow

### DIFF
--- a/src/static/scripts/components/utubs_deck/utubs_deck.js
+++ b/src/static/scripts/components/utubs_deck/utubs_deck.js
@@ -1,19 +1,5 @@
 "use strict";
 
-$(document).ready(function () {
-  const timeoutID = showUTubLoadingIconAndSetTimeout();
-  setUIWhenNoUTubSelected();
-  // Instantiate UTubDeck with user's accessible UTubs
-  try {
-    buildUTubDeck(UTubs, timeoutID);
-  } catch (error) {
-    console.log("Something is wrong!");
-    console.log(error);
-  }
-
-  setCreateDeleteUTubEventListeners();
-});
-
 // Utility function to show a loading icon when loading UTubs
 function showUTubLoadingIconAndSetTimeout() {
   return setTimeout(function () {

--- a/src/static/scripts/components/window_events.js
+++ b/src/static/scripts/components/window_events.js
@@ -29,13 +29,13 @@ window.addEventListener("popstate", function (e) {
 });
 
 window.addEventListener("pageshow", function (e) {
-  if (!this.sessionStorage.getItem("fullyLoaded")) {
+  if (!this.sessionStorage.getItem("fullyLoaded") || !getNumOfUTubs()) {
+    const timeoutID = showUTubLoadingIconAndSetTimeout();
     setUIWhenNoUTubSelected();
-    getAllUTubs().then((utubData) => {
-      buildUTubDeck(utubData);
-      setMemberDeckWhenNoUTubSelected();
-      setTagDeckSubheaderWhenNoUTubSelected();
-    });
+    buildUTubDeck(UTubs, timeoutID);
+    setMemberDeckWhenNoUTubSelected();
+    setTagDeckSubheaderWhenNoUTubSelected();
+    setCreateDeleteUTubEventListeners();
   }
 
   if (history.state && history.state.UTubID) {

--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -88,8 +88,8 @@ valid_urls = {
     "https://immich.app/docs/overview/introduction/": [
         "https://immich.app/docs/overview/introduction",
     ],
-    "https://developers.google.com/calendar/api/guides/overview": [
-        "https://developers.google.com/calendar/api/guides/overview",
+    "https://developers.google.com/workspace/calendar/api/guides/overview": [
+        "https://developers.google.com/workspace/calendar/api/guides/overview",
     ],
     "https://developers.google.com/workspace/keep/api/reference/rest": [
         "https://developers.google.com/workspace/keep/api/reference/rest"


### PR DESCRIPTION
Fixes bug by removing second call to `buildUTubDeck` in `$(document).ready`, and moves all functionality to `pageshow` event listener.

Closes #428 