### PR TITLE
Fix bug with yahoo not validating

### DIFF
--- a/tests/unit/test_url_validation.py
+++ b/tests/unit/test_url_validation.py
@@ -15,6 +15,12 @@ from src.utils.strings.url_validation_strs import USER_AGENT
 pytestmark = pytest.mark.unit
 
 valid_urls = {
+    "https://www.yahoo.com/": [
+        "yahoo.com",
+        "www.yahoo.com",
+        "https://www.yahoo.com",
+        "https://yahoo.com",
+    ],
     "https://www.google.com/": [
         "https://www.google.com/",
         "https://www.google.com",


### PR DESCRIPTION
Fix a bug where `yahoo.com` wouldn't validate but `www.yahoo.com` would.

Down the road, highly consider a sidecar process running Playright to handle these kinds of issues.

Closes #448 