### PR TITLE
Update URL, password, and email input types and for autocomplete

### DIFF
--- a/src/splash/forms.py
+++ b/src/splash/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField
+from wtforms import StringField, PasswordField, SubmitField, EmailField
 from wtforms.validators import Length, Email, EqualTo, InputRequired, ValidationError
 
 from src.models.users import Users
@@ -33,10 +33,10 @@ class UserRegistrationForm(FlaskForm):
             ),
         ],
     )
-    email = StringField(
+    email = EmailField(
         REGISTER_LOGIN_FORM.EMAIL_TEXT, validators=[InputRequired(), Email()]
     )
-    confirm_email = StringField(
+    confirm_email = EmailField(
         REGISTER_LOGIN_FORM.CONFIRM_EMAIL_TEXT,
         validators=[InputRequired(), EqualTo(REGISTER_LOGIN_FORM.EMAIL)],
         name=REGISTER_FORM.CONFIRM_EMAIL,

--- a/src/splash/forms.py
+++ b/src/splash/forms.py
@@ -132,7 +132,7 @@ class ValidateEmailForm(FlaskForm):
 
 
 class ForgotPasswordForm(FlaskForm):
-    email = StringField(
+    email = EmailField(
         FORGOT_PASSWORD.EMAIL_TEXT, validators=[InputRequired(), Email()]
     )
 

--- a/src/static/scripts/components/btns_forms.js
+++ b/src/static/scripts/components/btns_forms.js
@@ -1,9 +1,15 @@
 "use strict";
 
 // To differentiate between the text box types when dynamically creating input text boxes
-const INPUT_TYPES = Object.freeze({
+const METHOD_TYPES = Object.freeze({
   CREATE: Symbol("Create"),
   UPDATE: Symbol("Update"),
+});
+
+const INPUT_TYPES = Object.freeze({
+  TEXT: Symbol("text"),
+  URL: Symbol("url"),
+  EMAIL: Symbol("email"),
 });
 
 $(document).ready(function () {
@@ -125,7 +131,11 @@ function makeCancelButton(wh) {
 }
 
 // Fancy text box creation
-function makeTextInput(textInputID, type) {
+function makeTextInput(
+  textInputID,
+  method,
+  type = INPUT_TYPES.TEXT.description,
+) {
   const inputAndButtonWrap = $(document.createElement("div")).addClass(
     "createDiv flex-row full-width pad-top-5p",
   );
@@ -147,14 +157,14 @@ function makeTextInput(textInputID, type) {
 
   inputInputBox
     .attr({
-      type: "text",
+      type: type,
       name: textInputID,
     })
-    .addClass(textInputID + type);
+    .addClass(textInputID + method);
 
   inputLabel.attr({ for: textInputID });
 
-  inputErrorMessage.addClass(textInputID + type + "-error");
+  inputErrorMessage.addClass(textInputID + method + "-error");
 
   inputInnerContainer.append(inputInputBox).append(inputLabel);
 

--- a/src/static/scripts/components/urls_deck/url_cards/get_url.js
+++ b/src/static/scripts/components/urls_deck/url_cards/get_url.js
@@ -29,11 +29,17 @@ function updateURLBasedOnGetData(urlUpdateResponse, urlCard) {
     ? urlTitleElem.text(urlUpdateResponse.urlTitle)
     : null;
 
-  urlStringElem !== urlUpdateResponse.urlString
-    ? urlStringElem
-        .attr({ href: urlUpdateResponse.urlString })
-        .text(urlUpdateResponse.urlString)
-    : null;
+  if (urlStringElem.attr("href") !== urlUpdateResponse.urlString) {
+    let urlDisplayString = urlUpdateResponse.urlString.replace(
+      /^https:\/\//,
+      "",
+    );
+    urlDisplayString = urlDisplayString.replace(/^www\./, "");
+
+    urlStringElem
+      .attr({ href: urlUpdateResponse.urlString })
+      .text(urlDisplayString);
+  }
 
   updateURLTagsAndUTubTagsBasedOnGetURLData(
     urlTags,

--- a/src/static/scripts/components/urls_deck/url_cards/url_cards_url_string.js
+++ b/src/static/scripts/components/urls_deck/url_cards/url_cards_url_string.js
@@ -31,7 +31,8 @@ function createURLStringAndUpdateBlock(urlStringText, urlCard) {
 function createUpdateURLStringInput(urlStringText, urlCard) {
   const urlStringUpdateTextInputContainer = makeTextInput(
     "urlString",
-    INPUT_TYPES.UPDATE.description,
+    METHOD_TYPES.UPDATE.description,
+    INPUT_TYPES.URL.description,
   )
     .addClass("updateUrlStringWrap")
     .css("display", "none");

--- a/src/static/scripts/components/urls_deck/url_cards/url_cards_url_title.js
+++ b/src/static/scripts/components/urls_deck/url_cards/url_cards_url_title.js
@@ -57,7 +57,7 @@ function createUpdateURLTitleInput(urlTitleText, urlCard) {
   // Create the update title text box
   const urlTitleUpdateInputContainer = makeTextInput(
     "urlTitle",
-    INPUT_TYPES.UPDATE.description,
+    METHOD_TYPES.UPDATE.description,
   )
     .addClass("updateUrlTitleWrap")
     .css("display", "none");

--- a/src/static/scripts/components/urls_deck/url_tags/create_url_tag.js
+++ b/src/static/scripts/components/urls_deck/url_tags/create_url_tag.js
@@ -3,7 +3,7 @@
 function createTagInputBlock(urlCard) {
   const urlTagCreateTextInputContainer = makeTextInput(
     "urlTag",
-    INPUT_TYPES.CREATE.description,
+    METHOD_TYPES.CREATE.description,
   )
     .addClass("createUrlTagWrap")
     .css("display", "none");

--- a/src/static/scripts/components/urls_deck/url_tags/url_tags.js
+++ b/src/static/scripts/components/urls_deck/url_tags/url_tags.js
@@ -49,7 +49,7 @@ function createTagBadgesAndWrap(dictTags, tagArray, urlCard) {
 function createTagInputBlock(urlCard) {
   const urlTagCreateTextInputContainer = makeTextInput(
     "urlTag",
-    INPUT_TYPES.CREATE.description,
+    METHOD_TYPES.CREATE.description,
   )
     .addClass("createUrlTagWrap")
     .css("display", "none");

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -701,6 +701,7 @@ a.urlString:hover {
     position: relative;
 }
 
+.text-input[type="url"],
 .text-input[type="text"] {
     width: 100%;
     padding: 10px;
@@ -713,10 +714,12 @@ a.urlString:hover {
     color: whitesmoke;
 }
 
+.text-input[type="url"]:hover,
 .text-input[type="text"]:hover {
     border-color: var(--deckSelectionGreenHover);
 }
 
+.text-input[type="url"]:focus,
 .text-input[type="text"]:focus {
     border-color: var(--deckSelectionGreen);
 }

--- a/src/templates/home/URLDeck/CreateURLForm.html
+++ b/src/templates/home/URLDeck/CreateURLForm.html
@@ -1,21 +1,27 @@
 <div id="createURLWrap" class="input-text-holder flex-column createDiv pad-in-15p gap-20p" style="display: none;">
 	<div class="text-input-container">
 		<div class="text-input-inner-container">
-			<input class="text-input" type="text" id="urlTitleCreate" name="urlTitle" minlength={{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}} maxlength={{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}} required tabindex="0">
+			<input class="text-input" type="text" id="urlTitleCreate" name="urlTitle"
+				minlength={{CONSTANTS.URLS.MIN_URL_TITLE_LENGTH}}
+				maxlength={{CONSTANTS.URLS.MAX_URL_TITLE_LENGTH}} required tabindex="0">
 			<label class="text-input-label" for="urlTitleCreate">URL Title</label>
 		</div>
 		<span class="text-input-error-message" id="urlTitleCreate-error"></span>
 	</div>
 	<div class="text-input-container">
 		<div class="text-input-inner-container">
-			<input class="text-input" type="text" id="urlStringCreate" name="urlString" minlength={{CONSTANTS.URLS.MIN_URL_LENGTH}} maxlength={{CONSTANTS.URLS.MAX_URL_LENGTH}} required tabindex="0">
+			<input class="text-input" type="url" id="urlStringCreate" name="urlString"
+				minlength={{CONSTANTS.URLS.MIN_URL_LENGTH}} maxlength={{CONSTANTS.URLS.MAX_URL_LENGTH}}
+				required tabindex="0">
 			<label class="text-input-label" for="urlStringCreate">URL</label>
 		</div>
 		<span class="text-input-error-message" id="urlStringCreate-error"></span>
 	</div>
 	<div class="flex-row flex-start" style="gap: 8px; flex: 1 1 auto;">
-		<button id="urlSubmitBtnCreate" class="card-link btn green-clickable-wide btn-text-on-hvr" type="button">Add URL</button>
-		<button id="urlCancelBtnCreate" class="card-link btn cancelButton-wide btn-text-on-hvr" type="button">Cancel</button>
+		<button id="urlSubmitBtnCreate" class="card-link btn green-clickable-wide btn-text-on-hvr"
+			type="button">Add URL</button>
+		<button id="urlCancelBtnCreate" class="card-link btn cancelButton-wide btn-text-on-hvr"
+			type="button">Cancel</button>
 		<div id="urlCreateDualLoadingRing"></div>
 	</div>
 </div>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -18,27 +18,30 @@
             <div class="form-group first-in-register-login-form">
                 {{ login_form.username.label(class="form-control-label login-register-label")}}
                 {% if login_form.username.errors %}
-                {{ login_form.username(class="form-control login-register-form-group is-invalid") }}
+                {{ login_form.username(class="form-control login-register-form-group is-invalid",
+                autocomplete="username") }}
                 <div class="invalid-feedback">
                     {% for error in login_form.username.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ login_form.username(class="form-control login-register-form-group")}}
+                {{ login_form.username(class="form-control login-register-form-group", autocomplete="username")}}
                 {% endif %}
             </div>
             <div class="form-group">
                 {{ login_form.password.label(class="form-control-label login-register-label")}}
                 {% if login_form.password.errors %}
-                {{ login_form.password(class="form-control login-register-form-group is-invalid") }}
+                {{ login_form.password(class="form-control login-register-form-group is-invalid",
+                autocomplete="current-password") }}
                 <div class="invalid-feedback">
                     {% for error in login_form.password.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ login_form.password(class="form-control login-register-form-group")}}
+                {{ login_form.password(class="form-control login-register-form-group",
+                autocomplete="current-password")}}
                 {% endif %}
             </div>
             <div class="form-group" id="ForgotPasswordLink">

--- a/src/templates/password_reset/forgot_password.html
+++ b/src/templates/password_reset/forgot_password.html
@@ -17,14 +17,15 @@
             <div class="form-group forgot-password-form-group">
                 {{ forgot_password_form.email.label(class="form-control-label forgot-password-email-label")}}
                 {% if forgot_password_form.email.errors %}
-                {{ forgot_password_form.email(class="form-control login-register-form-group is-invalid") }}
+                {{ forgot_password_form.email(class="form-control login-register-form-group is-invalid",
+                autocomplete="email") }}
                 <div class="invalid-feedback">
                     {% for error in forgot_password_form.email.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ forgot_password_form.email(class="form-control login-register-form-group")}}
+                {{ forgot_password_form.email(class="form-control login-register-form-group", autocomplete="email")}}
                 {% endif %}
             </div>
         </fieldset>

--- a/src/templates/password_reset/reset_password.html
+++ b/src/templates/password_reset/reset_password.html
@@ -16,20 +16,23 @@
             <div class="form-group first-in-register-login-form">
                 {{ reset_password_form.new_password.label(class="form-control-label login-register-label")}}
                 {% if reset_password_form.new_password.errors %}
-                {{ reset_password_form.new_password(class="form-control login-register-form-group is-invalid") }}
+                {{ reset_password_form.new_password(class="form-control login-register-form-group is-invalid",
+                autocomplete="new-password") }}
                 <div class="invalid-feedback">
                     {% for error in reset_password_form.new_password.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ reset_password_form.new_password(class="form-control login-register-form-group")}}
+                {{ reset_password_form.new_password(class="form-control login-register-form-group",
+                autocomplete="new-password")}}
                 {% endif %}
             </div>
             <div class="form-group">
                 {{ reset_password_form.confirm_new_password.label(class="form-control-label login-register-label")}}
                 {% if reset_password_form.confirm_new_password.errors %}
-                {{ reset_password_form.confirm_new_password(class="form-control login-register-form-group is-invalid")
+                {{ reset_password_form.confirm_new_password(class="form-control login-register-form-group is-invalid",
+                autocomplete="new-password")
                 }}
                 <div class="invalid-feedback">
                     {% for error in reset_password_form.confirm_new_password.errors %}
@@ -37,7 +40,8 @@
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ reset_password_form.confirm_new_password(class="form-control login-register-form-group")}}
+                {{ reset_password_form.confirm_new_password(class="form-control login-register-form-group",
+                autocomplete="new-password")}}
                 {% endif %}
             </div>
         </fieldset>

--- a/src/templates/register_user.html
+++ b/src/templates/register_user.html
@@ -45,14 +45,15 @@
             <div class="form-group">
                 {{ register_form.confirm_email.label(class="form-control-label login-register-label")}}
                 {% if register_form.confirm_email.errors %}
-                {{ register_form.confirm_email(class="form-control login-register-form-group is-invalid") }}
+                {{ register_form.confirm_email(class="form-control login-register-form-group is-invalid",
+                autocomplete="email") }}
                 <div class="invalid-feedback">
                     {% for error in register_form.confirm_email.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ register_form.confirm_email(class="form-control login-register-form-group")}}
+                {{ register_form.confirm_email(class="form-control login-register-form-group", autocomplete="email")}}
                 {% endif %}
             </div>
             <div class="form-group">
@@ -66,7 +67,7 @@
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ register_form.password(class="form-control login-register-form-group")}}
+                {{ register_form.password(class="form-control login-register-form-group", autocomplete="new-password")}}
                 {% endif %}
             </div>
             <div class="form-group">

--- a/src/templates/register_user.html
+++ b/src/templates/register_user.html
@@ -17,27 +17,29 @@
             <div class="form-group first-in-register-login-form">
                 {{ register_form.username.label(class="form-control-label login-register-label")}}
                 {% if register_form.username.errors %}
-                {{ register_form.username(class="form-control login-register-form-group is-invalid") }}
+                {{ register_form.username(class="form-control login-register-form-group is-invalid",
+                autocomplete="username") }}
                 <div class="invalid-feedback">
                     {% for error in register_form.username.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ register_form.username(class="form-control login-register-form-group")}}
+                {{ register_form.username(class="form-control login-register-form-group", autocomplete="username")}}
                 {% endif %}
             </div>
             <div class="form-group">
                 {{ register_form.email.label(class="form-control-label login-register-label")}}
                 {% if register_form.email.errors %}
-                {{ register_form.email(class="form-control login-register-form-group is-invalid") }}
+                {{ register_form.email(class="form-control login-register-form-group is-invalid", autocomplete="email")
+                }}
                 <div class="invalid-feedback">
                     {% for error in register_form.email.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ register_form.email(class="form-control login-register-form-group")}}
+                {{ register_form.email(class="form-control login-register-form-group", autocomplete="email")}}
                 {% endif %}
             </div>
             <div class="form-group">
@@ -56,7 +58,8 @@
             <div class="form-group">
                 {{ register_form.password.label(class="form-control-label login-register-label")}}
                 {% if register_form.password.errors %}
-                {{ register_form.password(class="form-control login-register-form-group is-invalid") }}
+                {{ register_form.password(class="form-control login-register-form-group is-invalid",
+                autocomplete="new-password") }}
                 <div class="invalid-feedback">
                     {% for error in register_form.password.errors %}
                     <span>{{ error }}</span>
@@ -69,14 +72,16 @@
             <div class="form-group">
                 {{ register_form.confirm_password.label(class="form-control-label login-register-label")}}
                 {% if register_form.confirm_password.errors %}
-                {{ register_form.confirm_password(class="form-control login-register-form-group is-invalid") }}
+                {{ register_form.confirm_password(class="form-control login-register-form-group is-invalid",
+                autocomplete="new-password") }}
                 <div class="invalid-feedback">
                     {% for error in register_form.confirm_password.errors %}
                     <span>{{ error }}</span>
                     {% endfor %}
                 </div>
                 {% else %}
-                {{ register_form.confirm_password(class="form-control login-register-form-group")}}
+                {{ register_form.confirm_password(class="form-control login-register-form-group",
+                autocomplete="new-password")}}
                 {% endif %}
             </div>
         </fieldset>

--- a/tests/integration/splash/test_login_register_home_screen.py
+++ b/tests/integration/splash/test_login_register_home_screen.py
@@ -56,11 +56,11 @@ def test_get_login_screen_not_logged_in(app_with_server_name, client):
 
         assert response.status_code == 200
 
-        login_input_html = f'<input class="form-control login-register-form-group" id="username" maxlength="{USER_CONSTANTS.MAX_USERNAME_LENGTH}" minlength="{USER_CONSTANTS.MIN_USERNAME_LENGTH}" name="username" required type="text" value="">'
+        login_input_html = f'<input autocomplete="username" class="form-control login-register-form-group" id="username" maxlength="{USER_CONSTANTS.MAX_USERNAME_LENGTH}" minlength="{USER_CONSTANTS.MIN_USERNAME_LENGTH}" name="username" required type="text" value="">'
 
         assert login_input_html.encode() in response.data
         assert (
-            b'<input class="form-control login-register-form-group" id="password" name="password" required type="password" value="">'
+            b'<input autocomplete="current-password" class="form-control login-register-form-group" id="password" name="password" required type="password" value="">'
             in response.data
         )
         assert (
@@ -84,21 +84,21 @@ def test_get_register_screen_not_logged_in(app_with_server_name, client):
         assert response.status_code == 200
 
         assert (
-            b'<input class="form-control login-register-form-group" id="username" maxlength="20" minlength="3" name="username" required type="text" value="">'
+            b'<input autocomplete="username" class="form-control login-register-form-group" id="username" maxlength="20" minlength="3" name="username" required type="text" value="">'
             in response.data
         )
         assert (
-            b'<input class="form-control login-register-form-group" id="email" name="email" required type="text" value="">'
+            b'<input autocomplete="email" class="form-control login-register-form-group" id="email" name="email" required type="email" value="">'
             in response.data
         )
         assert (
-            b'<input class="form-control login-register-form-group" id="confirmEmail" name="confirmEmail" required type="text" value="">'
+            b'<input autocomplete="email" class="form-control login-register-form-group" id="confirmEmail" name="confirmEmail" required type="email" value="">'
             in response.data
         )
-        password_input_html = f'<input class="form-control login-register-form-group" id="password" maxlength="{USER_CONSTANTS.MAX_PASSWORD_LENGTH}" minlength="{USER_CONSTANTS.MIN_PASSWORD_LENGTH}" name="password" required type="password" value="">'
+        password_input_html = f'<input autocomplete="new-password" class="form-control login-register-form-group" id="password" maxlength="{USER_CONSTANTS.MAX_PASSWORD_LENGTH}" minlength="{USER_CONSTANTS.MIN_PASSWORD_LENGTH}" name="password" required type="password" value="">'
         assert password_input_html.encode() in response.data
         assert (
-            b'<input class="form-control login-register-form-group" id="confirmPassword" name="confirmPassword" required type="password" value="">'
+            b'<input autocomplete="new-password" class="form-control login-register-form-group" id="confirmPassword" name="confirmPassword" required type="password" value="">'
             in response.data
         )
         assert (

--- a/tests/integration/splash/test_login_user.py
+++ b/tests/integration/splash/test_login_user.py
@@ -343,11 +343,11 @@ def test_user_can_login_logout_login(login_first_user_with_register):
         in response.data
     )
 
-    login_input_html = f'<input class="form-control login-register-form-group" id="username" maxlength="{USER_CONSTANTS.MAX_USERNAME_LENGTH}" minlength="{USER_CONSTANTS.MIN_USERNAME_LENGTH}" name="username" required type="text" value="">'
+    login_input_html = f'<input autocomplete="username" class="form-control login-register-form-group" id="username" maxlength="{USER_CONSTANTS.MAX_USERNAME_LENGTH}" minlength="{USER_CONSTANTS.MIN_USERNAME_LENGTH}" name="username" required type="text" value="">'
 
     assert login_input_html.encode() in response.data
     assert (
-        b'<input class="form-control login-register-form-group" id="password" name="password" required type="password" value="">'
+        b'<input autocomplete="current-password" class="form-control login-register-form-group" id="password" name="password" required type="password" value="">'
         in response.data
     )
     assert response.request.path == url_for(ROUTES.SPLASH.LOGIN)
@@ -396,11 +396,11 @@ def test_login_modal_is_shown(app_with_server_name, client):
             b'<input id="csrf_token" name="csrf_token" type="hidden" value='
             in response.data
         )
-        login_input_html = f'<input class="form-control login-register-form-group" id="username" maxlength="{USER_CONSTANTS.MAX_USERNAME_LENGTH}" minlength="{USER_CONSTANTS.MIN_USERNAME_LENGTH}" name="username" required type="text" value="">'
+        login_input_html = f'<input autocomplete="username" class="form-control login-register-form-group" id="username" maxlength="{USER_CONSTANTS.MAX_USERNAME_LENGTH}" minlength="{USER_CONSTANTS.MIN_USERNAME_LENGTH}" name="username" required type="text" value="">'
 
         assert login_input_html.encode() in response.data
         assert (
-            b'<input class="form-control login-register-form-group" id="password" name="password" required type="password" value="">'
+            b'<input autocomplete="current-password" class="form-control login-register-form-group" id="password" name="password" required type="password" value="">'
             in response.data
         )
         assert request.path == url_for(ROUTES.SPLASH.LOGIN)

--- a/tests/integration/splash/test_register_user.py
+++ b/tests/integration/splash/test_register_user.py
@@ -235,21 +235,21 @@ def test_register_modal_is_shown(app_with_server_name, client):
             in response.data
         )
         assert (
-            b'<input class="form-control login-register-form-group" id="username" maxlength="20" minlength="3" name="username" required type="text" value="">'
+            b'<input autocomplete="username" class="form-control login-register-form-group" id="username" maxlength="20" minlength="3" name="username" required type="text" value="">'
             in response.data
         )
         assert (
-            b'<input class="form-control login-register-form-group" id="email" name="email" required type="text" value="">'
+            b'<input autocomplete="email" class="form-control login-register-form-group" id="email" name="email" required type="email" value="">'
             in response.data
         )
         assert (
-            b'<input class="form-control login-register-form-group" id="confirmEmail" name="confirmEmail" required type="text" value="">'
+            b'<input autocomplete="email" class="form-control login-register-form-group" id="confirmEmail" name="confirmEmail" required type="email" value="">'
             in response.data
         )
-        password_input_html = f'<input class="form-control login-register-form-group" id="password" maxlength="{USER_CONSTANTS.MAX_PASSWORD_LENGTH}" minlength="{USER_CONSTANTS.MIN_PASSWORD_LENGTH}" name="password" required type="password" value="">'
+        password_input_html = f'<input autocomplete="new-password" class="form-control login-register-form-group" id="password" maxlength="{USER_CONSTANTS.MAX_PASSWORD_LENGTH}" minlength="{USER_CONSTANTS.MIN_PASSWORD_LENGTH}" name="password" required type="password" value="">'
         assert password_input_html.encode() in response.data
         assert (
-            b'<input class="form-control login-register-form-group" id="confirmPassword" name="confirmPassword" required type="password" value="">'
+            b'<input autocomplete="new-password" class="form-control login-register-form-group" id="confirmPassword" name="confirmPassword" required type="password" value="">'
             in response.data
         )
         assert request.path == url_for(ROUTES.SPLASH.REGISTER)


### PR DESCRIPTION
Updates URL input fields to use `type=url`

Updates Email input fields to use `type=email`

Fixes CSS handling for this type.

Adds autocomplete attribute for username, email, and password for related forms.

Ensures async update for URL on URL delete still shows proper URL string.

Closes #378 