### PR TITLE
Handle Android intents

### DIFF
--- a/src/app_logger.py
+++ b/src/app_logger.py
@@ -210,6 +210,10 @@ def safe_retrieve_logs() -> str:
     return " | ".join([val for val in g.log_messages])
 
 
+def info_log(log: str):
+    current_app.logger.info(msg=log)
+
+
 def warning_log(log: str):
     current_app.logger.warning(msg=log)
 


### PR DESCRIPTION
Handle whenever a URL becomes an intent based on the user's device being an Android.

When `User-Agent` contains `Android` and a URL contains `intent` as it's schema, then assume the URL was valid and pass back the original URL used to validate the request.

Add tests for both handling invalid schemas in a return from a HEAD/GET response, and also for an intent being returned.