### PR TITLE
Refactor for API scheme

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -sv
+addopts = -sv --durations=10
 filterwarnings =
 	ignore::DeprecationWarning:flask_wtf.*:
 	ignore:'get_engine' is deprecated.*:DeprecationWarning:.*:

--- a/src/API_DOCUMENTATION.md
+++ b/src/API_DOCUMENTATION.md
@@ -615,8 +615,54 @@ UTub selection via the query parameter is handled on the client side.
 > ```
 
 </details>
+
+------------------------------------------------------------------------------------------
+
+#### UTubs
+
 <details>
- <summary><code>GET</code> <code><b>/utub/[int:UTubID]</b></code> <code>(get specific UTub information)</code></summary>
+ <summary><code>GET</code> <code><b>/utubs</b></code> <code>(gets summary of user's UTubs)</code></summary>
+
+##### Responses
+
+> | http code     | content-type                      | response  | details |
+> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
+> | `200`         | `application/json`                | `See below.` | Returns summary of user's UTubs in JSON format. |
+> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
+> | `404`         | `text/html;charset=utf−8`         | None | Unknown error occurred. |
+> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
+
+###### 200 HTTP Code Response Body
+
+> ```json
+> { "utubs": [
+>       {
+>           "id": 1,
+>           "name": "utub2",
+>           "memberRole": "creator",
+>       },
+>       {
+>           "id": 2,
+>           "name": "utub1",
+>           "memberRole": "member",
+>       }
+>   ]
+> }
+> ```
+
+##### Example cURL
+
+> ```bash
+> curl -X GET \
+>  https://urls4irl.app/utubs \
+>  -H 'Cookie: YOUR_COOKIE' \
+>  -H 'X-Requested-With: XMLHTTPRequest'
+> ```
+
+</details>
+
+<details>
+ <summary><code>GET</code> <code><b>/utubs/[int:UTubID]</b></code> <code>(get specific UTub information)</code></summary>
 
 ##### Parameters
 
@@ -691,51 +737,7 @@ UTub selection via the query parameter is handled on the client side.
 
 > ```bash
 > curl -X GET \
->  https://urls4irl.app/utub/1 \
->  -H 'Cookie: YOUR_COOKIE' \
->  -H 'X-Requested-With: XMLHTTPRequest'
-> ```
-
-</details>
-
-------------------------------------------------------------------------------------------
-
-#### UTubs
-
-<details>
- <summary><code>GET</code> <code><b>/utubs</b></code> <code>(gets summary of user's UTubs)</code></summary>
-
-##### Responses
-
-> | http code     | content-type                      | response  | details |
-> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
-> | `200`         | `application/json`                | `See below.` | Returns summary of user's UTubs in JSON format. |
-> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
-> | `404`         | `text/html;charset=utf−8`         | None | Unknown error occurred. |
-> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
-
-###### 200 HTTP Code Response Body
-
-> ```json
-> [
->     {
->         "id": 1,
->         "name": "utub2",
->         "memberRole": "creator",
->     },
->     {
->         "id": 2,
->         "name": "utub1",
->         "memberRole": "member",
->     }
-> ]
-> ```
-
-##### Example cURL
-
-> ```bash
-> curl -X GET \
->  https://urls4irl.app/utubs \
+>  https://urls4irl.app/utubs/1 \
 >  -H 'Cookie: YOUR_COOKIE' \
 >  -H 'X-Requested-With: XMLHTTPRequest'
 > ```
@@ -2114,125 +2116,6 @@ Indicates form errors with adding this tag onto this URL in this UTub.
 > curl -X DELETE \
 >  https://urls4irl.app/utubs/1/urls/1/tags/4 \
 >  -H 'Cookie: YOUR_COOKIE'
-> ```
-
-</details>
-<details>
- <summary><code>PUT</code> <code><b>/utubs/{UTubID}/urls/1/tags/1</b></code> <code>(modify tag on URL in UTub)</code></summary>
-
-##### Parameters
-
-> | name   |  type      | data type      | description                                          |
-> |--------|------------|----------------|------------------------------------------------------|
-> | `UTubID` |  required  | int ($int64) | The unique ID of the UTub containing the URL with given tag |
-> | `utubUrlID` |  required  | int ($int64) | The unique ID of the UTub-URL associated with the tag to modify |
-> | `tagID` |  required  | int ($int64) | The unique ID of the tag to modify |
-
-##### Request Payload
-
-Payload content-type should be `application/x-www-form-urlencoded; charset=utf−8`.
-
-Required form data:
-> ```
-> tagString: %New Tag%
-> csrf_token: %csrf_token%
-> ```
-
-##### Responses
-
-> | http code     | content-type                      | response  | details |
-> |---------------|-----------------------------------|-----------|---------------------------------------------------------|
-> | `200`         | `application/json`                | `See below.` | Successfully modified a tag, or no change. |
-> | `302`         | `text/html;charset=utf−8`         | `Redirects and renders HTML for splash page.` | User not email authenticated or not logged in. |
-> | `400`         | `application/json`                | `See below.` | Missing form fields or tag already on URL. |
-> | `403`         | `application/json`                | `See below.` | Only UTub members can modify a tag on a URL. |
-> | `404`         | `application/json`                | `See below.` | Unable to process the form. |
-> | `404`         | `text/html;charset=utf−8`         | None | Unable to find UTub, the URL within the UTub, or the tag on the URL. |
-> | `405`         | `text/html;charset=utf−8`         | None | Invalid HTTP method. |
-
-###### 200 HTTP Code Response Body
-
-Possible messages include: `Tag on this URL modified.`, `Tag was not modified on this URL.`
-
-> ```json
-> {
->     "status": "Success",
->     "message": "Tag on this URL modified.", 
->     "urlTagIDs": [1, 2, 3, 4],      // If modified, contains newly modified tag ID
->     "tag": {
->         "tagID": 4,
->         "tagString": "Hello",
->     },
->     "previousTag": {
->         "tagID": 5,
->         "tagInUTub": false,
->     }
-> }
-> ```
-
-###### 200 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "No change",
->     "message": "Tag was not modified on this URL.",
-> }
-> ```
-
-###### 400 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "URL already has this tag.",
->     "errorCode": 2,
-> }
-> ```
-
-###### 400 HTTP Code Response Body
-
-`tagString` field must be included in form.
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "Unable to add tag to URL.",
->     "errorCode": 3,
->     "errors": {
->         "tagString": ["This field is required."],
->     }
-> }
-> ```
-
-###### 403 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "Only UTub members can modify tags.",
->     "errorCode": 1
-> }
-> ```
-
-###### 404 HTTP Code Response Body
-
-> ```json
-> {
->     "status": "Failure",
->     "message": "Unable to add tag to URL.",
->     "errorCode": 4,
-> }
-> ```
-
-##### Example cURL
-
-> ```bash
-> curl -X PUT \
->  https://urls4irl.app/utubs/1/urls/1/tags/1 \
->  -H 'Content-Type: application/x-www-form-urlencoded' \
->  -H 'Cookie: YOUR_COOKIE' \
->  --data-urlencode 'tagString=NewTag' \
->  --data-urlencode 'csrf_token=CSRF_TOKEN'
 > ```
 
 </details>

--- a/src/models/users.py
+++ b/src/models/users.py
@@ -93,7 +93,7 @@ class Users(db.Model, UserMixin):
         }
 
     @property
-    def serialized_on_initial_load(self) -> list[dict]:
+    def serialized_on_initial_load(self) -> dict[str, list[dict]]:
         """Returns object in serialized for, with only the utub id and Utub name the user is a member of."""
 
         # Sort by last updated
@@ -111,7 +111,7 @@ class Users(db.Model, UserMixin):
             for utub in sorted_utubs_user_is_in
         ]
 
-        return utub_summaries
+        return {MODEL_STRS.UTUBS: utub_summaries}
 
     def __repr__(self):
         return f"User: {self.username}, Email: {self.email}, Password: {self.password}"

--- a/src/static/scripts/components/home.js
+++ b/src/static/scripts/components/home.js
@@ -12,7 +12,7 @@ function setUIWhenNoUTubSelected() {
 function resetHomePageToInitialState() {
   setUIWhenNoUTubSelected();
   getAllUTubs().then((utubData) => {
-    buildUTubDeck(utubData);
+    buildUTubDeck(utubData.utubs);
     setMemberDeckWhenNoUTubSelected();
     setTagDeckSubheaderWhenNoUTubSelected();
   });

--- a/src/utils/strings/model_strs.py
+++ b/src/utils/strings/model_strs.py
@@ -27,6 +27,7 @@ USERNAME = "username"
 UTUB_DESCRIPTION = "utubDescription"
 UTUB_URL_ID = "utubUrlID"
 CURRENT_USER = "currentUser"
+UTUBS = "utubs"
 
 
 class MODELS:
@@ -56,3 +57,4 @@ class MODELS:
     CAN_DELETE = CAN_DELETE
     UTUB_URL_ID = UTUB_URL_ID
     CURRENT_USER = CURRENT_USER
+    UTUBS = UTUBS

--- a/src/utubs/routes.py
+++ b/src/utubs/routes.py
@@ -15,6 +15,7 @@ from src import db
 from src.models.utubs import Utubs
 from src.models.utub_members import Member_Role, Utub_Members
 from src.utils.strings.config_strs import CONFIG_ENVS
+from src.utils.strings.model_strs import MODELS
 from src.utubs.forms import UTubForm, UTubDescriptionForm, UTubNewNameForm
 from src.utubs.utils import build_form_errors
 from src.utils.all_routes import ROUTES
@@ -60,7 +61,7 @@ def home():
         utub_details = current_user.serialized_on_initial_load
         return render_template(
             "home.html",
-            utubs_for_this_user=utub_details,
+            utubs_for_this_user=utub_details[MODELS.UTUBS],
             is_prod_or_testing=current_app.config.get(
                 CONFIG_ENVS.TESTING_OR_PROD, True
             ),
@@ -80,7 +81,7 @@ def home():
         utub_details = current_user.serialized_on_initial_load
         return render_template(
             "home.html",
-            utubs_for_this_user=utub_details,
+            utubs_for_this_user=utub_details[MODELS.UTUBS],
             is_prod_or_testing=current_app.config.get(
                 CONFIG_ENVS.TESTING_OR_PROD, True
             ),
@@ -91,7 +92,7 @@ def home():
         abort(404)
 
 
-@utubs.route("/utub/<int:utub_id>", methods=["GET"])
+@utubs.route("/utubs/<int:utub_id>", methods=["GET"])
 @email_validation_required
 def get_single_utub(utub_id: int):
     """

--- a/tests/unit/test_model_serialization.py
+++ b/tests/unit/test_model_serialization.py
@@ -275,7 +275,9 @@ def test_user_utub_data_serialized_on_initial_load():
 
     # Reverse considering the serialized values will be sorted by most recently updated
     valid_utubs.reverse()
-    assert json.dumps(valid_utubs) == json.dumps(new_user.serialized_on_initial_load)
+    assert json.dumps({MODEL_STRS.UTUBS: valid_utubs}) == json.dumps(
+        new_user.serialized_on_initial_load
+    )
 
 
 def test_utub_serialized_only_creator_no_urls_no_tags(


### PR DESCRIPTION
Add longest 10 tests duration to each test.

Cleanup API documentation.

Convert `/utub/<int: utub_id>` to `/utubs/<int: utub_id>` to follow naming of other endpoints and pluralization.

Closes #397 