### PR TITLE
Fix share.google or share.app links

### DIFF
--- a/src/cli/cli_options.py
+++ b/src/cli/cli_options.py
@@ -8,6 +8,7 @@ from redis.client import Redis
 
 from src.utils.strings.config_strs import CONFIG_ENVS as ENV
 from src.utils.strings.url_validation_strs import SHORT_URLS
+from src.utils.strings.url_validation_strs import CUSTOM_SHORT_URLS
 
 HELP_SUMMARY_SHORT_URL = """Add list of short URL domains to redis."""
 HELP_SUMMARY_UTILS = """General CLI Utils for U4I."""
@@ -53,7 +54,9 @@ def add_short_url_domains_to_redis():
         # Remove title block from list
         short_urls = short_urls[11:]
 
-        short_urls_strs = [str(val.decode()) for val in short_urls]
+        short_urls_strs = [str(val.decode()) for val in short_urls] + [
+            short for short in CUSTOM_SHORT_URLS
+        ]
 
         redis_client: Redis = redis.Redis.from_url(url=redis_uri)  # type: ignore
         added = redis_client.sadd(SHORT_URLS, *short_urls_strs)

--- a/src/utils/strings/url_validation_strs.py
+++ b/src/utils/strings/url_validation_strs.py
@@ -73,3 +73,9 @@ class URL_VALIDATION:
             REFERER,
         )
     }
+
+
+CUSTOM_SHORT_URLS = (
+    "share.google",
+    "share.app",
+)

--- a/tests/integration/cli/test_add_short_url_domains.py
+++ b/tests/integration/cli/test_add_short_url_domains.py
@@ -71,3 +71,12 @@ def test_validate_short_url(runner):
 
     assert LONG_URL == final_url
     assert is_validated
+
+    VALID_SHARE_GOOGLE_URL = "https://share.google/pgpkvcPWym6rP8LDz"
+    IN_FINAL_URL = "https://www.etsy.com"
+
+    with app.app_context():
+        final_url, is_validated = url_validator.validate_url(VALID_SHARE_GOOGLE_URL)
+
+    assert IN_FINAL_URL in final_url
+    assert is_validated


### PR DESCRIPTION
Due to Google adding new shortened URLs, we need to handle these specifically...

https://www.androidpolice.com/google-discover-feed-share-link-shortened/

These custom short URLs fix redirect to a `google.com` URL where the original shortened URL is added as a query,

i.e.:

1.  Shortened url - https://share.google/pgpkvcPWym6rP8LDz
2. On GET, redirects to https://www.google.com/?q=share.google/pgpkvcPWym6rP8LDz
3. We need to follow this link, so change request header HOST to be www.google.com now
4. Make final GET request against URL from step 2
5. Now final destination URL is in Location header