### PR TITLE
[frontend] Add visible tag counter to utub tags with tests

### DIFF
--- a/src/static/scripts/components/urls_deck/url_cards/delete_url_card.js
+++ b/src/static/scripts/components/urls_deck/url_cards/delete_url_card.js
@@ -59,7 +59,7 @@ async function deleteURL(utubUrlID, urlCard) {
     // Handle response
     request.done(function (response, textStatus, xhr) {
       if (xhr.status === 200) {
-        deleteURLSuccessOnDelete(response, urlCard);
+        deleteURLSuccess(response, urlCard);
       }
     });
 
@@ -73,9 +73,28 @@ async function deleteURL(utubUrlID, urlCard) {
 }
 
 // Displays changes related to a successful removal of a URL
-function deleteURLSuccessOnDelete(response, urlCard) {
+function deleteURLSuccess(response, urlCard) {
   // Close modal
   $("#confirmModal").modal("hide");
+  const currentURLTagIDs = urlCard.attr("data-utub-url-tag-ids") || "";
+  if (currentURLTagIDs.trim()) {
+    let tagIDs = currentURLTagIDs.split(",").map((s) => s.trim());
+    let tagCountElem, tagID, tagCountText;
+    for (let i = 0; i < tagIDs.length; i++) {
+      tagID = tagIDs[i];
+      tagCountElem = $(
+        `.tagFilter[data-utub-tag-id=${tagID}]` + " .tagAppliedToUrlsCount",
+      );
+      tagCountText = tagCountElem.text().split(" / ");
+      if (!tagCountText || tagCountText.length !== 2) continue;
+      tagCountElem.text(
+        `${parseInt(tagCountText[0]) - 1}` +
+          " / " +
+          `${parseInt(tagCountText[1]) - 1}`,
+      );
+    }
+  }
+
   urlCard.fadeOut("slow", function () {
     urlCard.remove();
     if ($("#listURLs .urlRow").length === 0) {

--- a/src/static/scripts/components/urls_deck/url_cards/get_url.js
+++ b/src/static/scripts/components/urls_deck/url_cards/get_url.js
@@ -61,23 +61,24 @@ function updateURLTagsAndUTubTagsBasedOnGetURLData(
 
   // Based on IDs, find if tag still exists in UTub - if not, remove from tag deck
   for (let i = 0; i < removedTagIDs.length; i++) {
-    if (!isTagInUTubTagDeck(receivedTag.utubTagID)) {
+    if (!isTagInUTubTagDeck(tag.utubTagID)) {
       removeTagFromTagDeckGivenTagID(removedTagIDs[i]);
     }
   }
 
   // Add tags that are in received tags but not in current tags
-  let exists, receivedTag;
+  let exists, receivedTag, currentTag;
   for (let i = 0; i < receivedTags.length; i++) {
     exists = false;
     receivedTag = receivedTags[i];
-    currentTags.each(function () {
-      if (
-        parseInt($(this).attr("data-utub-tag-id")) === receivedTag.utubTagID
-      ) {
-        exists = true;
-      }
-    });
+
+    for (let j = 0; j < currentTags.length; j++) {
+      currentTag = currentTags[j];
+      exists =
+        parseInt($(currentTag).attr("data-utub-tag-id")) ===
+        receivedTag.utubTagID;
+      if (exists) break;
+    }
 
     if (!exists) {
       // Add tag to URL

--- a/src/static/scripts/components/urls_deck/url_cards/url_cards.js
+++ b/src/static/scripts/components/urls_deck/url_cards/url_cards.js
@@ -65,6 +65,7 @@ function createURLBlock(url, tagArray) {
     utubUrlID: url.utubUrlID,
     urlSelected: false,
     filterable: true,
+    "data-utub-url-tag-ids": url.utubUrlTagIDs.join(","),
   });
 
   // Append update URL form if user can edit the URL

--- a/src/static/scripts/components/urls_deck/url_cards/url_cards_filtering.js
+++ b/src/static/scripts/components/urls_deck/url_cards/url_cards_filtering.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const TagCountOperation = Object.freeze({
+  INCREMENT: 1,
+  DECREMENT: -1,
+});
+
 function updateURLsAndTagSubheaderWhenTagSelected() {
   const selectedTagIDs = $.map($(".tagFilter.selected"), (tagFilter) =>
     parseInt($(tagFilter).attr("data-utub-tag-id")),
@@ -26,6 +31,69 @@ function updateURLsAndTagSubheaderWhenTagSelected() {
   });
   reapplyAlternatingURLCardBackgroundAfterFilter();
   updateCountOfTagFiltersApplied(numSelectedTagIDs);
+  updateVisibleURLsForTagCount();
+  sortTagFiltersInPlace();
+}
+
+function updateVisibleURLsForTagCount() {
+  const currentTagIDs = currentTagDeckIDs();
+  const currentTagIDsMap = new Map();
+  currentTagIDs.forEach((tagID) => {
+    currentTagIDsMap.set(`${tagID}`, 0);
+  });
+
+  const visibleURLCards = $(".urlRow[filterable=true]");
+
+  let urlTagIDsRaw, urlTagIDs, visibleURL, urlTag;
+  for (let i = 0; i < visibleURLCards.length; i++) {
+    visibleURL = $(visibleURLCards[i]);
+    urlTagIDsRaw = visibleURL.attr("data-utub-url-tag-ids");
+    if (!urlTagIDsRaw) continue;
+    urlTagIDs = urlTagIDsRaw.split(",");
+
+    urlTagIDs.forEach((tagID) => {
+      currentTagIDsMap.set(tagID, (currentTagIDsMap.get(tagID) || 0) + 1);
+    });
+  }
+
+  let tagCountElem, tagCountText, tagID;
+  for (let j = 0; j < currentTagIDs.length; j++) {
+    tagID = currentTagIDs[j];
+    tagCountElem = $(
+      `.tagFilter[data-utub-tag-id=${tagID}]` + " .tagAppliedToUrlsCount",
+    );
+    tagCountText = tagCountElem.text().split(" / ");
+    if (!tagCountText || tagCountText.length !== 2) continue;
+
+    tagCountElem.text(
+      `${currentTagIDsMap.get(`${tagID}`)}` + " / " + `${tagCountText[1]}`,
+    );
+  }
+}
+
+function updateTagFilterCount(utubTagID, tagCount, tagCountOperation) {
+  const tagCountElem = $(
+    `.tagFilter[data-utub-tag-id="${utubTagID}"]` + " .tagAppliedToUrlsCount",
+  );
+
+  const tagCountText = tagCountElem.text().split(" / ");
+  if (!tagCountText || tagCountText.length !== 2) {
+    tagCountElem.text(`${tagCount}` + " / " + `${tagCount}`);
+    return;
+  }
+
+  let delta;
+  switch (tagCountOperation) {
+    case TagCountOperation.DECREMENT:
+      delta = -1;
+      break;
+    default:
+      delta = 1;
+  }
+
+  tagCountElem.text(
+    `${parseInt(tagCountText[0]) + delta}` + " / " + `${tagCount}`,
+  );
 }
 
 function reapplyAlternatingURLCardBackgroundAfterFilter() {
@@ -36,6 +104,27 @@ function reapplyAlternatingURLCardBackgroundAfterFilter() {
       .removeClass("odd even")
       .addClass(idx % 2 == 0 ? "even" : "odd");
   });
+}
+
+function sortTagFiltersInPlace() {
+  const container = $("#listTags");
+  const tagFilters = container.children(".tagFilter").get();
+
+  tagFilters.sort((a, b) => {
+    const textA = $(a).find(".tagAppliedToUrlsCount").text().trim();
+    const textB = $(b).find(".tagAppliedToUrlsCount").text().trim();
+
+    const numeratorA = parseInt(textA.split(" / ")[0]) || 0;
+    const numeratorB = parseInt(textB.split(" / ")[0]) || 0;
+
+    return numeratorB - numeratorA;
+  });
+
+  const detachedElements = tagFilters.map((el) => $(el).detach());
+
+  for (let i = 0; i < detachedElements.length; i++) {
+    container.append(detachedElements[i]);
+  }
 }
 
 function isURLCurrentlyVisibleInURLDeck(urlString) {

--- a/src/static/scripts/components/urls_deck/url_tags/create_url_tag.js
+++ b/src/static/scripts/components/urls_deck/url_tags/create_url_tag.js
@@ -222,13 +222,16 @@ function createURLTagSuccess(response, urlCard) {
   const string = response.utubTag.tagString;
   const tagCount = response.tagCountsInUtub;
 
-  // Update tag filter in Tag Deck
-  updateTagFilterCount(utubTagID, tagCount);
-
   // Update tags in URL
   urlCard
     .find(".urlTagsContainer")
     .append(createTagBadgeInURL(utubTagID, string, urlCard));
+
+  const currentURLTagIDs = urlCard.attr("data-utub-url-tag-ids") || "";
+
+  currentURLTagIDs.trim()
+    ? urlCard.attr("data-utub-url-tag-ids", currentURLTagIDs + `,${utubTagID}`)
+    : urlCard.attr("data-utub-url-tag-ids", utubTagID);
 
   // Add SelectAll button if not yet there
   $("#unselectAllTagFilters").showClassNormal();
@@ -236,10 +239,13 @@ function createURLTagSuccess(response, urlCard) {
   if (!isTagInUTubTagDeck(utubTagID)) {
     const newTag = buildTagFilterInDeck(utubTagID, string, tagCount);
     // If max number of tags already selected
-    $(".tagFilter.selected") === CONSTANTS.TAGS_MAX_ON_URL
+    $(".tagFilter.selected").length === CONSTANTS.TAGS_MAX_ON_URL
       ? newTag.addClass("disabled").off(".tagFilterSelected")
       : null;
     $("#listTags").append(newTag);
+  } else {
+    // Update tag filter in Tag Deck
+    updateTagFilterCount(utubTagID, tagCount, TagCountOperation.INCREMENT);
   }
 }
 

--- a/src/static/scripts/components/urls_deck/url_tags/delete_url_tag.js
+++ b/src/static/scripts/components/urls_deck/url_tags/delete_url_tag.js
@@ -30,7 +30,7 @@ async function deleteURLTag(utubTagID, tagBadge, urlCard) {
     // Handle response
     request.done(function (response, _, xhr) {
       if (xhr.status === 200) {
-        deleteURLTagSuccess(response, tagBadge);
+        deleteURLTagSuccess(response, tagBadge, urlCard);
       }
     });
 
@@ -51,11 +51,26 @@ async function deleteURLTag(utubTagID, tagBadge, urlCard) {
 }
 
 // Displays changes related to a successful removal of a URL
-function deleteURLTagSuccess(response, tagBadge) {
-  // Update tag filter in Tag Deck
-  // If the removed tag is the last instance in the UTub, remove it from the Tag Deck. Else, reapply counter from response.
-  const tagID = tagBadge.attr("data-utub-tag-id");
-  updateTagFilterCount(tagID, response.tagCountsInUtub);
+function deleteURLTagSuccess(response, tagBadge, urlCard) {
+  const tagID = response.utubTag.utubTagID;
+
+  updateTagFilterCount(
+    tagID,
+    response.tagCountsInUtub,
+    TagCountOperation.DECREMENT,
+  );
+
+  const currentURLTagIDs = urlCard.attr("data-utub-url-tag-ids") || "";
+
+  if (currentURLTagIDs.trim()) {
+    let tagIDs = currentURLTagIDs.split(",").map((s) => s.trim());
+    const index = tagIDs.findIndex((num) => parseInt(num) === tagID);
+
+    if (index !== -1) {
+      tagIDs.splice(index, 1);
+    }
+    urlCard.attr("data-utub-url-tag-ids", tagIDs.join(","));
+  }
 
   // Remove the tag badge from the URL card
   tagBadge.remove();

--- a/src/static/scripts/components/utub_tags_deck/utub_tags.js
+++ b/src/static/scripts/components/utub_tags_deck/utub_tags.js
@@ -18,8 +18,9 @@ function buildTagFilterInDeck(tagID, string, urlCount = 0) {
       toggleTagFilterSelected(container);
     })
     .on("focus.tagFilterSelected", function () {
-      $(document).on("keyup.tagFilterSelected", function (e) {
-        if (e.which === 13) toggleTagFilterSelected(container);
+      $(document).offAndOn("keyup.tagFilterSelected", function (e) {
+        if (e.which === 13 && $(e.target).hasClass("tagFilter"))
+          toggleTagFilterSelected(container);
       });
     })
     .on("blur.tagFilterSelected", function () {
@@ -28,10 +29,12 @@ function buildTagFilterInDeck(tagID, string, urlCount = 0) {
 
   tagStringSpan.text(string);
 
-  // TODO: addClass("tagCountHoverable") only if utubUserID == utubOwnerID
-  rightContainer.addClass("tagCountHoverable");
+  // TODO: addClass("tagCountWrap") only if utubUserID == utubOwnerID
+  rightContainer.addClass("tagCountWrap");
 
-  urlCountSpan.addClass("tagAppliedToUrlsCount").text(urlCount);
+  urlCountSpan
+    .addClass("tagAppliedToUrlsCount")
+    .text(`${urlCount}` + " / " + `${urlCount}`);
 
   deleteTagButton
     .addClass("utubTagBtnDelete align-center pointerable tabbable")
@@ -40,7 +43,7 @@ function buildTagFilterInDeck(tagID, string, urlCount = 0) {
       deleteUtubTag(utubTagID, tagSpan, urlCard);
     })
     .offAndOn("focus.removeUtubTag", function () {
-      $(document).on("keyup.removeUtubTag", function (e) {
+      $(document).offAndOn("keyup.removeUtubTag", function (e) {
         if (e.which === 13) deleteUtubTag(utubTagID, tagSpan, urlCard);
       });
     })
@@ -163,18 +166,5 @@ function updateTagFilteringOnURLOrURLTagDeletion() {
     default:
       // Reapply filters based on tag removed
       updateURLsAndTagSubheaderWhenTagSelected();
-  }
-}
-
-function updateTagFilterCount(tagID, count) {
-  const tagFilter = $(`.tagFilter[data-utub-tag-id="${tagID}"]`);
-  const urlCountSpan = tagFilter.find(".tagAppliedToUrlsCount");
-
-  if (count === 0) {
-    // Remove the tag filter if no URLs are associated with it
-    tagFilter.remove();
-  } else {
-    // Update the count of URLs associated with the tag
-    urlCountSpan.text(count);
   }
 }

--- a/src/static/styles/app.css
+++ b/src/static/styles/app.css
@@ -49,6 +49,8 @@
     --tagBackgroundColorHover: rgba(126, 130, 130, 0.5);
     --tagBackgroundColorSelected: rgba(126, 130, 130, 1.0);
     --tagSelectedTextColor: rgba(14, 66, 27, 1.0);
+    --tagCountBackgroundSelectedColor: rgba(14, 186, 130, 1.0);
+    --tagCountBorderColor: rgba(72, 85, 86, 1.0);
 
     --tagBadgeDeleteBtnColor: rgba(136, 136, 136, 0.85);
     --tagBadgeDeleteBtnColorHover: var(--removeMemberColor);

--- a/src/static/styles/home.css
+++ b/src/static/styles/home.css
@@ -549,54 +549,35 @@
     border-radius: 25px;
 }
 
-.tagFilter>.tagCountHoverable>.tagAppliedToUrlsCount {
+.tagFilter>.tagCountWrap>.tagAppliedToUrlsCount {
     color: black;
-    background-color: var(--deckSelectionGreen);
+    background-color: var(--tagCountBackgroundSelectedColor);
 }
 
-.tagFilter.unselected>.tagCountHoverable>.tagAppliedToUrlsCount {
+.tagFilter.unselected>.tagCountWrap>.tagAppliedToUrlsCount {
     color: var(--darkSplashGreen);
     background: var(--cardBackgroundColor);
 }
 
-.tagCountHoverable {
+.tagCountWrap {
   position: relative;
   display: flex;
   align-items: center;
-  /* gap: 0.25em; */
 }
 
-/* .tagCountHoverable:hover .tagAppliedToUrlsCount {
-  width: 0;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.tagCountHoverable:hover .utubTagBtnDelete {
-  width: 2em;
-  aspect-ratio: 1;
-  opacity: 1;
-  pointer-events: auto;
-} */
 
 .tagAppliedToUrlsCount {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 2em;
-  aspect-ratio: 1;
+  width: 5rem;
   font-size: 1rem;
-  border: 1px solid var(--borderColor);
-  border-radius: 50%;
+  border: 1px solid var(--tagCountBorderColor);
+  border-radius: 5rem;
+  white-space: nowrap;
+  transition: background-color 0.2s ease-in-out; 
 }
 
-/* .utubTagBtnDelete {
-    width: 0;
-    opacity: 0;
-    padding: 0;
-    color: var(--tagBadgeDeleteBtnColor);
-    transition: width 0.1s ease-in, opacity 0.1s ease-in, color 0.1s ease-in, padding 0.1s ease-in;
-} */
 .utubTagBtnDelete {
   display: flex;
   justify-content: center;

--- a/src/utubs/forms.py
+++ b/src/utubs/forms.py
@@ -14,7 +14,7 @@ class UTubForm(FlaskForm):
     Form to create a UTub. Inherits from FlaskForm. All fields require data.
 
     Fields:
-        name (Stringfield): Maximum 30 chars? TODO
+        name (Stringfield): Maximum 30 chars?
     """
 
     name = StringFieldV2(

--- a/tests/functional/db_utils.py
+++ b/tests/functional/db_utils.py
@@ -132,6 +132,15 @@ def get_tag_on_url_in_utub(app: Flask, utub_id: int, utub_url_id: int) -> Utub_U
         ).first()
 
 
+def get_tag_in_utub_by_tag_string(
+    app: Flask, utub_id: int, tag_string: str
+) -> Utub_Tags:
+    with app.app_context():
+        return Utub_Tags.query.filter(
+            Utub_Tags.utub_id == utub_id, Utub_Tags.tag_string == tag_string
+        ).first()
+
+
 def add_tag_to_utub_user_created(
     app: Flask, utub_id: int, user_id: int, tag_string: str
 ) -> Utub_Tags:

--- a/tests/functional/locators.py
+++ b/tests/functional/locators.py
@@ -88,8 +88,8 @@ class HomePageLocators(GenericPageLocator):
 
     LIST_URL = "#listURLs"
     ROWS_URLS = ".urlRow"
-    ROW_SELECTED_URL = ".urlRow[urlselected='true']"
-    ROW_VISIBLE_URL = ".urlRow[filterable='true']"
+    ROW_SELECTED_URL = f"{ROWS_URLS}[urlselected='true']"
+    ROW_VISIBLE_URL = f"{ROWS_URLS}[filterable='true']"
 
     BUTTON_CORNER_URL_CREATE = "#urlBtnCreate"
     BUTTON_DECK_URL_CREATE = "#urlBtnDeckCreate"

--- a/tests/functional/selenium_utils.py
+++ b/tests/functional/selenium_utils.py
@@ -925,3 +925,7 @@ def set_focus_on_element(driver: WebDriver, element: WebElement):
     from tests.functional.assert_utils import assert_element_in_focus
 
     assert_element_in_focus(driver, element)
+
+
+def get_css_selector_for_url_by_id(url_id: int) -> str:
+    return f"{HPL.ROWS_URLS}[utuburlid='{url_id}']"

--- a/tests/functional/tags_ui/selenium_utils.py
+++ b/tests/functional/tags_ui/selenium_utils.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -7,6 +8,7 @@ from tests.functional.locators import HomePageLocators as HPL
 from tests.functional.selenium_utils import (
     clear_then_send_keys,
     wait_then_click_element,
+    wait_then_get_element,
     wait_until_in_focus,
     wait_until_visible_css_selector,
 )
@@ -81,15 +83,16 @@ def apply_tag_filter_by_id_and_get_shown_urls(
     return [url_row for url_row in url_row_elements if url_row.is_displayed()]
 
 
-def get_urls_count_with_tag_applied_from_tag_filter_by_tag_id(
+def get_visible_urls_and_urls_with_tag_text_by_tag_id(
     browser: WebDriver, tag_id: int
-) -> int:
+) -> Tuple[int, int]:
     """
-    Extracts the count of URLs that have a specific tag applied from the Tag Deck assocaited tag filter based on the tag ID.
+    Extracts the visible URLs and total count of URLs that have a specific tag from the Tag Deck associated with the tag filter based on the tag ID.
     """
-    tag_filter = browser.find_element(
-        By.CSS_SELECTOR, get_utub_tag_filter_selector(tag_id)
+    utub_tag_selector = (
+        f'{HPL.TAG_FILTERS}[data-utub-tag-id="{tag_id}"] {HPL.TAG_COUNT}'
     )
-    tag_filter_count_elem = tag_filter.find_element(By.CSS_SELECTOR, f"{HPL.TAG_COUNT}")
-    tag_filter_count = int(tag_filter_count_elem.text)
-    return tag_filter_count if tag_filter_count else 0
+    tag_filter_count_elem = wait_then_get_element(browser, utub_tag_selector)
+    assert tag_filter_count_elem
+    visible, total = tag_filter_count_elem.text.split(" / ")
+    return int(visible), int(total)

--- a/tests/functional/tags_ui/test_create_utub_tag_ui.py
+++ b/tests/functional/tags_ui/test_create_utub_tag_ui.py
@@ -15,6 +15,7 @@ from tests.functional.assert_utils import (
 )
 from tests.functional.db_utils import (
     count_urls_with_tag_applied_by_tag_string,
+    get_tag_in_utub_by_tag_string,
     get_utub_this_user_created,
 )
 from tests.functional.locators import HomePageLocators as HPL
@@ -34,6 +35,9 @@ from tests.functional.selenium_utils import (
     wait_until_hidden,
     wait_until_in_focus,
     wait_until_visible_css_selector,
+)
+from tests.functional.tags_ui.selenium_utils import (
+    get_visible_urls_and_urls_with_tag_text_by_tag_id,
 )
 
 pytestmark = pytest.mark.tags_ui
@@ -227,9 +231,16 @@ def test_open_input_create_utub_tag_click_submit_btn(
     assert_new_utub_tag_created(browser, new_tag, init_num_of_utub_tags)
 
     # Assert Tag Deck counter initialized at 0
-    assert init_tag_count_in_utub == count_urls_with_tag_applied_by_tag_string(
-        app, utub.id, new_tag
+    utub_tag = get_tag_in_utub_by_tag_string(app, utub_user_created.id, new_tag)
+    utub_tag_selector = f'{HPL.TAG_FILTERS}[data-utub-tag-id="{utub_tag.id}"]'
+    utub_tag_elem = wait_then_get_element(browser, utub_tag_selector)
+    assert utub_tag_elem
+
+    visible_urls, total_urls = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, utub_tag.id
     )
+    assert visible_urls == 0
+    assert total_urls == init_tag_count_in_utub
 
 
 def test_open_input_create_utub_tag_press_enter_key(
@@ -269,9 +280,16 @@ def test_open_input_create_utub_tag_press_enter_key(
     assert_new_utub_tag_created(browser, new_tag, init_num_of_utub_tags)
 
     # Assert Tag Deck counter initialized at 0
-    assert init_tag_count_in_utub == count_urls_with_tag_applied_by_tag_string(
-        app, utub.id, new_tag
+    utub_tag = get_tag_in_utub_by_tag_string(app, utub_user_created.id, new_tag)
+    utub_tag_selector = f'{HPL.TAG_FILTERS}[data-utub-tag-id="{utub_tag.id}"]'
+    utub_tag_elem = wait_then_get_element(browser, utub_tag_selector)
+    assert utub_tag_elem
+
+    visible_urls, total_urls = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, utub_tag.id
     )
+    assert visible_urls == 0
+    assert total_urls == init_tag_count_in_utub
 
 
 # Sad Path Tests

--- a/tests/functional/tags_ui/test_delete_tag_ui.py
+++ b/tests/functional/tags_ui/test_delete_tag_ui.py
@@ -11,7 +11,6 @@ from tests.functional.assert_utils import (
     assert_visited_403_on_invalid_csrf_and_reload,
 )
 from tests.functional.db_utils import (
-    count_urls_with_tag_applied_by_tag_id,
     get_utub_this_user_created,
     get_url_in_utub,
     get_tag_on_url_in_utub,
@@ -20,6 +19,7 @@ from tests.functional.login_utils import login_user_select_utub_by_id_and_url_by
 from tests.functional.tags_ui.selenium_utils import (
     get_tag_badge_selector_on_selected_url_by_tag_id,
     get_delete_tag_button_on_hover,
+    get_visible_urls_and_urls_with_tag_text_by_tag_id,
 )
 from tests.functional.selenium_utils import (
     get_selected_url,
@@ -115,11 +115,12 @@ def test_delete_tag(browser: WebDriver, create_test_tags, provide_app: Flask):
     url_tag = get_tag_on_url_in_utub(app, utub_id, url_id)
     tag_id = url_tag.utub_tag_id
 
-    with app.app_context():
-        init_tag_count_in_utub: int = count_urls_with_tag_applied_by_tag_id(app, tag_id)
-
     login_user_select_utub_by_id_and_url_by_id(
         app, browser, user_id_for_test, utub_id, url_id
+    )
+
+    init_vis, init_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
     )
 
     tag_badge_selector = get_tag_badge_selector_on_selected_url_by_tag_id(url_id)
@@ -136,14 +137,13 @@ def test_delete_tag(browser: WebDriver, create_test_tags, provide_app: Flask):
         browser.find_element(By.CSS_SELECTOR, tag_badge_selector)
 
     # Assert URL count in Tag Deck is decremented
-    with app.app_context():
-        updated_tag_count_in_utub: int = count_urls_with_tag_applied_by_tag_id(
-            app, tag_id
-        )
-        assert updated_tag_count_in_utub == init_tag_count_in_utub - 1
+    final_vis, final_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
+    )
+    assert final_vis == init_vis - 1
+    assert final_total == init_total - 1
 
 
-# Sad Path Tests
 def test_no_get_delete_tag_button_on_hover_update_url_title(
     browser: WebDriver, create_test_tags, provide_app: Flask
 ):

--- a/tests/functional/tags_ui/test_filter_tag_ui.py
+++ b/tests/functional/tags_ui/test_filter_tag_ui.py
@@ -18,13 +18,27 @@ from tests.functional.db_utils import (
     get_utub_this_user_created,
 )
 from tests.functional.locators import HomePageLocators as HPL
-from tests.functional.login_utils import login_user_and_select_utub_by_utubid
+from tests.functional.locators import ModalLocators as ML
+from tests.functional.login_utils import (
+    login_user_and_select_utub_by_utubid,
+    login_user_select_utub_by_id_and_url_by_id,
+)
 from tests.functional.tags_ui.selenium_utils import (
+    add_tag_to_url,
     apply_tag_filter_by_id_and_get_shown_urls,
+    get_delete_tag_button_on_hover,
+    get_tag_badge_selector_on_selected_url_by_tag_id,
     get_utub_tag_filter_selector,
+    get_visible_urls_and_urls_with_tag_text_by_tag_id,
 )
 from tests.functional.selenium_utils import (
+    get_css_selector_for_url_by_id,
+    wait_for_animation_to_end_check_top_lhs_corner,
+    wait_for_element_to_be_removed,
     wait_then_click_element,
+    wait_then_get_element,
+    wait_then_get_elements,
+    wait_until_hidden,
     wait_until_visible_css_selector,
 )
 
@@ -142,10 +156,10 @@ def test_filter_multiple_tags_with_some_urls_filtered(
     browser: WebDriver, create_test_urls, provide_app: Flask
 ):
     """
-    Tests a user's ability to filter a specific tag in the URL deck by selecting a tag filter.
+    Tests a user's ability to filter URLs by selecting tag filters.
 
     GIVEN a user has access to UTubs with URLs with tags on some URLs
-    WHEN the user selects a tag from the tag deck applied to some, and then another tag applied to some
+    WHEN the user selects a tag from the tag deck applied to some URLs, and then another tag applied to some URLs
     THEN ensure some URLs are hidden
     """
     app = provide_app
@@ -248,35 +262,35 @@ def test_unselect_button_unselects_all_tags_when_clicked(
         browser, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}", timeout=3
     )
 
-    assert len(
-        browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}")
-    ) == len(utub_tag_ids)
-
     for utub_tag_id in utub_tag_ids:
         utub_tag_filter = get_utub_tag_filter_selector(utub_tag_id)
         wait_then_click_element(browser, utub_tag_filter, time=3)
 
-    assert (
-        len(
-            browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}")
-        )
-        == 0
+    unselected_tags = wait_then_get_elements(
+        browser, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}", time=3
     )
-    assert len(
-        browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.SELECTED}")
-    ) == len(utub_tag_ids)
+    assert len(unselected_tags) == 0
 
-    unselect_filters_btn = browser.find_element(
-        By.CSS_SELECTOR, HPL.BUTTON_UNSELECT_ALL
+    selected_tags = wait_then_get_elements(
+        browser, f"{HPL.TAG_FILTERS}{HPL.SELECTED}", time=3
     )
-    unselect_filters_btn.click()
+    assert len(selected_tags) == len(utub_tag_ids)
+
+    wait_then_click_element(browser, HPL.BUTTON_UNSELECT_ALL, time=3)
+
+    selected_tags = wait_then_get_elements(
+        browser, f"{HPL.TAG_FILTERS}{HPL.SELECTED}", time=3
+    )
+    assert len(selected_tags) == 0
+
     assert (
         len(browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.SELECTED}"))
         == 0
     )
-    assert len(
-        browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}")
-    ) == len(utub_tag_ids)
+    unselected_tags = wait_then_get_elements(
+        browser, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}", time=3
+    )
+    assert len(unselected_tags) == len(utub_tag_ids)
 
 
 def test_unfilter_tag_with_all_urls_filtered(
@@ -367,7 +381,6 @@ def test_unfilter_multiple_tags_with_some_urls_filtered(
     )
 
 
-# Sad Path Tests
 def test_filter_tag_attempt_with_tag_limit_reached(
     browser: WebDriver, create_test_tags, provide_app: Flask
 ):
@@ -474,4 +487,201 @@ def test_filter_tag_clickable_after_unclicking_from_tag_limit(
     utub_tag_badge.click()
 
 
-# TODO: Test URL hidden when all tags selected, all tags on URL, and one of tags on URL is deleted
+def test_filtered_url_hides_when_filter_tag_deleted(
+    browser: WebDriver, create_test_urls, provide_app: Flask
+):
+    """
+    Tests U4I's decrementing of tag counts when deleting URL tag while a tag filter is applied.
+
+    GIVEN a user has access to UTubs with URLs with tags on some URLs and the URLs are filtered
+    WHEN the user deletes a URL tag that is shown while filtering
+    THEN ensure the tag counter decrements and the URL hides
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    tag_in_utub = add_tag_to_utub_user_created(
+        app, utub_user_created.id, user_id_for_test, UTS.TEST_TAG_NAME_1
+    )
+    tag_id = tag_in_utub.id
+
+    with app.app_context():
+        utub_urls: list[Utub_Urls] = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_created.id
+        ).all()
+        urls_tag_applied_to = len(utub_urls) - 2
+        for idx in range(urls_tag_applied_to):
+            utub_url = utub_urls[idx]
+            new_url_tag = Utub_Url_Tags(
+                utub_id=utub_user_created.id,
+                utub_url_id=utub_url.id,
+                utub_tag_id=tag_id,
+            )
+            db.session.add(new_url_tag)
+        db.session.commit()
+        url_id_to_hide = utub_urls[0].id
+
+    login_user_select_utub_by_id_and_url_by_id(
+        app, browser, user_id_for_test, utub_user_created.id, utub_url_id=url_id_to_hide
+    )
+    displayed_urls = apply_tag_filter_by_id_and_get_shown_urls(browser, tag_id)
+    assert len(displayed_urls) == urls_tag_applied_to
+
+    selected_url_selector = get_css_selector_for_url_by_id(url_id_to_hide)
+    init_vis, init_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
+    )
+
+    tag_badge_selector = get_tag_badge_selector_on_selected_url_by_tag_id(tag_id)
+    delete_tag_button = get_delete_tag_button_on_hover(browser, tag_badge_selector)
+    delete_tag_button.click()
+
+    # Wait for DELETE request
+    wait_until_hidden(browser, selected_url_selector, timeout=3)
+    final_vis, final_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
+    )
+    assert final_vis == init_vis - 1
+    assert final_total == init_total - 1
+
+
+def test_filtered_url_count_decrements_when_url_deleted(
+    browser: WebDriver, create_test_urls, provide_app: Flask
+):
+    """
+    Tests U4I's decrementing of tag counts when deleting URL while a tag filter is applied.
+
+    GIVEN a user has access to UTubs with URLs with tags on some URLs and the URLs are filtered
+    WHEN the user deletes a URL that is shown while filtering
+    THEN ensure the tag counter decrements
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    tag_in_utub = add_tag_to_utub_user_created(
+        app, utub_user_created.id, user_id_for_test, UTS.TEST_TAG_NAME_1
+    )
+    tag_id = tag_in_utub.id
+
+    with app.app_context():
+        utub_urls: list[Utub_Urls] = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_created.id
+        ).all()
+        urls_tag_applied_to = len(utub_urls) - 2
+        for idx in range(urls_tag_applied_to):
+            utub_url = utub_urls[idx]
+            new_url_tag = Utub_Url_Tags(
+                utub_id=utub_user_created.id,
+                utub_url_id=utub_url.id,
+                utub_tag_id=tag_id,
+            )
+            db.session.add(new_url_tag)
+        db.session.commit()
+        url_id_to_hide = utub_urls[0].id
+
+    login_user_select_utub_by_id_and_url_by_id(
+        app, browser, user_id_for_test, utub_user_created.id, utub_url_id=url_id_to_hide
+    )
+    displayed_urls = apply_tag_filter_by_id_and_get_shown_urls(browser, tag_id)
+    assert len(displayed_urls) == urls_tag_applied_to
+
+    selected_url_selector = get_css_selector_for_url_by_id(url_id_to_hide)
+    init_vis, init_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
+    )
+
+    wait_for_animation_to_end_check_top_lhs_corner(
+        browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_ACCESS}"
+    )
+    wait_then_click_element(
+        browser, f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_URL_DELETE}", time=3
+    )
+    wait_until_visible_css_selector(browser, ML.ELEMENT_MODAL, timeout=3)
+    modal = wait_then_get_element(browser, HPL.BODY_MODAL)
+    assert modal is not None
+
+    url_elem_to_delete = browser.find_element(By.CSS_SELECTOR, selected_url_selector)
+
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT)
+
+    # Wait for DELETE request
+    assert wait_for_element_to_be_removed(browser, url_elem_to_delete)
+    final_vis, final_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
+    )
+    assert final_vis == init_vis - 1
+    assert final_total == init_total - 1
+
+
+def test_filtered_url_count_increments_for_another_tag_while_filtered_when_added(
+    browser: WebDriver, create_test_urls, provide_app: Flask
+):
+    """
+    Tests U4I's incrementing of tag counts while adding a tag when a tag filter is applied.
+
+    GIVEN a user has access to UTubs with URLs with tags on some URLs and the URLs are filtered
+    WHEN the user adds a tag to a filtered URL
+    THEN ensure the tag counter increments
+    """
+    app = provide_app
+    user_id_for_test = 1
+    new_tag_str = "Another"
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    tag_in_utub = add_tag_to_utub_user_created(
+        app, utub_user_created.id, user_id_for_test, UTS.TEST_TAG_NAME_1
+    )
+    tag_id = tag_in_utub.id
+
+    with app.app_context():
+        utub_urls: list[Utub_Urls] = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub_user_created.id
+        ).all()
+        urls_tag_applied_to = len(utub_urls) - 2
+        for idx in range(urls_tag_applied_to):
+            utub_url = utub_urls[idx]
+            new_url_tag = Utub_Url_Tags(
+                utub_id=utub_user_created.id,
+                utub_url_id=utub_url.id,
+                utub_tag_id=tag_id,
+            )
+            db.session.add(new_url_tag)
+        db.session.commit()
+        url_id_to_add_tag = utub_urls[0].id
+
+        add_tag_to_utub_user_created(
+            app=app,
+            tag_string=new_tag_str,
+            utub_id=utub_user_created.id,
+            user_id=user_id_for_test,
+        )
+
+        new_tag = Utub_Tags.query.filter(Utub_Tags.tag_string == new_tag_str).first()
+        new_tag_id = new_tag.id
+
+    login_user_select_utub_by_id_and_url_by_id(
+        app,
+        browser,
+        user_id_for_test,
+        utub_user_created.id,
+        utub_url_id=url_id_to_add_tag,
+    )
+    displayed_urls = apply_tag_filter_by_id_and_get_shown_urls(browser, tag_id)
+    assert len(displayed_urls) == urls_tag_applied_to
+
+    init_vis, init_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, new_tag_id
+    )
+
+    add_tag_to_url(browser, url_id_to_add_tag, new_tag_str)
+    btn_selector = f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_TAG_SUBMIT_CREATE}"
+    wait_then_click_element(browser, btn_selector, time=3)
+
+    # Wait for POST request
+    wait_until_hidden(browser, btn_selector, timeout=3)
+
+    final_vis, final_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, new_tag_id
+    )
+    assert final_vis == init_vis + 1
+    assert final_total == init_total + 1

--- a/tests/functional/tags_ui/test_tag_filter_count.py
+++ b/tests/functional/tags_ui/test_tag_filter_count.py
@@ -1,23 +1,29 @@
+from typing import List
 from flask import Flask, url_for
 import pytest
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from src import db
+from src.models.urls import Urls
 from src.models.utub_tags import Utub_Tags
 from src.models.utub_url_tags import Utub_Url_Tags
 from src.models.utub_urls import Utub_Urls
+from src.models.utubs import Utubs
 from src.utils.all_routes import ROUTES
 from src.utils.strings.form_strs import TAG_FORM
 from src.utils.strings.ui_testing_strs import UI_TEST_STRINGS as UTS
+from src.utils.strings.url_strs import DELETE_URL_WARNING
 from tests.functional.db_utils import (
     add_tag_to_utub_user_created,
     add_two_tags_across_urls_in_utub,
-    count_urls_with_tag_applied_by_tag_id,
     count_urls_with_tag_applied_by_tag_string,
     get_tag_id_by_name,
+    get_tag_in_utub_by_tag_string,
     get_url_in_utub,
     get_utub_this_user_created,
+    get_utub_this_user_did_not_create,
 )
 from tests.functional.locators import HomePageLocators as HPL
 from src.cli.mock_constants import MOCK_TAGS
@@ -26,15 +32,20 @@ from tests.functional.login_utils import (
     login_user_select_utub_by_id_and_url_by_id,
 )
 from tests.functional.selenium_utils import (
+    get_num_url_rows,
+    select_utub_by_id,
+    wait_for_element_to_be_removed,
     wait_then_click_element,
+    wait_then_get_element,
     wait_until_hidden,
-    wait_until_visible_css_selector,
 )
 from tests.functional.tags_ui.selenium_utils import (
     add_tag_to_url,
     apply_tag_filter_by_id_and_get_shown_urls,
-    get_urls_count_with_tag_applied_from_tag_filter_by_tag_id,
-    get_utub_tag_filter_selector,
+    get_visible_urls_and_urls_with_tag_text_by_tag_id,
+)
+from tests.functional.urls_ui.login_utils import (
+    login_select_utub_select_url_click_delete_get_modal_url,
 )
 
 pytestmark = pytest.mark.tags_ui
@@ -67,13 +78,12 @@ def test_tag_filter_count_after_add_fresh_tag_to_url(
 
     tag_id = get_tag_id_by_name(app, utub_user_created.id, UTS.TEST_TAG_NAME_1)
 
-    tag_filter_count = get_urls_count_with_tag_applied_from_tag_filter_by_tag_id(
+    vis_count, total_count = get_visible_urls_and_urls_with_tag_text_by_tag_id(
         browser, tag_id
     )
 
-    assert (
-        tag_filter_count == 1
-    ), f"Expected tag filter count to be 1, but got {tag_filter_count} for tag ID {tag_id}"
+    assert vis_count == 1
+    assert total_count == 1
 
 
 def test_tag_filter_count_after_add_existing_tag_to_url(
@@ -106,27 +116,27 @@ def test_tag_filter_count_after_add_existing_tag_to_url(
         data=new_tag_form,
     )
 
-    with app.app_context():
-        init_tag_filter_count = count_urls_with_tag_applied_by_tag_string(
-            app, utub_id, new_tag_string
-        )
-        assert init_tag_filter_count == 0
-
     login_user_select_utub_by_id_and_url_by_id(
         app, browser, user_id_for_test, utub_id, url_id
     )
+
+    tag_id = get_tag_id_by_name(app, utub_id, new_tag_string)
+    init_vis, init_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
+    )
+    assert init_vis == 0
+    assert init_total == 0
 
     add_tag_to_url(browser, url_id, new_tag_string)
     btn_selector = f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_TAG_SUBMIT_CREATE}"
     wait_then_click_element(browser, btn_selector, time=3)
 
     wait_until_hidden(browser, btn_selector, timeout=3)
-
-    tag_filter_count = count_urls_with_tag_applied_by_tag_string(
-        app, utub_id, new_tag_string
+    final_vis, final_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, tag_id
     )
-
-    assert init_tag_filter_count + 1 == tag_filter_count
+    assert final_vis == init_vis + 1
+    assert final_total == init_total + 1
 
 
 def test_tag_filter_count_on_tag_filter_creation(
@@ -145,9 +155,18 @@ def test_tag_filter_count_on_tag_filter_creation(
     tag_in_utub = add_tag_to_utub_user_created(
         app, utub_user_created.id, user_id_for_test, UTS.TEST_TAG_NAME_1
     )
-    tag_id = tag_in_utub.id
 
-    assert count_urls_with_tag_applied_by_tag_id(app, tag_id) == 0
+    login_user_and_select_utub_by_utubid(
+        app,
+        browser,
+        user_id_for_test,
+        utub_user_created.id,
+    )
+
+    tag_id = tag_in_utub.id
+    visible, total = get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, tag_id)
+    assert visible == 0
+    assert total == 0
 
 
 def test_tag_filter_count_display_on_utub_selection(
@@ -187,6 +206,10 @@ def test_tag_filter_count_display_on_utub_selection(
     displayed_urls = apply_tag_filter_by_id_and_get_shown_urls(browser, tag_id)
     assert len(displayed_urls) == urls_tag_applied_to
 
+    visible, total = get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, tag_id)
+    assert visible == urls_tag_applied_to
+    assert total == urls_tag_applied_to
+
 
 def test_tag_filter_count_display_on_utub_selection_change(
     browser: WebDriver, create_test_tags, app: Flask
@@ -203,19 +226,25 @@ def test_tag_filter_count_display_on_utub_selection_change(
     """
     user_id_for_test = 1
     utub_user_created = get_utub_this_user_created(app, user_id_for_test)
-    tag_in_utub = add_tag_to_utub_user_created(
-        app, utub_user_created.id, user_id_for_test, UTS.TEST_TAG_NAME_1
-    )
-    tag_id = tag_in_utub.id
+    utub_user_member_of = get_utub_this_user_did_not_create(app, user_id_for_test)
 
     with app.app_context():
+        new_tag = Utub_Tags(
+            utub_id=utub_user_member_of.id,
+            tag_string=UTS.TEST_TAG_NAME_1,
+            created_by=user_id_for_test,
+        )
+        db.session.add(new_tag)
+        db.session.commit()
+        tag_id = get_tag_id_by_name(app, utub_user_member_of.id, UTS.TEST_TAG_NAME_1)
+
         utub_urls: list[Utub_Urls] = Utub_Urls.query.filter(
-            Utub_Urls.utub_id == utub_user_created.id
+            Utub_Urls.utub_id == utub_user_member_of.id
         ).all()
         urls_tag_applied_to = len(utub_urls)
         for utub_url in utub_urls:
             new_url_tag = Utub_Url_Tags(
-                utub_id=utub_user_created.id,
+                utub_id=utub_user_member_of.id,
                 utub_url_id=utub_url.id,
                 utub_tag_id=tag_id,
             )
@@ -225,19 +254,26 @@ def test_tag_filter_count_display_on_utub_selection_change(
     login_user_and_select_utub_by_utubid(
         app, browser, user_id_for_test, utub_user_created.id
     )
+    select_utub_by_id(browser, utub_user_member_of.id)
+
     displayed_urls = apply_tag_filter_by_id_and_get_shown_urls(browser, tag_id)
     assert len(displayed_urls) == urls_tag_applied_to
 
+    visible, total = get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, tag_id)
+    assert visible == urls_tag_applied_to
+    assert total == urls_tag_applied_to
 
-def test_tag_filter_count_update_on_tag_badge_removal(
+
+def test_tag_filter_count_update_with_multiple_tag_filters_applied(
     browser: WebDriver, create_test_tags, app: Flask
 ):
     """
-    Tests the tag filter count in the Tag Deck when a tag badge is remove from an existing URL.
+    Tests the tag filter count in the Tag Deck when two tag badges are applied to.
+    all available URLs in the UTub.
 
     GIVEN a user has access to UTubs with URLs and tags
-    WHEN the user removes a tag from a URL
-    THEN ensure the corresponding tag filter is decremented by 1
+    WHEN the user applies two tag filters
+    THEN ensure the corresponding tag filter count is correct
     """
 
     user_id_for_test = 1
@@ -267,65 +303,207 @@ def test_tag_filter_count_update_on_tag_badge_removal(
     )
     assert len(displayed_urls_for_first_tag) == num_urls_for_first_tag
 
+    first_vis_init, first_total_init = (
+        get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, first_tag_id)
+    )
+    assert first_vis_init == num_urls_for_first_tag
+    assert first_total_init == num_urls_for_first_tag
+
+    second_vis_init, second_total_init = (
+        get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, second_tag_id)
+    )
+    assert second_vis_init == num_urls_for_second_tag
+    assert second_total_init == num_urls_for_second_tag
+
     displayed_urls_for_second_tag = apply_tag_filter_by_id_and_get_shown_urls(
         browser, second_tag_id
     )
     assert len(displayed_urls_for_second_tag) == num_urls_for_second_tag
 
+    first_vis_final, first_total_final = (
+        get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, first_tag_id)
+    )
+    assert first_vis_final == num_urls_for_second_tag
+    assert first_total_final == num_urls_for_first_tag
 
-def test_tag_filter_count_update_on_url_deletion(
-    browser: WebDriver, create_test_tags, app: Flask
+    second_vis_final, second_total_final = (
+        get_visible_urls_and_urls_with_tag_text_by_tag_id(browser, second_tag_id)
+    )
+    assert second_vis_final == num_urls_for_second_tag
+    assert second_total_final == num_urls_for_second_tag
+
+
+def test_delete_url_decrements_all_tag_counters(
+    browser: WebDriver, create_test_tags, provide_app: Flask
 ):
     """
-    Tests the tag filter count in the Tag Deck when a URL with tags applied is deleted from the UTub.
+    Tests U4I's ability to decrement the tag counters when deleting a URL with all 5 tags
+    visible in the Tag Deck
 
-    GIVEN a user has access to UTubs with URLs and tags
-    WHEN the user deletes a URL with tags applied
-    THEN ensure all the corresponding tag filters are each decremented by 1
+    GIVEN a user, selected UTub and selected URL
+    WHEN deleteURL button is selected and confirmation modal confirmed
+    THEN ensure the URL is deleted from the UTub, and the tag counters are decremented
     """
-
     user_id_for_test = 1
-    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    app = provide_app
 
     with app.app_context():
-        utub_tags: list[Utub_Tags] = Utub_Tags.query.filter(
-            Utub_Tags.utub_id == utub_user_created.id
+        utub: Utubs = Utubs.query.filter(Utubs.name == UTS.TEST_UTUB_NAME_1).first()
+        url: Urls = Urls.query.filter(
+            Urls.url_string == UTS.TEST_URL_STRING_CREATE
+        ).first()
+
+        utub_url: Utub_Urls = Utub_Urls.query.filter(
+            Utub_Urls.utub_id == utub.id, Utub_Urls.url_id == url.id
+        ).first()
+        url_tags: List[Utub_Url_Tags] = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub.id, Utub_Url_Tags.utub_url_id == utub_url.id
         ).all()
-        utub_tag_ids = [utub_tag.id for utub_tag in utub_tags]
 
-    login_user_and_select_utub_by_utubid(
-        app, browser, user_id_for_test, utub_user_created.id
-    )
-    wait_until_visible_css_selector(
-        browser, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}", timeout=3
-    )
+        utub_tag_ids = [tag.utub_tag_id for tag in url_tags]
 
-    assert len(
-        browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}")
-    ) == len(utub_tag_ids)
-
-    for utub_tag_id in utub_tag_ids:
-        utub_tag_filter = get_utub_tag_filter_selector(utub_tag_id)
-        wait_then_click_element(browser, utub_tag_filter, time=3)
-
-    assert (
-        len(
-            browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}")
+    delete_modal, url_elem_to_delete = (
+        login_select_utub_select_url_click_delete_get_modal_url(
+            browser=browser,
+            app=provide_app,
+            user_id=user_id_for_test,
+            utub_name=UTS.TEST_UTUB_NAME_1,
+            url_string=UTS.TEST_URL_STRING_CREATE,
         )
-        == 0
     )
-    assert len(
-        browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.SELECTED}")
-    ) == len(utub_tag_ids)
 
-    unselect_filters_btn = browser.find_element(
-        By.CSS_SELECTOR, HPL.BUTTON_UNSELECT_ALL
+    init_vis_total = {}
+    for tag_id in utub_tag_ids:
+        init_vis_total[tag_id] = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+            browser, tag_id
+        )
+
+    css_selector = f'{HPL.URL_STRING_READ}[href="{UTS.TEST_URL_STRING_CREATE}"]'
+    assert browser.find_element(By.CSS_SELECTOR, css_selector)
+
+    init_num_url_rows = get_num_url_rows(browser)
+
+    confirmation_modal_body_text = delete_modal.text
+
+    # Assert warning modal appears with appropriate text
+    assert confirmation_modal_body_text == DELETE_URL_WARNING
+
+    wait_then_click_element(browser, HPL.BUTTON_MODAL_SUBMIT)
+    wait_until_hidden(browser, HPL.BUTTON_MODAL_SUBMIT)
+
+    # Wait for animation to complete
+    assert wait_for_element_to_be_removed(browser, url_elem_to_delete)
+
+    # Assert URL no longer exists in UTub
+    with pytest.raises(NoSuchElementException):
+        browser.find_element(By.CSS_SELECTOR, css_selector)
+    assert init_num_url_rows - 1 == get_num_url_rows(browser)
+
+    for tag_id in utub_tag_ids:
+        final_vis, final_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+            browser, tag_id
+        )
+        init_vis, init_total = init_vis_total[tag_id]
+        assert final_vis == init_vis - 1
+        assert final_total == init_total - 1
+
+
+def test_create_fresh_tag_sets_count(
+    browser: WebDriver, create_test_urls, provide_app: Flask
+):
+    """
+    Tests a user's ability to create a fresh tag to a URL.
+
+    GIVEN a user has access to UTubs with URLs
+    WHEN the createTag form is populated with a tag value that is not yet in the UTub
+    THEN ensure the appropriate tag is applied and displayed and the counter is incremented
+    """
+    tag_text = UTS.TEST_TAG_NAME_1
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    utub_id = utub_user_created.id
+    url_in_utub = get_url_in_utub(app, utub_id)
+    with app.app_context():
+        init_tag_count_on_url: int = Utub_Url_Tags.query.filter(
+            Utub_Url_Tags.utub_id == utub_id,
+            Utub_Url_Tags.utub_url_id == url_in_utub.id,
+        ).count()
+
+        init_tag_count_in_utub: int = count_urls_with_tag_applied_by_tag_string(
+            app, utub_id, tag_text
+        )
+
+    login_user_select_utub_by_id_and_url_by_id(
+        app, browser, user_id_for_test, utub_user_created.id, url_in_utub.id
     )
-    unselect_filters_btn.click()
-    assert (
-        len(browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.SELECTED}"))
-        == 0
+
+    add_tag_to_url(browser, url_in_utub.id, tag_text)
+
+    # Submit
+    btn_selector = f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_TAG_SUBMIT_CREATE}"
+    wait_then_click_element(browser, btn_selector, time=3)
+
+    # Wait for POST request
+    wait_until_hidden(browser, btn_selector, timeout=3)
+
+    # Confirm Tag Deck counter incremented
+    utub_tag = get_tag_in_utub_by_tag_string(app, utub_id, tag_text)
+    utub_tag_selector = f'{HPL.TAG_FILTERS}[data-utub-tag-id="{utub_tag.id}"]'
+    utub_tag_elem = wait_then_get_element(browser, utub_tag_selector)
+    assert utub_tag_elem
+
+    visible_urls, total_urls = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, utub_tag.id
     )
-    assert len(
-        browser.find_elements(By.CSS_SELECTOR, f"{HPL.TAG_FILTERS}{HPL.UNSELECTED}")
-    ) == len(utub_tag_ids)
+    assert visible_urls == init_tag_count_on_url + 1
+    assert total_urls == init_tag_count_in_utub + 1
+
+
+def test_create_non_fresh_tag_increments_counts(
+    browser: WebDriver, create_test_urls, provide_app: Flask
+):
+    """
+    Tests a user's ability to create a non-fresh tag to a URL.
+
+    GIVEN a user has access to UTubs with URLs
+    WHEN the createTag form is populated with a tag value that is already in the UTub
+    THEN ensure the appropriate tag is applied and displayed and the counter is incremented
+    """
+    app = provide_app
+    user_id_for_test = 1
+    utub_user_created = get_utub_this_user_created(app, user_id_for_test)
+    utub_id = utub_user_created.id
+    url_in_utub = get_url_in_utub(app, utub_id)
+    tag_already_in_utub_str = "Another"
+    with app.app_context():
+        utub_tag = add_tag_to_utub_user_created(
+            app=app,
+            tag_string=tag_already_in_utub_str,
+            utub_id=utub_id,
+            user_id=user_id_for_test,
+        )
+
+    login_user_select_utub_by_id_and_url_by_id(
+        app, browser, user_id_for_test, utub_user_created.id, url_in_utub.id
+    )
+
+    init_vis, init_total = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, utub_tag.id
+    )
+
+    add_tag_to_url(browser, url_in_utub.id, tag_already_in_utub_str)
+
+    # Submit
+    btn_selector = f"{HPL.ROW_SELECTED_URL} {HPL.BUTTON_TAG_SUBMIT_CREATE}"
+    wait_then_click_element(browser, btn_selector, time=3)
+
+    # Wait for POST request
+    wait_until_hidden(browser, btn_selector, timeout=3)
+
+    # Confirm Tag Deck counter incremented
+    visible_urls, total_urls = get_visible_urls_and_urls_with_tag_text_by_tag_id(
+        browser, utub_tag.id
+    )
+    assert visible_urls == init_vis + 1
+    assert total_urls == init_total + 1

--- a/tests/functional/urls_ui/test_delete_url_ui.py
+++ b/tests/functional/urls_ui/test_delete_url_ui.py
@@ -58,7 +58,7 @@ def test_delete_url_tooltip_animates(
     THEN ensure a tooltip is shown appropriately
     """
 
-    _, cli_runner = runner
+    _, _ = runner
     app = provide_app
     user_id_for_test = 1
     utub_user_created = get_utub_this_user_created(app, user_id_for_test)
@@ -86,7 +86,6 @@ def test_delete_url_submit(browser: WebDriver, create_test_urls, provide_app: Fl
     """
     user_id_for_test = 1
 
-    # Login as test user, select first test UTub, and select first test URL
     delete_modal, url_elem_to_delete = (
         login_select_utub_select_url_click_delete_get_modal_url(
             browser=browser,
@@ -131,7 +130,6 @@ def test_delete_url_cancel_click_cancel_btn(
     """
     user_id_for_test = 1
 
-    # Login as test user, select first test UTub, and select first test URL
     delete_modal, url_elem_to_delete = (
         login_select_utub_select_url_click_delete_get_modal_url(
             browser=browser,
@@ -170,7 +168,6 @@ def test_delete_url_cancel_click_x_btn(
     """
     user_id_for_test = 1
 
-    # Login as test user, select first test UTub, and select first test URL
     delete_modal, url_elem_to_delete = (
         login_select_utub_select_url_click_delete_get_modal_url(
             browser=browser,
@@ -209,7 +206,6 @@ def test_delete_url_cancel_press_esc_key(
     """
     user_id_for_test = 1
 
-    # Login as test user, select first test UTub, and select first test URL
     delete_modal, url_elem_to_delete = (
         login_select_utub_select_url_click_delete_get_modal_url(
             browser=browser,
@@ -248,7 +244,6 @@ def test_delete_url_cancel_click_outside_modal(
     """
     user_id_for_test = 1
 
-    # Login as test user, select first test UTub, and select first test URL
     delete_modal, url_elem_to_delete = (
         login_select_utub_select_url_click_delete_get_modal_url(
             browser=browser,
@@ -301,7 +296,6 @@ def test_delete_last_url(
 
     user_id_for_test = 1
 
-    # Login as test user, select first test UTub, and select first test URL
     _, url_elem_to_delete = login_select_utub_select_url_click_delete_get_modal_url(
         browser=browser,
         app=provide_app,

--- a/tests/functional/utubs_ui/test_update_utub_name_ui.py
+++ b/tests/functional/utubs_ui/test_update_utub_name_ui.py
@@ -49,7 +49,7 @@ def test_select_utub(browser: WebDriver, create_test_urls, provide_app: Flask):
 
     GIVEN a fresh load of the U4I Home page
     WHEN user selects a UTub, then selects another UTub
-    THEN ensure the URL deck header changes and TODO: displayed URLs change
+    THEN ensure the URL deck header changes and displayed URLs change
     """
     app = provide_app
     user_id = 1


### PR DESCRIPTION
Adds a visible tag counter to all UTub Tags to indicate how many of the associated visible URLs contain that tag.

Closes #505 