### PR TITLE
Remove user details from logs

### DIFF
--- a/src/extensions/url_validation/url_validator.py
+++ b/src/extensions/url_validation/url_validator.py
@@ -678,7 +678,11 @@ class UrlValidator:
             self._log(warning_log, f"Invalid schema on deconstructed URL: {location}")
             return None
 
-        return location
+        return (
+            self._filter_out_common_redirect(location)
+            if location is not None
+            else location
+        )
 
     def _check_if_is_short_url(self, url_domain: str) -> bool:
         if not self._redis_uri or self._redis_uri == "memory://":
@@ -897,7 +901,7 @@ class UrlValidator:
                 )
                 return unquote(url)
 
-        self._log(warning_log, "Unable to find common direct for URL")
+        self._log(safe_add_log, "Unable to find common direct for URL")
         return unquote(url)
 
     @staticmethod

--- a/src/extensions/url_validation/url_validator.py
+++ b/src/extensions/url_validation/url_validator.py
@@ -286,7 +286,8 @@ class UrlValidator:
             safe_add_many_logs,
             [
                 f"From HEAD request with redirect: {response.headers} ",
-                f"{redirect_url=}" f"{response.url=}",
+                f"{redirect_url=}",
+                f"{response.url=}",
             ],
         )
         return response
@@ -312,7 +313,8 @@ class UrlValidator:
         safe_add_many_logs(
             [
                 f"From HEAD request without redirect: {response.headers} ",
-                f"{url=}" f"{response.url=}",
+                f"{url=}",
+                f"{response.url=}",
             ]
         )
         return response
@@ -409,7 +411,8 @@ class UrlValidator:
             safe_add_many_logs,
             [
                 f"From GET request with redirect: {response.headers} ",
-                f"{redirect_url=}" f"{response.url=}",
+                f"{redirect_url=}",
+                f"{response.url=}",
             ],
         )
         return response

--- a/src/models/users.py
+++ b/src/models/users.py
@@ -116,7 +116,7 @@ class Users(db.Model, UserMixin):
         return {MODEL_STRS.UTUBS: utub_summaries}
 
     def __repr__(self):
-        return f"User: {self.username}, Email: {self.email}, Password: {self.password}"
+        return f"User: {self.username}"
 
     def get_email_validation_token(
         self, expires_in=EMAIL_CONSTANTS.WAIT_TO_ATTEMPT_AFTER_MAX_ATTEMPTS

--- a/tests/ui_test_utils.py
+++ b/tests/ui_test_utils.py
@@ -25,6 +25,17 @@ def run_app(port: int, show_flask_logs: bool):
         log.disabled = True
         app_for_test.logger.disabled = True
 
+        # Remove all StreamHandlers from the app logger to prevent console output
+        handlers_to_remove = []
+        for handler in app_for_test.logger.handlers:
+            if isinstance(handler, logging.StreamHandler) and not isinstance(
+                handler, logging.NullHandler
+            ):
+                handlers_to_remove.append(handler)
+
+        for handler in handlers_to_remove:
+            app_for_test.logger.removeHandler(handler)
+
         import flask.cli
 
         flask.cli.show_server_banner = lambda *args: None


### PR DESCRIPTION
User details should not be so thorough in the logs.

Only the first log for a request should have detailed request info, remove for other logs in the same request.