### PR TITLE
[frontend] Rate limit contact form btn in UI

### DIFF
--- a/src/contact/contact_us.py
+++ b/src/contact/contact_us.py
@@ -7,9 +7,12 @@ from src.extensions.extension_utils import safe_get_notif_sender
 from src.models.contact_form_entries import ContactFormEntries
 
 
-def load_contact_us_page(contact_form: ContactForm) -> str:
+def load_contact_us_page(contact_form: ContactForm, contacted: bool = False) -> str:
     return render_template(
-        "pages/contact_us.html", contact_form=contact_form, is_contact_form=True
+        "pages/contact_us.html",
+        contact_form=contact_form,
+        is_contact_form=True,
+        contacted=contacted,
     )
 
 
@@ -43,4 +46,4 @@ def validate_and_contact(contact_form: ContactForm) -> str:
         db.session.commit()
 
     flash("Sent! Thanks for reaching out.")
-    return load_contact_us_page(contact_form)
+    return load_contact_us_page(contact_form, contacted=True)

--- a/src/static/styles/contact_form.css
+++ b/src/static/styles/contact_form.css
@@ -8,6 +8,21 @@ h1 {
     color: var(--splashGreen);
 }
 
+input[type="submit"] {
+    background-color: var(--splashGreen);
+    color: black;
+}
+
+
+h4 {
+    color: var(--grayBadgeSelection);
+    width: 75%;
+    text-align: center;
+    text-wrap: balance;
+    max-width: 40em;
+    letter-spacing: 0.02em;
+}
+
 label {
     font-size: 1.5rem;
 }

--- a/src/templates/pages/contact_us.html
+++ b/src/templates/pages/contact_us.html
@@ -9,6 +9,7 @@
         </ul>
       {% endif %}
     {% endwith %}
+    <h4>Feature ideas, bugs, compliments? Send it our way!</h4>
 
     <form id="ContactForm" method="POST" action="/contact" class="flex-column g-1-5r" novalidate>
         {{ contact_form.hidden_tag() }}
@@ -44,10 +45,55 @@
             </div>
         </fieldset>
         <div>
+            {% if contacted %}
+            {{ contact_form.submit(class="btn btn-success login-register-form-group col-12 login-register-buttons", data_sent="true")}}
+            {% else %}
             {{ contact_form.submit(class="btn btn-success login-register-form-group col-12 login-register-buttons")}}
+            {% endif %}
         </div>
     </form>
 
 </main>
+
+<script nonce="{{ nonce }}">
+    (function($) {
+        const $form = $('form');
+
+        if ($form.length) {
+            $form.on("submit", function(e) {
+                const $submitBtn = $(this).find('input[type="submit"]');
+                $submitBtn.prop('disabled', true);
+                $submitBtn.val("Sending...");
+            });
+        }
+    })(jQuery);
+</script>
+
+{% if contacted %}
+<script nonce="{{ nonce }}">
+    (function($) {
+        const $submitBtn = $('input[data-sent="true"]');
+
+        if ($submitBtn.length) {
+            $submitBtn.prop('disabled', true);
+            const originalValue = $submitBtn.val();
+            let timeLeft = 5;
+            
+            $submitBtn.val(`Submitted! Please wait ${timeLeft}s...`);
+            
+            const interval = setInterval(function() {
+                timeLeft--;
+                if (timeLeft > 0) {
+                    $submitBtn.val(`Submitted! Please wait ${timeLeft}s...`);
+                } else {
+                    clearInterval(interval);
+                    $submitBtn.prop('disabled', false);
+                    $submitBtn.val(originalValue);
+                }
+            }, 1000);
+        }
+    })(jQuery);
+</script>
+{% endif %}
 
 {% endblock %}

--- a/tests/functional/home_ui/test_home_footer_ui.py
+++ b/tests/functional/home_ui/test_home_footer_ui.py
@@ -20,6 +20,7 @@ from tests.functional.selenium_utils import (
     visit_privacy_page,
     visit_terms_page,
     wait_then_click_element,
+    wait_then_get_element,
     wait_then_get_elements,
     wait_until_visible_css_selector,
 )
@@ -238,3 +239,27 @@ def test_submit_empty_fields(
     assert len(error_elems) == len(contact_form_fields) - len(
         [val for val in contact_form_fields if bool(val)]
     )
+
+
+def test_contact_form_button_disables_on_submit(
+    browser: ChromeRemoteWebDriver,
+    create_test_users,
+    provide_app: Flask,
+):
+    """
+    GIVEN a user on the contact us page
+    WHEN they submit an entry in the form with an empty field
+    THEN verify that proper error response is shown
+    """
+    app = provide_app
+    user_id = 1
+    session_id = create_user_session_and_provide_session_id(app, user_id)
+    login_user_with_cookie_from_session(browser, session_id)
+
+    visit_contact_us_page(browser)
+    contact_form_entry(browser=browser, subject="Subject" * 2, content="Content" * 10)
+    wait_then_click_element(browser, HPL.CONTACT_SUBMIT)
+
+    submit_btn = wait_then_get_element(browser, HPL.CONTACT_SUBMIT)
+    assert submit_btn
+    assert submit_btn.get_property("disabled")


### PR DESCRIPTION
Rate limit the button in the Contact Form by:

- Disabling the button on click to avoid double sends
- On successful send, disabling the button for 5 seconds via inline script that is conditionally sent on form validation success

Also makes the colors of the Contact Form page line up better (equivalent greens for titles vs btn).

Adds a CLI helper utility to reset the rate limiter during development.