### PR TITLE
Hide newly created URL if tag was already selected

### DIFF
--- a/src/app_logger.py
+++ b/src/app_logger.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import logging
 import os
 import time
+from typing import Optional
 import uuid
 
 from flask import Flask, Request, Response, current_app, g, has_request_context, request
@@ -235,7 +236,11 @@ def setup_before_request_logging(app: Flask):
         log_with_detailed_info(app, logging.INFO, message)
 
     @app.after_request
-    def after_request(response: Response):
+    def after_request(response: Optional[Response]):
+        if response is None:
+            warning_log("Received no response object")
+            return response
+
         duration_ms = (
             (time.time() - g.request_start_time) * 1000
             if hasattr(g, "request_start_time")

--- a/src/static/scripts/components/urls_deck/url_cards/create_url_card.js
+++ b/src/static/scripts/components/urls_deck/url_cards/create_url_card.js
@@ -120,7 +120,12 @@ function createURLSuccess(response) {
   currentNumOfURLs === 0
     ? null
     : updateColorOfFollowingURLCardsAfterURLCreated();
-  selectURLCard(newUrlCard);
+
+  // Only select the URL when no tags are selected
+  // If a tag is selected, new URLs have no Tags associated, so they should be hidden after added
+  isATagSelected()
+    ? newUrlCard.attr({ filterable: false })
+    : selectURLCard(newUrlCard);
 }
 
 // Displays appropriate prompts and options to user following a failed addition of a new URL

--- a/src/static/scripts/components/utub_tags_deck/utub_tags_utils.js
+++ b/src/static/scripts/components/utub_tags_deck/utub_tags_utils.js
@@ -21,3 +21,7 @@ function isTagInUTub(tagBadges, utubTagID) {
   });
   return tagExistsInUTub;
 }
+
+function isATagSelected() {
+  return $(".tagFilter.selected").length > 0;
+}

--- a/tests/functional/tags_ui/utils_for_test_tag_ui.py
+++ b/tests/functional/tags_ui/utils_for_test_tag_ui.py
@@ -210,12 +210,15 @@ def add_tag_to_utub_user_created(
         return Utub_Tags.query.filter(Utub_Tags.tag_string == tag_string).first()
 
 
-def apply_tag_based_on_id_and_get_shown_urls(
-    browser: WebDriver, utub_tag_id: int
-) -> list[WebElement]:
+def apply_tag_based_on_id(browser: WebDriver, utub_tag_id: int):
     utub_tag_badge_selector = get_utub_tag_badge_selector(utub_tag_id)
     wait_then_click_element(browser, utub_tag_badge_selector, time=3)
 
+
+def apply_tag_based_on_id_and_get_shown_urls(
+    browser: WebDriver, utub_tag_id: int
+) -> list[WebElement]:
+    apply_tag_based_on_id(browser, utub_tag_id)
     url_row_elements = browser.find_elements(By.CSS_SELECTOR, HPL.ROWS_URLS)
     return [url_row for url_row in url_row_elements if url_row.is_displayed()]
 


### PR DESCRIPTION
When a URL is created while a tag is selected, the URL should not be shown since it has no tags applied.

Closes #431 