### PR TITLE
[Frontend] Minimizable left panels

### DIFF
--- a/src/static/scripts/components/collapsible_decks.js
+++ b/src/static/scripts/components/collapsible_decks.js
@@ -1,9 +1,11 @@
 "use strict";
 
 $(document).ready(function () {
-  setupUTubHeaderForMaximizeMinimize();
-  setupMemberHeaderForMaximizeMinimize();
-  setupTagHeaderForMaximizeMinimize();
+  if (!isMobile()) {
+    setupCollapsibleLeftDecks();
+  } else {
+    removeCollapsibleClickableHeaderClass();
+  }
 });
 
 const UTUB_DECK_CSS_SELECTOR = ".deck#UTubDeck";
@@ -15,8 +17,31 @@ const LHS_DECKS = [
   UTUB_TAG_DECK_CSS_SELECTOR,
 ];
 
+function removeCollapsibleClickableHeaderClass() {
+  $("#UTubDeckHeaderAndCaret").removeClass("clickable");
+  $("#MemberDeckHeaderAndCaret").removeClass("clickable");
+  $("#TagDeckHeaderAndCaret").removeClass("clickable");
+}
+
+function addCollapsibleClickableHeaderClass() {
+  $("#UTubDeckHeaderAndCaret").addClass("clickable");
+  $("#MemberDeckHeaderAndCaret").addClass("clickable");
+  $("#TagDeckHeaderAndCaret").addClass("clickable");
+}
+
+function setupCollapsibleLeftDecks() {
+  setupUTubHeaderForMaximizeMinimize();
+  setupMemberHeaderForMaximizeMinimize();
+  setupTagHeaderForMaximizeMinimize();
+}
+
 function setupUTubHeaderForMaximizeMinimize() {
-  $("#UTubDeckHeaderAndCaret").offAndOn("click.collapsibleUTubDeck", () => {
+  const headerAndCaret = $("#UTubDeckHeaderAndCaret");
+  if (!headerAndCaret.hasClass("clickable"))
+    headerAndCaret.addClass("clickable");
+
+  headerAndCaret.offAndOn("click.collapsibleUTubDeck", () => {
+    if (isMobile()) return;
     const caret = $("#UTubDeckHeaderAndCaret .title-caret");
     if (caret.hasClass("closed")) {
       caret.removeClass("closed");
@@ -39,7 +64,12 @@ function setupUTubHeaderForMaximizeMinimize() {
 }
 
 function setupMemberHeaderForMaximizeMinimize() {
-  $("#MemberDeckHeaderAndCaret").offAndOn("click.collapsibleMemberDeck", () => {
+  const headerAndCaret = $("#MemberDeckHeaderAndCaret");
+  if (!headerAndCaret.hasClass("clickable"))
+    headerAndCaret.addClass("clickable");
+
+  headerAndCaret.offAndOn("click.collapsibleMemberDeck", () => {
+    if (isMobile()) return;
     const caret = $("#MemberDeckHeaderAndCaret .title-caret");
     if (caret.hasClass("closed")) {
       caret.removeClass("closed");
@@ -61,7 +91,12 @@ function setupMemberHeaderForMaximizeMinimize() {
 }
 
 function setupTagHeaderForMaximizeMinimize() {
-  $("#TagDeckHeaderAndCaret").offAndOn("click.collapsibleUTubTagDeck", () => {
+  const headerAndCaret = $("#TagDeckHeaderAndCaret");
+  if (!headerAndCaret.hasClass("clickable"))
+    headerAndCaret.addClass("clickable");
+
+  headerAndCaret.offAndOn("click.collapsibleUTubTagDeck", () => {
+    if (isMobile()) return;
     const caret = $("#TagDeckHeaderAndCaret .title-caret");
     if (caret.hasClass("closed")) {
       caret.removeClass("closed");

--- a/src/static/scripts/components/collapsible_decks.js
+++ b/src/static/scripts/components/collapsible_decks.js
@@ -1,0 +1,115 @@
+"use strict";
+
+$(document).ready(function () {
+  setupUTubHeaderForMaximizeMinimize();
+  setupMemberHeaderForMaximizeMinimize();
+  setupTagHeaderForMaximizeMinimize();
+});
+
+const UTUB_DECK_CSS_SELECTOR = ".deck#UTubDeck";
+const MEMBER_DECK_CSS_SELECTOR = ".deck#MemberDeck";
+const UTUB_TAG_DECK_CSS_SELECTOR = ".deck#TagDeck";
+const LHS_DECKS = [
+  UTUB_DECK_CSS_SELECTOR,
+  MEMBER_DECK_CSS_SELECTOR,
+  UTUB_TAG_DECK_CSS_SELECTOR,
+];
+
+function setupUTubHeaderForMaximizeMinimize() {
+  $("#UTubDeckHeaderAndCaret").offAndOn("click.collapsibleUTubDeck", () => {
+    const caret = $("#UTubDeckHeaderAndCaret .title-caret");
+    if (caret.hasClass("closed")) {
+      caret.removeClass("closed");
+      $(UTUB_DECK_CSS_SELECTOR).removeClass("collapsed");
+      return;
+    }
+
+    const numDecksAlreadyCollapsed = getNumDecksAlreadyCollapsed();
+    caret.addClass("closed");
+    $(UTUB_DECK_CSS_SELECTOR).addClass("collapsed");
+
+    closeUTubSearchAndEraseInput();
+    createUTubHideInput();
+
+    if (numDecksAlreadyCollapsed >= 2) {
+      ensureOnlyTwoDecksCollapsedAtOnce(UTUB_DECK_CSS_SELECTOR);
+    }
+    setLastCollapsed(UTUB_DECK_CSS_SELECTOR);
+  });
+}
+
+function setupMemberHeaderForMaximizeMinimize() {
+  $("#MemberDeckHeaderAndCaret").offAndOn("click.collapsibleMemberDeck", () => {
+    const caret = $("#MemberDeckHeaderAndCaret .title-caret");
+    if (caret.hasClass("closed")) {
+      caret.removeClass("closed");
+      $(MEMBER_DECK_CSS_SELECTOR).removeClass("collapsed");
+      return;
+    }
+
+    const numDecksAlreadyCollapsed = getNumDecksAlreadyCollapsed();
+    caret.addClass("closed");
+    $(MEMBER_DECK_CSS_SELECTOR).addClass("collapsed");
+
+    createMemberHideInput();
+
+    if (numDecksAlreadyCollapsed >= 2) {
+      ensureOnlyTwoDecksCollapsedAtOnce(MEMBER_DECK_CSS_SELECTOR);
+    }
+    setLastCollapsed(MEMBER_DECK_CSS_SELECTOR);
+  });
+}
+
+function setupTagHeaderForMaximizeMinimize() {
+  $("#TagDeckHeaderAndCaret").offAndOn("click.collapsibleUTubTagDeck", () => {
+    const caret = $("#TagDeckHeaderAndCaret .title-caret");
+    if (caret.hasClass("closed")) {
+      caret.removeClass("closed");
+      $(UTUB_TAG_DECK_CSS_SELECTOR).removeClass("collapsed");
+      return;
+    }
+
+    const numDecksAlreadyCollapsed = getNumDecksAlreadyCollapsed();
+    caret.addClass("closed");
+    $(UTUB_TAG_DECK_CSS_SELECTOR).addClass("collapsed");
+
+    createUTubTagHideInput();
+
+    if (numDecksAlreadyCollapsed >= 2) {
+      ensureOnlyTwoDecksCollapsedAtOnce(UTUB_TAG_DECK_CSS_SELECTOR);
+    }
+    setLastCollapsed(UTUB_TAG_DECK_CSS_SELECTOR);
+  });
+}
+
+function getNumDecksAlreadyCollapsed() {
+  let collapsedDecksCount = 0;
+
+  for (let i = 0; i < LHS_DECKS.length; i++) {
+    if ($(LHS_DECKS[i]).hasClass("collapsed")) collapsedDecksCount += 1;
+  }
+
+  return collapsedDecksCount;
+}
+
+function ensureOnlyTwoDecksCollapsedAtOnce(collapsingDeck) {
+  let deckToExpandSelector;
+  for (let i = 0; i < LHS_DECKS.length; i++) {
+    if ($(LHS_DECKS[i]).attr("data-last-collapsed") === "true") {
+      deckToExpandSelector = LHS_DECKS[i];
+      break;
+    }
+  }
+
+  const deckToExpand = $(deckToExpandSelector);
+  deckToExpand.find(".title-caret").first().removeClass("closed");
+  deckToExpand.removeClass("collapsed");
+}
+
+function setLastCollapsed(collapsingDeck) {
+  for (let i = 0; i < LHS_DECKS.length; i++) {
+    collapsingDeck === LHS_DECKS[i]
+      ? $(collapsingDeck).attr("data-last-collapsed", "true")
+      : $(LHS_DECKS[i]).attr("data-last-collapsed", "false");
+  }
+}

--- a/src/static/scripts/components/mobile.js
+++ b/src/static/scripts/components/mobile.js
@@ -21,10 +21,12 @@ $(document).ready(function () {
       } else {
         setMobileUIWhenUTubNotSelectedOrUTubDeleted();
       }
+      removeCollapsibleClickableHeaderClass();
     } else {
       // Set full screen navbar
       // Show all panels and decks
       revertMobileUIToFullScreenUI();
+      addCollapsibleClickableHeaderClass();
     }
   });
 });

--- a/src/static/scripts/components/utub_tags_deck/create_utub_tag.js
+++ b/src/static/scripts/components/utub_tags_deck/create_utub_tag.js
@@ -25,15 +25,6 @@ function resetNewUTubTagForm() {
   $("#utubTagCreate").val(null);
 }
 
-// Shows new UTub Tag input fields
-function createUTubTagShowInput() {
-  $("#createUTubTagWrap").showClassFlex();
-  $("#listTags").hideClass();
-  $("#utubTagBtnCreate").hideClass();
-  setupCreateUTubTagEventListeners();
-  $("#utubTagCreate").trigger("focus");
-}
-
 function setupCreateUTubTagEventListeners() {
   const utubTagSubmitBtnCreate = $("#utubTagSubmitBtnCreate");
   const utubTagCancelBtnCreate = $("#utubTagCancelBtnCreate");
@@ -103,7 +94,14 @@ function unbindCreateUTubTagFocusEventListeners() {
   $(document).off(".createUTubTagSubmitEscape");
 }
 
-// Hides new UTubTag input fields
+function createUTubTagShowInput() {
+  $("#createUTubTagWrap").showClassFlex();
+  $("#listTags").hideClass();
+  $("#utubTagBtnCreate").hideClass();
+  setupCreateUTubTagEventListeners();
+  $("#utubTagCreate").trigger("focus");
+}
+
 function createUTubTagHideInput() {
   $("#createUTubTagWrap").hideClass();
   $("#listTags").showClassNormal();

--- a/src/static/scripts/components/utubs_deck/utubs_search.js
+++ b/src/static/scripts/components/utubs_deck/utubs_search.js
@@ -64,9 +64,7 @@ function setUTubSelectorSearchEventListener() {
   });
 
   searchInput
-    // Use namespacing like in the example (.searchInputEsc)
     .offAndOn("focus.searchInputEsc", function () {
-      // When the input gains focus, attach a keyup listener to the document
       $(document).offAndOn("keyup.searchInputEsc", function (e) {
         if (e.which === 27) {
           searchInput.blur();
@@ -79,7 +77,6 @@ function setUTubSelectorSearchEventListener() {
     .offAndOn("input", function () {
       const searchTerm = searchInput.val().toLowerCase();
       if (searchTerm.length < CONSTANTS.UTUBS_MIN_NAME_LENGTH) {
-        // Show all UTubs
         updatedUTubSelectorDisplay([]);
         return;
       }

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -40,20 +40,50 @@
     padding-bottom: 8px;
 }
 
-.deckContent {
-    width: 100%;
-    height: 90%;
-    margin: 0px;
+.deck#UTubDeck,
+.deck#MemberDeck,
+.deck#TagDeck {
+    flex: 1 1 0;
+    transition: flex 0.3s ease;
+}
+
+.deck#UTubDeck.collapsed,
+.deck#MemberDeck.collapsed,
+.deck#TagDeck.collapsed {
+    flex: 0 0 48px;
+    padding-bottom: 0;
+}
+
+.content {
+    flex: 1 1 0;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    border-top: 2px solid var(--contentTopBorder);
+    padding-bottom: 3px;
+    min-height: 0;
+}
+
+.content {
+    transition: opacity 0.3s ease;
+}
+
+.titleElement {
+    transition: all 0.3s ease;
+}
+
+.deck.collapsed .content,
+.deck.collapsed .titleElement:nth-of-type(2) {
+    opacity: 0;
+    flex-shrink: 0;
+    height: 0;
+    min-height: 0;
     overflow: hidden;
 }
 
-.deck#MemberDeck,
-.deck#TagDeck {
-    height: 33%;
-}
-
-.deck#UTubDeck {
-    height: 34%;
+.deck.collapsed .button-container {
+    transition: opacity 0.3s ease;
+    opacity: 0;
+    pointer-events: none;
 }
 
 /* Buttons */
@@ -86,6 +116,10 @@
 .funnel-x:hover {
     cursor: pointer;
     background: var(--removeIconColorHover);
+}
+
+.clickable {
+    cursor: pointer;
 }
 
 .cancelButton {
@@ -135,6 +169,16 @@
     justify-content: flex-end;
 }
 
+.title-caret {
+    color: var(--deckHeaderGreen);
+    transition: transform 0.15s ease;
+    transform-origin: center;
+}
+
+.title-caret.closed {
+    transform: rotate(-90deg);
+}
+
 /* Utility */
 
 .flex-row {
@@ -159,12 +203,8 @@
     flex-direction: row;
 }
 
-.content {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    scrollbar-width: thin;
-    border-top: 2px solid var(--contentTopBorder);
-    padding-bottom: 3px;
+.deck .titleElement:first-child {
+    height: 38px;
 }
 
 .flex-1-1-auto {

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -1265,6 +1265,16 @@ a.urlString:hover {
     .urlRow[filterable="true"][urlSelected="true"] .createUrlTagWrap>.text-input-container {
         width: 100%;
     }
+
+    .title-caret {
+        display: none;
+    }
+
+    #MemberDeckHeader,
+    #TagDeckHeader,
+    #UTubDeckHeader {
+        pointer-events: none;
+    }
 }
 
 @media (max-width: 767.98px) {
@@ -1287,7 +1297,6 @@ a.urlString:hover {
     #accessAllURLsBtn {
         width: 100% !important;
     }
-
 }
 
 @media (min-width: 465px) {}

--- a/src/templates/home/MemberDeck/MemberDeck.html
+++ b/src/templates/home/MemberDeck/MemberDeck.html
@@ -1,4 +1,4 @@
-<div id="MemberDeck" class="deck flex-column">
+<div id="MemberDeck" class="deck flex-column" data-last-collapsed="false">
 
 	<!-- Headers -->
 	{% include 'home/MemberDeck/MemberDeckHeaders.html' %}

--- a/src/templates/home/MemberDeck/MemberDeckHeaders.html
+++ b/src/templates/home/MemberDeck/MemberDeckHeaders.html
@@ -1,6 +1,11 @@
 <div class="titleElement sidePanelTitle pad-in-15p">
 	<div class="col-6 col-lg-6">
-		<h2 id="MemberDeckHeader">Members</h2>
+		<div id="MemberDeckHeaderAndCaret" class="flex-row flex-center gap-2p clickable">
+			<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-fill title-caret" viewBox="0 0 16 16">
+				<path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/>
+			</svg>
+			<h2 id="MemberDeckHeader">Members</h2>
+		</div>
 	</div>
 	<div class="col-6 col-lg-6 d-flex flex-row button-container">
 		<!-- Add user button -->

--- a/src/templates/home/TagsDeck/TagsDeck.html
+++ b/src/templates/home/TagsDeck/TagsDeck.html
@@ -1,7 +1,12 @@
-<div id="TagDeck" class="deck flex-column">
+<div id="TagDeck" class="deck flex-column" data-last-collapsed="false">
 	<div class="titleElement pad-in-15p justify-space-between">
 		<div class="flex-row gap-10p">
-			<h2 id="TagDeckHeader">Tags</h2>
+			<div id="TagDeckHeaderAndCaret" class="flex-row flex-center gap-2p clickable">
+				<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-fill title-caret" viewBox="0 0 16 16">
+				<path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/>
+				</svg>
+				<h2 id="TagDeckHeader">Tags</h2>
+			</div>
 		</div>
 		<div class="flex-row button-container gap-2p">
 			<!-- Add tag button -->

--- a/src/templates/home/UTubDeck/UTubDeck.html
+++ b/src/templates/home/UTubDeck/UTubDeck.html
@@ -1,4 +1,4 @@
-<div id="UTubDeck" class="deck flex-column">
+<div id="UTubDeck" class="deck flex-column" data-last-collapsed="false">
 
     <!-- Headers -->
     {% include 'home/UTubDeck/UTubDeckHeaders.html' %}

--- a/src/templates/home/UTubDeck/UTubDeckHeaders.html
+++ b/src/templates/home/UTubDeck/UTubDeckHeaders.html
@@ -1,7 +1,12 @@
 <!-- Header -->
 <div class="titleElement pad-in-15p justify-space-between">
     <div class="flex-row gap-5p">
-        <h2 id="UTubDeckHeader">UTubs</h2>
+        <div id="UTubDeckHeaderAndCaret" class="flex-row flex-center gap-2p clickable">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-fill title-caret" viewBox="0 0 16 16">
+              <path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/>
+            </svg>
+            <h2 id="UTubDeckHeader">UTubs</h2>
+        </div>
         <div id="UTubSelectDualLoadingRing"></div>
     </div>
     <!-- Icons -->

--- a/tests/functional/home_ui/selenium_utils.py
+++ b/tests/functional/home_ui/selenium_utils.py
@@ -1,0 +1,23 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from tests.functional.assert_utils import (
+    assert_not_visible_css_selector,
+)
+from tests.functional.selenium_utils import (
+    Decks,
+    wait_for_animation_to_end_check_height,
+    wait_then_click_element,
+    wait_then_get_element,
+)
+
+
+def collapse_deck(browser: WebDriver, deck_header_selector: str, collapsed_deck: Decks):
+    first_collapsed_deck_header_elem = wait_then_get_element(
+        browser, deck_header_selector, time=3
+    )
+    assert first_collapsed_deck_header_elem is not None
+
+    wait_then_click_element(browser, deck_header_selector, time=3)
+
+    wait_for_animation_to_end_check_height(browser, collapsed_deck.value)
+    assert_not_visible_css_selector(browser, f"{collapsed_deck.value} .content")

--- a/tests/functional/home_ui/test_collapsing_decks.py
+++ b/tests/functional/home_ui/test_collapsing_decks.py
@@ -1,0 +1,201 @@
+from flask import Flask
+import pytest
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from tests.functional.assert_utils import (
+    assert_login,
+    assert_not_visible_css_selector,
+    assert_visible_css_selector,
+)
+from tests.functional.home_ui.selenium_utils import collapse_deck
+from tests.functional.locators import HomePageLocators as HPL
+from tests.functional.login_utils import (
+    login_user_to_home_page,
+)
+from tests.functional.selenium_utils import (
+    Decks,
+    wait_for_animation_to_end_check_height,
+    wait_then_click_element,
+    wait_then_get_element,
+)
+
+pytestmark = pytest.mark.home_ui
+
+
+@pytest.mark.parametrize(
+    "deck_title_selector, collapsed_deck_selector",
+    [
+        (HPL.HEADER_TAG_DECK, Decks.TAGS),
+        (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+        (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+    ],
+)
+def test_single_collapsible_lhs_decks(
+    browser: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    deck_title_selector,
+    collapsed_deck_selector,
+):
+    """
+    Tests a user's ability to collapse one LHS deck.
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user clicks any one of the deck headers
+    THEN ensure the given deck is collapsed
+    """
+    app = provide_app
+    user_id = 1
+    login_user_to_home_page(app, browser, user_id)
+    assert_login(browser)
+
+    deck_header_elem = wait_then_get_element(browser, deck_title_selector, time=3)
+    assert deck_header_elem is not None
+
+    wait_then_click_element(browser, deck_title_selector, time=3)
+
+    wait_for_animation_to_end_check_height(browser, collapsed_deck_selector.value)
+    assert_not_visible_css_selector(
+        browser, f"{collapsed_deck_selector.value} .content"
+    )
+
+    for deck in (
+        Decks.UTUBS,
+        Decks.MEMBERS,
+        Decks.TAGS,
+    ):
+        if deck == collapsed_deck_selector:
+            continue
+        assert_visible_css_selector(browser, f"{deck.value} .content")
+
+
+@pytest.mark.parametrize(
+    "first_collapsed_header_and_deck, second_collapsed_header_and_deck, open_deck",
+    [
+        (
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            Decks.UTUBS,
+        ),
+        (
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            Decks.MEMBERS,
+        ),
+        (
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            Decks.UTUBS,
+        ),
+        (
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            Decks.TAGS,
+        ),
+        (
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            Decks.TAGS,
+        ),
+        (
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            Decks.MEMBERS,
+        ),
+    ],
+)
+def test_double_collapsible_lhs_decks(
+    browser: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    first_collapsed_header_and_deck,
+    second_collapsed_header_and_deck,
+    open_deck,
+):
+    """
+    Tests a user's ability to collapse two LHS decks
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user clicks any two of the deck headers
+    THEN ensure the given decks are collapsed
+    """
+    first_collapsed_deck_header, first_collapsed_deck = first_collapsed_header_and_deck
+    second_collapsed_deck_header, second_collapsed_deck = (
+        second_collapsed_header_and_deck
+    )
+
+    app = provide_app
+    user_id = 1
+    login_user_to_home_page(app, browser, user_id)
+    assert_login(browser)
+
+    collapse_deck(browser, first_collapsed_deck_header, first_collapsed_deck)
+    collapse_deck(browser, second_collapsed_deck_header, second_collapsed_deck)
+    assert_visible_css_selector(browser, f"{open_deck.value} .content")
+
+
+@pytest.mark.parametrize(
+    "first_collapsed_header_and_deck, second_collapsed_header_and_deck, third_collapsed_header_and_deck",
+    [
+        (
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+        ),
+        (
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+        ),
+        (
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+        ),
+        (
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+        ),
+        (
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+        ),
+        (
+            (HPL.HEADER_UTUB_DECK, Decks.UTUBS),
+            (HPL.HEADER_TAG_DECK, Decks.TAGS),
+            (HPL.HEADER_MEMBER_DECK, Decks.MEMBERS),
+        ),
+    ],
+)
+def test_previously_collapsed_deck_shows_after_two_collapsed(
+    browser: WebDriver,
+    create_test_tags,
+    provide_app: Flask,
+    first_collapsed_header_and_deck,
+    second_collapsed_header_and_deck,
+    third_collapsed_header_and_deck,
+):
+    """
+    Tests a user's ability to collapse three LHS decks, but makes sure U4I shows max two decks collapsed.
+
+    GIVEN a fresh load of the U4I Home page
+    WHEN user clicks all three of the deck headers
+    THEN ensure the second deck (previously selected deck) is shown
+    """
+    first_collapsed_deck_header, first_collapsed_deck = first_collapsed_header_and_deck
+    second_collapsed_deck_header, second_collapsed_deck = (
+        second_collapsed_header_and_deck
+    )
+    third_collapsed_deck_header, third_collapsed_deck = third_collapsed_header_and_deck
+
+    app = provide_app
+    user_id = 1
+    login_user_to_home_page(app, browser, user_id)
+    assert_login(browser)
+
+    collapse_deck(browser, first_collapsed_deck_header, first_collapsed_deck)
+    collapse_deck(browser, second_collapsed_deck_header, second_collapsed_deck)
+    collapse_deck(browser, third_collapsed_deck_header, third_collapsed_deck)
+    assert_visible_css_selector(browser, f"{second_collapsed_deck.value} .content")

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -31,6 +31,7 @@ class HomePageLocators(GenericPageLocator):
     )
 
     # UTub Deck
+    HEADER_UTUB_DECK = "#UTubDeckHeader"
     SUBHEADER_UTUB_DECK = "#UTubDeckSubheader"
     LIST_UTUB = "#listUTubs"
     SELECTORS_UTUB = ".UTubSelector"
@@ -53,6 +54,7 @@ class HomePageLocators(GenericPageLocator):
     UTUB_SEARCH_INPUT = "#UTubNameSearch"
 
     # Tag Deck
+    HEADER_TAG_DECK = "#TagDeckHeader"
     SUBHEADER_TAG_DECK = "#TagDeckSubheader"
     LIST_TAGS = "#listTags"
     TAG_FILTERS = ".tagFilter"
@@ -139,7 +141,7 @@ class HomePageLocators(GenericPageLocator):
     GO_TO_URL_ICON = ".goToUrlIcon"
 
     # Members Deck
-    SUBHEADER_MEMBER_DECK = "#memberDeckSubheader"
+    HEADER_MEMBER_DECK = "#MemberDeckHeader"
     BUTTON_MEMBER_CREATE = "#memberBtnCreate"
     INPUT_MEMBER_CREATE = "#memberCreate"
     BUTTON_MEMBER_CANCEL_CREATE = "#memberCancelBtnCreate"
@@ -148,7 +150,6 @@ class HomePageLocators(GenericPageLocator):
     BUTTON_MEMBER_DELETE = ".memberOtherBtnDelete"
     INPUT_MEMBER_CREATE_ERROR = INPUT_MEMBER_CREATE + INVALID_FIELD_SUFFIX
 
-    SUBHEADER_UTUB = "#MemberDeckSubheader"
     LIST_MEMBERS = "#listMembers"
     BADGES_MEMBERS = ".member"
     BADGE_OWNER = "#UTubOwner > .member"

--- a/tests/functional/login_utils.py
+++ b/tests/functional/login_utils.py
@@ -15,7 +15,7 @@ from tests.functional.selenium_utils import (
     select_url_by_title,
     select_url_by_url_string,
     select_utub_by_name,
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_then_click_element,
     wait_until_visible_css_selector,
 )
@@ -110,7 +110,7 @@ def login_user_select_utub_by_id_and_url_by_id(
     wait_then_click_element(browser, url_row_selector, time=10)
     selected_url_access_btn = f"{url_row_selector} {HPL.BUTTON_URL_ACCESS}"
     wait_until_visible_css_selector(browser, selected_url_access_btn, timeout=3)
-    wait_for_animation_to_end(browser, selected_url_access_btn)
+    wait_for_animation_to_end_check_top_lhs_corner(browser, selected_url_access_btn)
 
 
 def login_user_and_select_utub_by_name(

--- a/tests/functional/selenium_utils.py
+++ b/tests/functional/selenium_utils.py
@@ -275,10 +275,10 @@ def wait_until_in_focus(browser: WebDriver, css_selector: str, timeout=10):
     )
 
 
-def wait_for_animation_to_end(
+def wait_for_animation_to_end_check_top_lhs_corner(
     browser: WebDriver, locator: str, timeout=10, interval=0.1
 ):
-    """Wait until an element stops moving by checking its position."""
+    """Wait until an element stops moving by checking its position via the top LHS corner."""
 
     def element_stopped_moving(browser: WebDriver):
         element = browser.find_element(By.CSS_SELECTOR, locator)
@@ -289,6 +289,27 @@ def wait_for_animation_to_end(
         time.sleep(interval)  # Wait a bit before checking again
         new_position = browser.execute_script(
             "return [arguments[0].getBoundingClientRect().left, arguments[0].getBoundingClientRect().top];",
+            element,
+        )
+        return initial_position == new_position
+
+    WebDriverWait(browser, timeout).until(element_stopped_moving)
+
+
+def wait_for_animation_to_end_check_height(
+    browser: WebDriver, locator: str, timeout=10, interval=0.1
+):
+    """Wait until an element stops moving by checking its height."""
+
+    def element_stopped_moving(browser: WebDriver):
+        element = browser.find_element(By.CSS_SELECTOR, locator)
+        initial_position = browser.execute_script(
+            "return [arguments[0].getBoundingClientRect().height];",
+            element,
+        )
+        time.sleep(interval)  # Wait a bit before checking again
+        new_position = browser.execute_script(
+            "return [arguments[0].getBoundingClientRect().height];",
             element,
         )
         return initial_position == new_position

--- a/tests/functional/tags_ui/test_delete_tag_ui.py
+++ b/tests/functional/tags_ui/test_delete_tag_ui.py
@@ -25,7 +25,7 @@ from tests.functional.selenium_utils import (
     get_selected_url,
     invalidate_csrf_token_on_page,
     open_update_url_title,
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_for_element_to_be_removed,
     wait_then_click_element,
 )
@@ -91,7 +91,7 @@ def test_hide_delete_tag_button_after_hover(
     actions.move_to_element(url_title).pause(3).perform()
 
     delete_tag_btn_selector = f"{tag_badge_selector} > {HPL.BUTTON_TAG_DELETE}"
-    wait_for_animation_to_end(browser, delete_tag_btn_selector)
+    wait_for_animation_to_end_check_top_lhs_corner(browser, delete_tag_btn_selector)
     assert not browser.find_element(
         By.CSS_SELECTOR, delete_tag_btn_selector
     ).is_displayed()

--- a/tests/functional/urls_ui/assert_utils.py
+++ b/tests/functional/urls_ui/assert_utils.py
@@ -7,7 +7,7 @@ from selenium.webdriver.remote.webelement import WebElement
 
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.selenium_utils import (
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_then_get_element,
     wait_until_visible,
 )
@@ -49,7 +49,7 @@ def assert_select_url_as_non_utub_owner_and_non_url_adder(
     assert url_title.is_enabled()
 
     # Wait for element to fully get in view
-    wait_for_animation_to_end(
+    wait_for_animation_to_end_check_top_lhs_corner(
         browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_ACCESS}"
     )
 
@@ -92,7 +92,7 @@ def assert_select_url_as_utub_owner_or_url_creator(
     assert url_title.is_enabled()
 
     # Wait for element to fully get in view
-    wait_for_animation_to_end(
+    wait_for_animation_to_end_check_top_lhs_corner(
         browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_ACCESS}"
     )
 

--- a/tests/functional/urls_ui/login_utils.py
+++ b/tests/functional/urls_ui/login_utils.py
@@ -11,7 +11,7 @@ from tests.functional.login_utils import (
 )
 from tests.functional.selenium_utils import (
     get_selected_url,
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_visible_css_selector,
@@ -30,7 +30,7 @@ def login_select_utub_select_url_click_delete_get_modal_url(
         app, browser, user_id, utub_name, url_string
     )
     url_row = get_selected_url(browser)
-    wait_for_animation_to_end(
+    wait_for_animation_to_end_check_top_lhs_corner(
         browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_ACCESS}"
     )
 

--- a/tests/functional/urls_ui/test_copy_url.py
+++ b/tests/functional/urls_ui/test_copy_url.py
@@ -16,7 +16,7 @@ from tests.functional.login_utils import login_user_select_utub_by_id_and_url_by
 from tests.functional.selenium_utils import (
     ChromeRemoteWebDriver,
     set_focus_on_element,
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_for_any_element_with_text,
     wait_for_element_with_text,
     wait_then_click_element,
@@ -85,7 +85,9 @@ def test_copy_url_btn_click_fail(
     url_copy_btn = wait_then_get_element(browser, copy_btn)
     assert url_copy_btn
     ActionChains(browser).move_to_element(url_copy_btn).perform()
-    wait_for_animation_to_end(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
+    )
     assert_visible_css_selector(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
 
     tooltip_on_hvr = wait_then_get_element(
@@ -110,7 +112,9 @@ def test_copy_url_btn_click_fail(
     assert tooltip_on_click
     assert tooltip_on_click.text == STRINGS.COPIED_URL_FAILURE_TOOLIP
 
-    wait_for_animation_to_end(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
+    )
     assert_not_visible_css_selector(
         browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
     )
@@ -151,7 +155,9 @@ def test_copy_url_btn_click(
     url_copy_btn = wait_then_get_element(browser, copy_btn)
     assert url_copy_btn
     ActionChains(browser).move_to_element(url_copy_btn).perform()
-    wait_for_animation_to_end(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
+    )
     assert_visible_css_selector(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
 
     tooltip_on_hvr = wait_then_get_element(
@@ -178,7 +184,9 @@ def test_copy_url_btn_click(
 
     assert clipboard_mock.get_clipboard_content() == url_string
 
-    wait_for_animation_to_end(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
+    )
     assert_not_visible_css_selector(
         browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
     )
@@ -220,7 +228,9 @@ def test_copy_url_btn_key(
     assert url_copy_btn
     set_focus_on_element(browser, url_copy_btn)
 
-    wait_for_animation_to_end(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
+    )
     assert_visible_css_selector(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
 
     tooltip_on_hvr = wait_then_get_element(
@@ -249,7 +259,9 @@ def test_copy_url_btn_key(
 
     assert clipboard_mock.get_clipboard_content() == url_string
 
-    wait_for_animation_to_end(browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}")
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
+    )
     assert_not_visible_css_selector(
         browser, f"{HPL.BUTTON_URL_COPY}{HPL.TOOLTIP_SUFFIX}"
     )

--- a/tests/functional/urls_ui/test_select_url_ui.py
+++ b/tests/functional/urls_ui/test_select_url_ui.py
@@ -17,7 +17,7 @@ from tests.functional.selenium_utils import (
     get_all_url_ids_in_selected_utub,
     get_selected_url,
     get_selected_utub_id,
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_for_web_element_and_click,
     wait_then_get_elements,
     wait_until_visible_css_selector,
@@ -189,7 +189,7 @@ def test_select_urls_using_down_key(
     first_url_string = (
         url_rows[0].find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).text
     )
-    wait_for_animation_to_end(
+    wait_for_animation_to_end_check_top_lhs_corner(
         browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_ACCESS}"
     )
     selected_url = get_selected_url(browser)
@@ -243,7 +243,7 @@ def test_select_urls_using_up_key(
     first_url_string = (
         url_rows[0].find_element(By.CSS_SELECTOR, HPL.URL_STRING_READ).text
     )
-    wait_for_animation_to_end(
+    wait_for_animation_to_end_check_top_lhs_corner(
         browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_ACCESS}"
     )
     selected_url = get_selected_url(browser)

--- a/tests/functional/utubs_ui/selenium_utils.py
+++ b/tests/functional/utubs_ui/selenium_utils.py
@@ -6,7 +6,7 @@ from tests.functional.assert_utils import assert_visible_css_selector
 from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.selenium_utils import (
     clear_then_send_keys,
-    wait_for_animation_to_end,
+    wait_for_animation_to_end_check_top_lhs_corner,
     wait_then_click_element,
     wait_then_get_element,
     wait_until_hidden,
@@ -168,7 +168,9 @@ def open_utub_search_box(browser: WebDriver):
 
     wait_then_click_element(browser, HPL.UTUB_OPEN_SEARCH_ICON, time=3)
     browser.get_screenshot_as_file("p1.png")
-    wait_for_animation_to_end(browser, HPL.UTUB_SEARCH_INPUT, timeout=3)
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, HPL.UTUB_SEARCH_INPUT, timeout=3
+    )
     wait_until_in_focus(browser, HPL.UTUB_SEARCH_INPUT)
 
     assert_visible_css_selector(browser, HPL.UTUB_CLOSE_SEARCH_ICON, time=3)


### PR DESCRIPTION
Allows users to collapse the UTub, Member, or Tags panel, which gracefully expands the open panels to fill the rest of the space.

The maximum number of panels that can be collapsed is 2.

If the user tries to collapse a third panel, the previously collapsed panel will open in its place.

Collapsing does not work on mobile or on tablet UI.

Closes #443 