### PR TITLE
Add Mobile UI Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
           - [11, 'UI Member Functional Tests']
           - [12, 'UI UTub URL Functional Tests']
           - [13, 'UI UTub Tags Functional Tests']
+          - [14, 'UI Mobile Functional Tests']
 
     name: ${{ format('{0}', matrix.worker[1]) }}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,4 @@ markers =
 	members_ui: associated with members UI on home page
 	urls_ui: associated with URL UI on home page
 	tags_ui: associated with tags UI on home page
+	mobile_ui: associated with mobile UI

--- a/src/static/scripts/components/mobile.js
+++ b/src/static/scripts/components/mobile.js
@@ -39,6 +39,7 @@ function setMobileUIWhenUTubSelectedOrURLNavSelected() {
   $(".home#toUTubs").removeClass("hidden");
   $(".home#toMembers").removeClass("hidden");
   $(".home#toTags").removeClass("hidden");
+  $(".home#toURLs").addClass("hidden");
 
   $(".deck#MemberDeck").removeClass("visible-flex");
   $(".deck#TagDeck").removeClass("visible-flex");
@@ -107,7 +108,7 @@ function setMobileUIWhenTagDeckSelected() {
   $(".deck#MemberDeck").addClass("hidden");
 
   $(".home#toUTubs").removeClass("hidden");
-  $(".home#toTags").removeClass("hidden");
+  $(".home#toTags").addClass("hidden");
   $(".home#toURLs").removeClass("hidden");
   $(".home#toMembers").removeClass("hidden");
 

--- a/src/static/scripts/components/mobile.js
+++ b/src/static/scripts/components/mobile.js
@@ -29,6 +29,10 @@ $(document).ready(function () {
   });
 });
 
+function isMobile() {
+  return $(window).width() < TABLET_WIDTH;
+}
+
 function setMobileUIWhenUTubSelectedOrURLNavSelected() {
   $(".panel#leftPanel").addClass("hidden");
   $(".panel#centerPanel").addClass("visible-flex");
@@ -72,6 +76,9 @@ function setMobileUIWhenUTubDeckSelected() {
   $(".deck#UTubDeck").removeClass("hidden");
 
   NAVBAR_TOGGLER.toggler.hide();
+  if ($(".UTubSelector.active").length) {
+    makeUTubSelectableAgainIfMobile($(".UTubSelector.active"));
+  }
 }
 
 function setMobileUIWhenMemberDeckSelected() {

--- a/src/static/scripts/components/utubs_deck/delete_utub_form.js
+++ b/src/static/scripts/components/utubs_deck/delete_utub_form.js
@@ -117,6 +117,8 @@ function deleteUTubSuccess() {
       resetUTubDeckIfNoUTubs();
       hideIfShown($("#utubTagBtnCreate"));
     }
+
+    isMobile() ? setMobileUIWhenUTubNotSelectedOrUTubDeleted() : null;
   });
 }
 

--- a/src/static/scripts/components/utubs_deck/utubs.js
+++ b/src/static/scripts/components/utubs_deck/utubs.js
@@ -93,12 +93,15 @@ function selectUTub(selectedUTubID, utubSelector) {
 
   currentlySelected.removeClass("active");
   utubSelector.addClass("active");
+  getSelectedUTubInfo(selectedUTubID);
+}
 
+function getSelectedUTubInfo(selectedUTubID) {
   getUTubInfo(selectedUTubID).then(
     (selectedUTub) => {
       buildSelectedUTub(selectedUTub);
       // If mobile, go straight to URL deck
-      if ($(window).width() < TABLET_WIDTH) {
+      if (isMobile()) {
         setMobileUIWhenUTubSelectedOrURLNavSelected();
       }
     },
@@ -139,4 +142,13 @@ function createUTubSelector(utubName, utubID, index) {
     .append(utubSelectorText);
 
   return utubSelector;
+}
+
+function makeUTubSelectableAgainIfMobile(utub) {
+  $(utub).offAndOn("click.selectUTubMobile", function (e) {
+    e.stopPropagation();
+    e.preventDefault();
+    getSelectedUTubInfo($(this).attr("utubid"));
+    $(this).off("click.selectUTubMobile");
+  });
 }

--- a/src/static/styles/splash.css
+++ b/src/static/styles/splash.css
@@ -193,6 +193,7 @@ img {
 #ForgotPasswordText {
     color: black;
 }
+
 /* Login-Register */
 
 /* Validate Email */
@@ -240,5 +241,20 @@ img {
 
     #splash-major-text {
         text-align: center;
+    }
+}
+
+@media (max-width: 992px) {
+    .bg-cover {
+        overflow-y: hidden;
+    }
+
+    .bg-img {
+        /* https://images.unsplash.com/photo-1523240795612-9a054b0db644?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1740&q=80 */
+        background: url("splash.jpg");
+        background-size: cover;
+        background-position: center center;
+        background-repeat: no-repeat;
+        min-height: 380px;
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ TEST_SPLIT = (
     "members_ui",
     "urls_ui",
     "tags_ui",
+    "mobile_ui",
 )
 
 

--- a/tests/functional/home_ui/test_home_ui.py
+++ b/tests/functional/home_ui/test_home_ui.py
@@ -57,7 +57,7 @@ def test_logout(browser: WebDriver, create_test_users, provide_app: Flask):
     navbar = wait_then_get_element(browser, SPL.SPLASH_NAVBAR)
     assert navbar is not None
 
-    login_btn = navbar.find_element(By.CSS_SELECTOR, SPL.BUTTON_LOGIN)
+    login_btn = navbar.find_element(By.CSS_SELECTOR, SPL.NAVBAR_LOGIN)
 
     assert login_btn.is_displayed()
 

--- a/tests/functional/home_ui/test_mobile_home_ui.py
+++ b/tests/functional/home_ui/test_mobile_home_ui.py
@@ -1,12 +1,463 @@
-# TODO: Test clicking on UTub brings to URLs panel
-# TODO: Test clicking on already selected UTub brings to URLs panel
+from flask import Flask
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
 
-# TODO: Test navbar shows only Logout and Logged in as on UTub panel - UTub unselected
+from src.models.utubs import Utubs
+from tests.functional.locators import HomePageLocators as HPL
+from tests.functional.utils_for_test import (
+    Decks,
+    assert_not_visible_css_selector,
+    assert_visible_css_selector,
+    click_on_navbar,
+    get_utub_this_user_created,
+    login_user_and_select_utub_by_utubid_mobile,
+    login_user_to_home_page,
+    verify_panel_visibility_mobile,
+    wait_for_class_to_be_removed,
+    wait_for_element_to_be_removed,
+    wait_then_click_element,
+    wait_until_visible_css_selector,
+)
 
-# TODO: Test navbar shows Back to UTubs/Members/Tags/Logout on URLs Panel
-# TODO: Test navbar shows Back to UTubs/URLs/Tags/Logout on Members Panel
-# TODO: Test navbar shows Back to UTubs/URLs/Members/Logout on Tags Panel
-# TODO: Test navbar shows Back to UTubs/Members/Tags/Logout on URLs Panel
-# TODO: Test navbar shows URLS/Members/Tags/Logout when UTub panel and UTub selected
+
+def test_navbar_on_utub_panel_utub_unselected_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user on home page on mobile
+
+    GIVEN a user logs in or registers
+    WHEN the user clicks on the navbar dropdown
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
+
+    click_on_navbar(browser)
+
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+
+
+def test_navbar_after_utub_deleted_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user deletes UTub
+
+    GIVEN a user logs in or registers
+    WHEN the user deletes a UTub
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel back to UTub panel from URLs panel
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_UTUB_DECK, time=10)
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.UTUBS)
+
+    # Delete the UTub
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_DELETE, time=10)
+    wait_until_visible_css_selector(browser, HPL.BUTTON_MODAL_SUBMIT, timeout=10)
+    utub_selector = browser.find_element(By.CSS_SELECTOR, HPL.SELECTOR_SELECTED_UTUB)
+    assert utub_selector is not None
+
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT, time=10)
+    wait_for_element_to_be_removed(browser, utub_selector, timeout=10)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+
+
+def test_navbar_after_select_utub_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user selects UTub
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user travels to URLs deck by selecting a UTub
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+    assert_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+
+
+def test_navbar_after_reselect_utub_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user re-selects UTub
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user travels to URLs deck by selecting a UTub that was already selected
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to utubs
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_UTUB_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.UTUBS)
+
+    wait_then_click_element(browser, HPL.SELECTOR_SELECTED_UTUB)
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.URLS)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+    assert_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+
+
+def test_navbar_after_open_tag_deck_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user opens Tags deck after selecting UTub
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user travels to tags deck via navbar navigation
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to tags
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_TAGS_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.TAGS)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+    assert_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+
+
+def test_nav_on_url_panel_after_open_member_deck_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user opens Members deck after selecting UTub
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user travels to member deck via navbar navigation
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to members
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_MEMBER_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.MEMBERS)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+    assert_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+
+
+def test_nav_on_url_panel_after_selected_utub_on_utub_deck_mobile(
+    browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask
+):
+    """
+    Tests visibility of navbar when user returns to UTub deck after selecting UTub
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user returns to UTub deck via navbar navigation
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to utub deck
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_UTUB_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.UTUBS)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    assert_visible_css_selector(browser, HPL.LOGGED_IN_USERNAME_READ)
+    assert_visible_css_selector(browser, HPL.NAVBAR_LOGOUT)
+    assert_visible_css_selector(browser, HPL.NAVBAR_URLS_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_MEMBER_DECK)
+    assert_visible_css_selector(browser, HPL.NAVBAR_TAGS_DECK)
+
+    assert_not_visible_css_selector(browser, HPL.NAVBAR_UTUB_DECK)
+
+
+@pytest.mark.parametrize(
+    "selected_navbar_option,visible_deck",
+    [
+        (HPL.NAVBAR_TAGS_DECK, Decks.TAGS),
+        (HPL.NAVBAR_MEMBER_DECK, Decks.MEMBERS),
+        (HPL.NAVBAR_UTUB_DECK, Decks.UTUBS),
+    ],
+)
+def test_nav_from_url_deck_to_other_deck_mobile(
+    browser_mobile_portrait: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    selected_navbar_option,
+    visible_deck,
+):
+    """
+    Tests visibility of navbar when user travels from url deck
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user navigates using navbar
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to url deck
+    click_on_navbar(browser)
+    wait_then_click_element(browser, selected_navbar_option)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=visible_deck)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    for navbar_option in HPL.MOBILE_NAVBAR_OPTIONS:
+        if navbar_option == selected_navbar_option:
+            assert_not_visible_css_selector(browser, navbar_option)
+        else:
+            assert_visible_css_selector(browser, navbar_option)
+
+
+@pytest.mark.parametrize(
+    "selected_navbar_option,visible_deck",
+    [
+        (HPL.NAVBAR_TAGS_DECK, Decks.TAGS),
+        (HPL.NAVBAR_MEMBER_DECK, Decks.MEMBERS),
+        (HPL.NAVBAR_URLS_DECK, Decks.URLS),
+    ],
+)
+def test_nav_from_utub_deck_to_other_deck_with_utub_selected_mobile(
+    browser_mobile_portrait: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    selected_navbar_option,
+    visible_deck,
+):
+    """
+    Tests visibility of navbar when user travels after returning to UTub deck after selecting UTub
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user returns to UTub deck via navbar navigation
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to utub deck
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_UTUB_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.UTUBS)
+
+    # Travel to other decks
+    click_on_navbar(browser)
+    wait_then_click_element(browser, selected_navbar_option)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=visible_deck)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    for navbar_option in HPL.MOBILE_NAVBAR_OPTIONS:
+        if navbar_option == selected_navbar_option:
+            assert_not_visible_css_selector(browser, navbar_option)
+        else:
+            assert_visible_css_selector(browser, navbar_option)
+
+
+@pytest.mark.parametrize(
+    "selected_navbar_option,visible_deck",
+    [
+        (HPL.NAVBAR_UTUB_DECK, Decks.UTUBS),
+        (HPL.NAVBAR_MEMBER_DECK, Decks.MEMBERS),
+        (HPL.NAVBAR_URLS_DECK, Decks.URLS),
+    ],
+)
+def test_nav_from_tag_deck_to_other_deck_mobile(
+    browser_mobile_portrait: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    selected_navbar_option,
+    visible_deck,
+):
+    """
+    Tests visibility of navbar when user travels from tag deck
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user travels to tag deck and then navigates using navbar
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to tags deck
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_TAGS_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.TAGS)
+
+    # Travel to other decks
+    click_on_navbar(browser)
+    wait_then_click_element(browser, selected_navbar_option)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=visible_deck)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    for navbar_option in HPL.MOBILE_NAVBAR_OPTIONS:
+        if navbar_option == selected_navbar_option:
+            assert_not_visible_css_selector(browser, navbar_option)
+        else:
+            assert_visible_css_selector(browser, navbar_option)
+
+
+@pytest.mark.parametrize(
+    "selected_navbar_option,visible_deck",
+    [
+        (HPL.NAVBAR_UTUB_DECK, Decks.UTUBS),
+        (HPL.NAVBAR_TAGS_DECK, Decks.TAGS),
+        (HPL.NAVBAR_URLS_DECK, Decks.URLS),
+    ],
+)
+def test_nav_from_member_deck_to_other_deck_mobile(
+    browser_mobile_portrait: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    selected_navbar_option,
+    visible_deck,
+):
+    """
+    Tests visibility of navbar when user travels from members deck
+
+    GIVEN a logged in user on URLs deck on mobile
+    WHEN the user travels to tag deck and then navigates using navbar
+    THEN ensure the correct navbar options are shown
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+
+    # Travel to tags deck
+    click_on_navbar(browser)
+    wait_then_click_element(browser, HPL.NAVBAR_MEMBER_DECK)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=Decks.MEMBERS)
+
+    # Travel to other decks
+    click_on_navbar(browser)
+    wait_then_click_element(browser, selected_navbar_option)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    verify_panel_visibility_mobile(browser, visible_deck=visible_deck)
+
+    # Click on navbar and verify proper menus are shown
+    click_on_navbar(browser)
+    for navbar_option in HPL.MOBILE_NAVBAR_OPTIONS:
+        if navbar_option == selected_navbar_option:
+            assert_not_visible_css_selector(browser, navbar_option)
+        else:
+            assert_visible_css_selector(browser, navbar_option)
+
 
 # TODO: Test back button brings user to previous panel was focused on (hides all other)

--- a/tests/functional/home_ui/test_mobile_home_ui.py
+++ b/tests/functional/home_ui/test_mobile_home_ui.py
@@ -20,6 +20,8 @@ from tests.functional.utils_for_test import (
     wait_until_visible_css_selector,
 )
 
+pytestmark = pytest.mark.mobile_ui
+
 
 def test_navbar_on_utub_panel_utub_unselected_mobile(
     browser_mobile_portrait: WebDriver, create_test_tags, provide_app: Flask

--- a/tests/functional/home_ui/test_mobile_home_ui.py
+++ b/tests/functional/home_ui/test_mobile_home_ui.py
@@ -1,0 +1,12 @@
+# TODO: Test clicking on UTub brings to URLs panel
+# TODO: Test clicking on already selected UTub brings to URLs panel
+
+# TODO: Test navbar shows only Logout and Logged in as on UTub panel - UTub unselected
+
+# TODO: Test navbar shows Back to UTubs/Members/Tags/Logout on URLs Panel
+# TODO: Test navbar shows Back to UTubs/URLs/Tags/Logout on Members Panel
+# TODO: Test navbar shows Back to UTubs/URLs/Members/Logout on Tags Panel
+# TODO: Test navbar shows Back to UTubs/Members/Tags/Logout on URLs Panel
+# TODO: Test navbar shows URLS/Members/Tags/Logout when UTub panel and UTub selected
+
+# TODO: Test back button brings user to previous panel was focused on (hides all other)

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -1,6 +1,8 @@
 class GenericPageLocator:
     ERROR_PAGE_HANDLER = "#ErrorPageHandler"
     ERROR_PAGE_REFRESH_BTN = f"{ERROR_PAGE_HANDLER} .refresh-button"
+    NAVBAR_TOGGLER = ".navbar-toggler"
+    NAVBAR_DROPDOWN = "#NavbarNavDropdown"
 
 
 class HomePageLocators(GenericPageLocator):
@@ -136,14 +138,27 @@ class HomePageLocators(GenericPageLocator):
     ACCESS_ALL_URL_MODAL = ".accessAllUrlModal"
     DELETE_URL_MODAL = ".deleteUrlModal"
 
+    # Decks
+    UTUB_DECK = ".deck#UTubDeck"
+    MEMBER_DECK = ".deck#MemberDeck"
+    TAG_DECK = ".deck#TagDeck"
+    URL_DECK = ".deck#URLDeck"
+
+    # Panels
+    MAIN_PANEL = "main#mainPanel"
+
 
 class SplashPageLocators(GenericPageLocator):
     """A collector class for splash page locators"""
 
     # Options
     SPLASH_NAVBAR = "#NavbarDropdownsSplash"
-    BUTTON_REGISTER = ".to-register"
-    BUTTON_LOGIN = ".to-login"
+    BUTTON_REGISTER = ".btn.to-register"
+    BUTTON_LOGIN = ".btn.to-login"
+
+    # Navbar
+    NAVBAR_REGISTER = ".nav-bar-inner-item.to-register"
+    NAVBAR_LOGIN = ".nav-bar-inner-item.to-login"
 
     # Common
     INPUT_USERNAME = "#username"

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -15,6 +15,19 @@ class HomePageLocators(GenericPageLocator):
     BUTTON_LOGOUT = "#logout > .nav-bar-inner-item"
     LOGGED_IN_USERNAME_READ = "#userLoggedIn"
     U4I_LOGO = ".navbar-brand"
+    NAVBAR_UTUB_DECK = "#NavbarDropdownsHome #toUTubs"
+    NAVBAR_URLS_DECK = "#NavbarDropdownsHome #toURLs"
+    NAVBAR_MEMBER_DECK = "#NavbarDropdownsHome #toMembers"
+    NAVBAR_TAGS_DECK = "#NavbarDropdownsHome #toTags"
+    NAVBAR_LOGOUT = "#NavbarDropdownsHome #logout"
+    MOBILE_NAVBAR_OPTIONS = (
+        LOGGED_IN_USERNAME_READ,
+        NAVBAR_UTUB_DECK,
+        NAVBAR_URLS_DECK,
+        NAVBAR_MEMBER_DECK,
+        NAVBAR_TAGS_DECK,
+        NAVBAR_LOGOUT,
+    )
 
     # UTub Deck
     SUBHEADER_UTUB_DECK = "#UTubDeckSubheader"
@@ -146,13 +159,6 @@ class HomePageLocators(GenericPageLocator):
 
     # Panels
     MAIN_PANEL = "main#mainPanel"
-
-    # Navbar
-    NAVBAR_UTUB_DECK = "#NavbarDropdownsHome #toUTubs"
-    NAVBAR_URLS_DECK = "#NavbarDropdownsHome #toURLs"
-    NAVBAR_MEMBER_DECK = "#NavbarDropdownsHome #toMembers"
-    NAVBAR_TAGS_DECK = "#NavbarDropdownsHome #toTags"
-    NAVBAR_LOGOUT = "#NavbarDropdownsHome #logout"
 
 
 class SplashPageLocators(GenericPageLocator):

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -147,6 +147,13 @@ class HomePageLocators(GenericPageLocator):
     # Panels
     MAIN_PANEL = "main#mainPanel"
 
+    # Navbar
+    NAVBAR_UTUB_DECK = "#NavbarDropdownsHome #toUTubs"
+    NAVBAR_URLS_DECK = "#NavbarDropdownsHome #toURLs"
+    NAVBAR_MEMBER_DECK = "#NavbarDropdownsHome #toMembers"
+    NAVBAR_TAGS_DECK = "#NavbarDropdownsHome #toTags"
+    NAVBAR_LOGOUT = "#NavbarDropdownsHome #logout"
+
 
 class SplashPageLocators(GenericPageLocator):
     """A collector class for splash page locators"""

--- a/tests/functional/splash_ui/test_login_user_ui.py
+++ b/tests/functional/splash_ui/test_login_user_ui.py
@@ -66,7 +66,7 @@ def test_open_login_modal_RHS_btn(browser: WebDriver):
     navbar = wait_then_get_element(browser, SPL.SPLASH_NAVBAR)
     assert navbar is not None
 
-    login_btn = navbar.find_element(By.CSS_SELECTOR, SPL.BUTTON_LOGIN)
+    login_btn = navbar.find_element(By.CSS_SELECTOR, SPL.NAVBAR_LOGIN)
     login_btn.click()
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)

--- a/tests/functional/splash_ui/test_mobile_splash_ui.py
+++ b/tests/functional/splash_ui/test_mobile_splash_ui.py
@@ -15,7 +15,7 @@ from tests.functional.utils_for_test import (
     wait_then_click_element,
 )
 
-pytestmark = pytest.mark.splash_ui
+pytestmark = pytest.mark.mobile_ui
 
 
 def test_splash_page_ui_shows(browser_mobile_portrait: WebDriver):

--- a/tests/functional/splash_ui/test_mobile_splash_ui.py
+++ b/tests/functional/splash_ui/test_mobile_splash_ui.py
@@ -9,9 +9,9 @@ from tests.functional.utils_for_test import (
     Decks,
     assert_not_visible_css_selector,
     assert_visible_css_selector,
+    click_on_navbar,
     input_login_fields,
     verify_panel_visibility_mobile,
-    wait_for_class_to_be_removed,
     wait_then_click_element,
 )
 
@@ -44,8 +44,7 @@ def test_navbar_on_mobile_splash_shows_login_register(
     """
     browser = browser_mobile_portrait
 
-    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
-    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    click_on_navbar(browser)
 
     assert_visible_css_selector(browser, SPL.NAVBAR_LOGIN)
     assert_visible_css_selector(browser, SPL.NAVBAR_REGISTER)
@@ -63,11 +62,9 @@ def test_navbar_on_mobile_splash_hides_login_register(
     """
     browser = browser_mobile_portrait
 
-    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
-    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    click_on_navbar(browser)
 
-    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
-    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    click_on_navbar(browser)
 
     assert_not_visible_css_selector(browser, SPL.NAVBAR_LOGIN)
     assert_not_visible_css_selector(browser, SPL.NAVBAR_REGISTER)
@@ -112,8 +109,7 @@ def test_mobile_login_brings_user_to_utub_panel(
     """
     browser = browser_mobile_portrait
 
-    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
-    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    click_on_navbar(browser)
 
     wait_then_click_element(browser, SPL.NAVBAR_LOGIN)
     input_login_fields(browser)

--- a/tests/functional/splash_ui/test_mobile_splash_ui.py
+++ b/tests/functional/splash_ui/test_mobile_splash_ui.py
@@ -1,0 +1,123 @@
+from flask import Flask
+import pytest
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from src.models.users import Users
+from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
+from tests.functional.locators import SplashPageLocators as SPL
+from tests.functional.utils_for_test import (
+    Decks,
+    assert_not_visible_css_selector,
+    assert_visible_css_selector,
+    input_login_fields,
+    verify_panel_visibility_mobile,
+    wait_for_class_to_be_removed,
+    wait_then_click_element,
+)
+
+pytestmark = pytest.mark.splash_ui
+
+
+def test_splash_page_ui_shows(browser_mobile_portrait: WebDriver):
+    """
+    Tests that the main buttons are visible on the splash page in mobile.
+
+    GIVEN a fresh load of the U4I Splash page on mobile
+    WHEN user views the web page
+    THEN ensure the login, register, and navbar toggler buttons are visible
+    """
+    browser = browser_mobile_portrait
+    assert_visible_css_selector(browser, SPL.BUTTON_REGISTER)
+    assert_visible_css_selector(browser, SPL.BUTTON_LOGIN)
+    assert_visible_css_selector(browser, SPL.NAVBAR_TOGGLER)
+
+
+def test_navbar_on_mobile_splash_shows_login_register(
+    browser_mobile_portrait: WebDriver,
+):
+    """
+    Tests that the login and register buttons are visible in the navbar on mobile.
+
+    GIVEN a fresh load of the U4I Splash page on mobile
+    WHEN user clicks on navbar toggler
+    THEN ensure the login and register buttons are shown
+    """
+    browser = browser_mobile_portrait
+
+    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
+    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+
+    assert_visible_css_selector(browser, SPL.NAVBAR_LOGIN)
+    assert_visible_css_selector(browser, SPL.NAVBAR_REGISTER)
+
+
+def test_navbar_on_mobile_splash_hides_login_register(
+    browser_mobile_portrait: WebDriver,
+):
+    """
+    Tests that the login and register buttons are visible in the navbar on mobile.
+
+    GIVEN a fresh load of the U4I Splash page on mobile
+    WHEN user clicks on navbar toggler and then clicks to hide it
+    THEN ensure the login and register buttons are no longer shown
+    """
+    browser = browser_mobile_portrait
+
+    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
+    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+
+    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
+    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+
+    assert_not_visible_css_selector(browser, SPL.NAVBAR_LOGIN)
+    assert_not_visible_css_selector(browser, SPL.NAVBAR_REGISTER)
+
+
+def test_mobile_email_validation_brings_user_to_utub_panel(
+    browser_mobile_portrait: WebDriver,
+    create_user_unconfirmed_email,
+    provide_app: Flask,
+):
+    """
+    Tests that email validation on modal brings user to proper panel
+
+    GIVEN a user validating their email after registration
+    WHEN user clicks link in the email for email validation
+    THEN ensure the UTub panel is shown on mobile
+    """
+    browser = browser_mobile_portrait
+
+    app = provide_app
+    validation_url_suffix = create_user_unconfirmed_email
+    validation_url = browser.current_url + validation_url_suffix
+
+    browser.get(validation_url)
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.UTUBS)
+
+    with app.app_context():
+        user: Users = Users.query.filter(Users.username == UTS.TEST_USERNAME_1).first()
+        assert user.is_email_authenticated()
+
+
+def test_mobile_login_brings_user_to_utub_panel(
+    browser_mobile_portrait: WebDriver,
+    create_test_users,
+):
+    """
+    Tests that email validation on modal brings user to proper panel
+
+    GIVEN a user validating their email after registration
+    WHEN user clicks link in the email for email validation
+    THEN ensure the UTub panel is shown on mobile
+    """
+    browser = browser_mobile_portrait
+
+    wait_then_click_element(browser, SPL.NAVBAR_TOGGLER)
+    wait_for_class_to_be_removed(browser, SPL.NAVBAR_DROPDOWN, class_name="collapsing")
+
+    wait_then_click_element(browser, SPL.NAVBAR_LOGIN)
+    input_login_fields(browser)
+
+    wait_then_click_element(browser, SPL.BUTTON_SUBMIT)
+
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.UTUBS)

--- a/tests/functional/splash_ui/test_register_user_ui.py
+++ b/tests/functional/splash_ui/test_register_user_ui.py
@@ -62,7 +62,7 @@ def test_open_register_modal_RHS_btn(browser: WebDriver):
     navbar = wait_then_get_element(browser, SPL.SPLASH_NAVBAR)
     assert navbar is not None
 
-    register_btn = navbar.find_element(By.CSS_SELECTOR, SPL.BUTTON_REGISTER)
+    register_btn = navbar.find_element(By.CSS_SELECTOR, SPL.NAVBAR_REGISTER)
     register_btn.click()
 
     modal_element = wait_then_get_element(browser, SPL.SPLASH_MODAL)

--- a/tests/functional/tags_ui/test_create_utub_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_utub_tag_ui.py
@@ -1,4 +1,5 @@
 from flask import Flask
+import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -27,6 +28,8 @@ from tests.functional.utils_for_test import (
     wait_until_in_focus,
     wait_until_visible_css_selector,
 )
+
+pytestmark = pytest.mark.tags_ui
 
 
 def test_open_input_create_utub_tag(

--- a/tests/functional/tags_ui/test_create_utub_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_utub_tag_ui.py
@@ -104,7 +104,6 @@ def test_open_input_create_utub_tag_tab_focus(
     set_focus_on_element(browser, create_utub_tag_btn)
     create_utub_tag_btn.send_keys(Keys.ENTER)
 
-    browser.get_screenshot_as_file("p1.png")
     wait_until_visible_css_selector(browser, HPL.INPUT_UTUB_TAG_CREATE, timeout=3)
 
     # Ensure input is focused

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -35,6 +35,25 @@ from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.locators import ModalLocators as MP
 
 
+# Mobile
+class Decks(Enum):
+    UTUBS = HPL.UTUB_DECK
+    MEMBERS = HPL.MEMBER_DECK
+    TAGS = HPL.TAG_DECK
+    URLS = HPL.URL_DECK
+
+
+def verify_panel_visibility_mobile(browser: WebDriver, visible_deck: Decks):
+    wait_until_visible_css_selector(browser, HPL.MAIN_PANEL, timeout=10)
+
+    for deck in Decks:
+        if visible_deck == deck:
+            continue
+        assert_not_visible_css_selector(browser, deck.value)
+
+    assert_visible_css_selector(browser, visible_deck.value)
+
+
 # General
 def wait_for_element_presence(
     browser: WebDriver, css_selector: str, timeout: int = 10
@@ -418,6 +437,18 @@ def login_user_and_select_utub_by_utubid(
     )
 
 
+def login_user_and_select_utub_by_utubid_mobile(
+    app: Flask, browser: WebDriver, user_id: int, utub_id: int
+):
+    session_id = create_user_session_and_provide_session_id(app, user_id)
+    login_user_with_cookie_from_session(browser, session_id)
+    verify_panel_visibility_mobile(browser, Decks.UTUBS)
+
+    wait_then_click_element(
+        browser, f"{HPL.SELECTORS_UTUB}[utubid='{utub_id}']", time=10
+    )
+
+
 def login_user_select_utub_by_id_and_url_by_id(
     app: Flask, browser: WebDriver, user_id: int, utub_id: int, utub_url_id: int
 ):
@@ -621,6 +652,13 @@ def select_utub_by_id(browser: WebDriver, utub_id: int):
     utub_name = utub_selector_elem.text
     wait_then_click_element(browser, utub_selector, time=3)
     wait_until_utub_name_appears(browser, utub_name)
+
+
+def select_utub_by_id_mobile(browser: WebDriver, utub_id: int):
+    utub_selector = f"{HPL.SELECTORS_UTUB}[utubid='{utub_id}']"
+    utub_selector_elem = wait_for_element_presence(browser, utub_selector, timeout=10)
+    assert utub_selector_elem is not None
+    wait_then_click_element(browser, utub_selector, time=3)
 
 
 def wait_until_utub_name_appears(browser: WebDriver, utub_name: str):
@@ -988,25 +1026,6 @@ def verify_tags_exist_in_tag_deck(browser: WebDriver, utub_tag_ids: list[int]):
         utub_tag_elem = wait_then_get_element(browser, utub_tag_selector, time=3)
         assert utub_tag_elem is not None
         assert utub_tag_elem.is_displayed()
-
-
-# Mobile
-class Decks(Enum):
-    UTUBS = HPL.UTUB_DECK
-    MEMBERS = HPL.MEMBER_DECK
-    TAGS = HPL.TAG_DECK
-    URLS = HPL.URL_DECK
-
-
-def verify_panel_visibility_mobile(browser: WebDriver, visible_deck: Decks):
-    wait_until_visible_css_selector(browser, HPL.MAIN_PANEL, timeout=10)
-
-    for deck in Decks:
-        if visible_deck == deck:
-            continue
-        assert_not_visible_css_selector(browser, deck.value)
-
-    assert_visible_css_selector(browser, visible_deck.value)
 
 
 # Misc

--- a/tests/functional/utils_for_test.py
+++ b/tests/functional/utils_for_test.py
@@ -54,6 +54,11 @@ def verify_panel_visibility_mobile(browser: WebDriver, visible_deck: Decks):
     assert_visible_css_selector(browser, visible_deck.value)
 
 
+def click_on_navbar(browser: WebDriver):
+    wait_then_click_element(browser, HPL.NAVBAR_TOGGLER)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+
+
 # General
 def wait_for_element_presence(
     browser: WebDriver, css_selector: str, timeout: int = 10
@@ -594,7 +599,6 @@ def verify_no_utub_selected(browser: WebDriver):
     with pytest.raises(NoSuchElementException):
         browser.find_element(By.CSS_SELECTOR, HPL.BADGES_MEMBERS)
 
-    browser.get_screenshot_as_file("p1.png")
     with pytest.raises(NoSuchElementException):
         browser.find_element(By.CSS_SELECTOR, HPL.TAG_FILTERS)
 

--- a/tests/functional/utubs_ui/test_mobile_utubs_ui.py
+++ b/tests/functional/utubs_ui/test_mobile_utubs_ui.py
@@ -6,12 +6,12 @@ from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.utils_for_test import (
     Decks,
+    click_on_navbar,
     get_utub_this_user_created,
     login_user_and_select_utub_by_utubid_mobile,
     login_user_to_home_page,
     select_utub_by_id_mobile,
     verify_panel_visibility_mobile,
-    wait_for_class_to_be_removed,
     wait_then_click_element,
     wait_until_hidden,
 )
@@ -66,10 +66,8 @@ def test_tap_on_already_selected_utub_shows_url_deck_mobile(
     verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.URLS)
 
     # Travel back
-    wait_then_click_element(browser, HPL.NAVBAR_TOGGLER)
-    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+    click_on_navbar(browser)
 
-    browser.get_screenshot_as_file("p1.png")
     wait_then_click_element(browser, HPL.NAVBAR_UTUB_DECK, time=10)
     verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.UTUBS)
 

--- a/tests/functional/utubs_ui/test_mobile_utubs_ui.py
+++ b/tests/functional/utubs_ui/test_mobile_utubs_ui.py
@@ -1,0 +1,2 @@
+# TODO: Test creating new UTub brings user to URLs panel
+# TODO: Test tapping on already selected UTubs brings user to URLs panel

--- a/tests/functional/utubs_ui/test_mobile_utubs_ui.py
+++ b/tests/functional/utubs_ui/test_mobile_utubs_ui.py
@@ -1,2 +1,77 @@
-# TODO: Test creating new UTub brings user to URLs panel
-# TODO: Test tapping on already selected UTubs brings user to URLs panel
+from flask import Flask
+from selenium.webdriver.remote.webdriver import WebDriver
+from src.cli.mock_constants import MOCK_UTUB_DESCRIPTION
+from src.models.utubs import Utubs
+from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
+from tests.functional.locators import HomePageLocators as HPL
+from tests.functional.utils_for_test import (
+    Decks,
+    get_utub_this_user_created,
+    login_user_and_select_utub_by_utubid_mobile,
+    login_user_to_home_page,
+    select_utub_by_id_mobile,
+    verify_panel_visibility_mobile,
+    wait_for_class_to_be_removed,
+    wait_then_click_element,
+    wait_until_hidden,
+)
+from tests.functional.utubs_ui.utils_for_test_utub_ui import create_utub
+
+
+def test_create_utub_shows_url_deck_mobile(
+    browser_mobile_portrait: WebDriver, create_test_users, provide_app: Flask
+):
+    """
+    Tests a user's ability to create a UTub on mobile
+
+    GIVEN a user attempting to make a UTub
+    WHEN the createUTub form is populated and submitted by the 'check' button on mobile
+    THEN ensure the user is taken to the URL deck upon successful creation
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    login_user_to_home_page(app, browser, USER_ID)
+
+    utub_name = UTS.TEST_UTUB_NAME_1
+
+    create_utub(browser, utub_name, MOCK_UTUB_DESCRIPTION)
+
+    # Submits new UTub
+    wait_then_click_element(browser, HPL.BUTTON_UTUB_SUBMIT_CREATE)
+
+    # Wait for POST request
+    wait_until_hidden(browser, HPL.INPUT_UTUB_NAME_CREATE, timeout=3)
+
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.URLS)
+
+
+def test_tap_on_already_selected_utub_shows_url_deck_mobile(
+    browser_mobile_portrait: WebDriver, create_test_utubs, provide_app: Flask
+):
+    """
+    Tests a user's ability to re-select a UTub on mobile
+
+    GIVEN a user attempting to re-select a UTub
+    WHEN the UTub is already selected and the user taps on it
+    THEN ensure the user is taken to the URL deck
+    """
+    browser = browser_mobile_portrait
+    app = provide_app
+    USER_ID = 1
+    utub: Utubs = get_utub_this_user_created(app, USER_ID)
+    login_user_and_select_utub_by_utubid_mobile(
+        app=app, browser=browser, utub_id=utub.id, user_id=USER_ID
+    )
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.URLS)
+
+    # Travel back
+    wait_then_click_element(browser, HPL.NAVBAR_TOGGLER)
+    wait_for_class_to_be_removed(browser, HPL.NAVBAR_DROPDOWN, class_name="collapsing")
+
+    browser.get_screenshot_as_file("p1.png")
+    wait_then_click_element(browser, HPL.NAVBAR_UTUB_DECK, time=10)
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.UTUBS)
+
+    select_utub_by_id_mobile(browser, utub.id)
+    verify_panel_visibility_mobile(browser=browser, visible_deck=Decks.URLS)

--- a/tests/functional/utubs_ui/test_mobile_utubs_ui.py
+++ b/tests/functional/utubs_ui/test_mobile_utubs_ui.py
@@ -1,4 +1,5 @@
 from flask import Flask
+import pytest
 from selenium.webdriver.remote.webdriver import WebDriver
 from src.cli.mock_constants import MOCK_UTUB_DESCRIPTION
 from src.models.utubs import Utubs
@@ -16,6 +17,8 @@ from tests.functional.utils_for_test import (
     wait_until_hidden,
 )
 from tests.functional.utubs_ui.utils_for_test_utub_ui import create_utub
+
+pytestmark = pytest.mark.mobile_ui
 
 
 def test_create_utub_shows_url_deck_mobile(


### PR DESCRIPTION
Adds mobile UI tests for mobile navigation and UI.

Allows selecting an already selected UTub on mobile, which brings user to URL panel.

Fixes some bugs for mobile UI found while testing.

Closes #355 
Closes #264 